### PR TITLE
A11y test fail

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,8 @@
 name: Run Tests
 on: 
   pull_request:
-      - main
+      branches:
+        - main
 
 jobs:
   build-deploy:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,25 @@
+name: Compile Core
+on: 
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'package.json'
+
+jobs:
+  build-deploy:
+    name: Compile Core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Install
+        run: npm install
+      - name: Compile sass
+        run: gulp compile
+      - name: Compile components
+        run: npm run build
+      - uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,15 +1,11 @@
-name: Compile Core
+name: Run Tests
 on: 
-  push:
-    branches:
+  pull_request:
       - main
-    paths:
-      - 'src/**'
-      - 'package.json'
 
 jobs:
   build-deploy:
-    name: Compile Core
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -19,7 +15,4 @@ jobs:
       - name: Compile sass
         run: gulp compile
       - name: Compile components
-        run: npm run build
-      - uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+        run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "gc-ds-button",
-  "version": "0.0.1",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gc-ds-button",
-      "version": "0.0.1",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.7.0"
       },
       "devDependencies": {
+        "@axe-core/puppeteer": "^4.3.2",
         "@types/jest": "^26.0.24",
         "gulp": "^4.0.2",
         "gulp-sass": "^5.0.0",
@@ -19,6 +20,21 @@
         "jest-cli": "^26.6.3",
         "puppeteer": "^10.0.0",
         "sass": "^1.43.5"
+      }
+    },
+    "node_modules/@axe-core/puppeteer": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.3.2.tgz",
+      "integrity": "sha512-/0Od30pNxUr00cO20pndz2n/b5DyYrkAKBBXlpTAbAMPuLtz6JnavR9A1oQMDyBeoQDNbKr7B97FRYSNPPgI9Q==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">=1.10.0 <= 10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1410,6 +1426,15 @@
       },
       "engines": {
         "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-jest": {
@@ -9150,6 +9175,15 @@
     }
   },
   "dependencies": {
+    "@axe-core/puppeteer": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/puppeteer/-/puppeteer-4.3.2.tgz",
+      "integrity": "sha512-/0Od30pNxUr00cO20pndz2n/b5DyYrkAKBBXlpTAbAMPuLtz6JnavR9A1oQMDyBeoQDNbKr7B97FRYSNPPgI9Q==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.3.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
@@ -10248,6 +10282,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "axe-core": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
+      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
       "dev": true
     },
     "babel-jest": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "@stencil/core": "^2.7.0"
   },
   "devDependencies": {
+    "@axe-core/puppeteer": "^4.3.2",
     "@types/jest": "^26.0.24",
+    "gulp": "^4.0.2",
+    "gulp-sass": "^5.0.0",
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
     "puppeteer": "^10.0.0",
-    "gulp": "^4.0.2",
-    "gulp-sass": "^5.0.0",
     "sass": "^1.43.5"
   },
   "license": "MIT"

--- a/src/components/my-component/my-component.e2e.ts
+++ b/src/components/my-component/my-component.e2e.ts
@@ -1,32 +1,52 @@
 import { newE2EPage } from '@stencil/core/testing';
+const { AxePuppeteer } = require('@axe-core/puppeteer');
 
-describe('my-component', () => {
+describe('gc-ds-button', () => {
   it('renders', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<my-component></my-component>');
-    const element = await page.find('my-component');
+    await page.setContent('<gc-ds-button></gc-ds-button>');
+    const element = await page.find('gc-ds-button');
     expect(element).toHaveClass('hydrated');
   });
 
-  it('renders changes to the name data', async () => {
+  it('renders changes to the label data', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<my-component></my-component>');
-    const component = await page.find('my-component');
-    const element = await page.find('my-component >>> div');
-    expect(element.textContent).toEqual(`Hello, World! I'm `);
+    await page.setContent('<gc-ds-button></gc-ds-button>');
+    const component = await page.find('gc-ds-button');
+    const element = await page.find('gc-ds-button >>> button');
+    expect(element.textContent).toEqual(`Fallback Button Label`);
 
-    component.setProperty('first', 'James');
+    component.setProperty('label', 'Vanilla JS button');
     await page.waitForChanges();
-    expect(element.textContent).toEqual(`Hello, World! I'm James`);
+    expect(element.textContent).toEqual(` Vanilla JS button`);
+  });
+});
 
-    component.setProperty('last', 'Quincy');
-    await page.waitForChanges();
-    expect(element.textContent).toEqual(`Hello, World! I'm James Quincy`);
+/*
+ * Accessibility tests
+ */
 
-    component.setProperty('middle', 'Earl');
-    await page.waitForChanges();
-    expect(element.textContent).toEqual(`Hello, World! I'm James Earl Quincy`);
+describe('gc-ds-button a11y tests', () => {
+  it('pass colour contrast', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<gc-ds-button></gc-ds-button>');
+    
+    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
+    let results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('can focus with keyboard', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<gc-ds-button></gc-ds-button>');
+
+    const buttonText = await (await page.find('gc-ds-button >>> button')).innerText;
+
+    await page.keyboard.press("Tab");
+
+    expect(await page.evaluate(() => window.document.activeElement.shadowRoot.textContent)).toEqual(buttonText);
   });
 });

--- a/src/components/my-component/my-component.spec.ts
+++ b/src/components/my-component/my-component.spec.ts
@@ -1,32 +1,36 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { MyComponent } from './my-component';
 
-describe('my-component', () => {
+describe('gc-ds-button', () => {
   it('renders', async () => {
     const { root } = await newSpecPage({
       components: [MyComponent],
-      html: '<my-component></my-component>',
+      html: '<gc-ds-button></gc-ds-button>',
     });
     expect(root).toEqualHtml(`
-      <my-component>
+      <gc-ds-button>
         <mock:shadow-root>
-          buttonLabel
+          <button>
+            Fallback Button Label
+          </button>
         </mock:shadow-root>
-      </my-component>
+      </mgc-ds-button>
     `);
   });
 
   it('renders with values', async () => {
     const { root } = await newSpecPage({
       components: [MyComponent],
-      html: `<my-component buttonLabel="Example Button"></my-component>`,
+      html: `<gc-ds-button label="Example Button"></gc-ds-button>`,
     });
     expect(root).toEqualHtml(`
-      <my-component buttonLabel="Example Button">
+      <gc-ds-button label="Example Button">
         <mock:shadow-root>
-          Example Button
+          <button>
+            Example Button
+          </button>
         </mock:shadow-root>
-      </my-component>
+      </gc-ds-button>
     `);
   });
 });

--- a/src/styles/variables/variables.css
+++ b/src/styles/variables/variables.css
@@ -6,7 +6,7 @@
 :root {
   --gcds-colour-utils-blue: #0535D2;
   --gcds-colour-utils-purple: #7834BC;
-  --gcds-colour-utils-white: #ffffff;
+  --gcds-colour-utils-white: blue;
   --gcds-colour-utils-black: #000000;
   --gcds-colour-base-red-100: #ecb6b5;
   --gcds-colour-base-red-300: #c85c5a;

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,11 +1,11 @@
 import { format } from './utils';
 
 describe('format', () => {
-  it('returns empty string for no names defined', () => {
-    expect(format(undefined)).toEqual('');
+  it('returns Fallback Button Label', () => {
+    expect(format(undefined)).toEqual('Fallback Button Label');
   });
 
-  it('formats just first names', () => {
-    expect(format('Joseph')).toEqual('Joseph');
+  it('renders label with given string', () => {
+    expect(format('Vanilla JS button')).toEqual(' Vanilla JS button');
   });
 });


### PR DESCRIPTION
# Purpose 
To take advantage of Stencil's spec and e2e tests when a component is generated to build accessibility testing right into the component. These tests can then be used by GitHub through actions to provide an additional layer of quality control.

This pull request was authored to show a failed colour contrast accessibility test using [axe-core/puppeteer](https://www.npmjs.com/package/@axe-core/puppeteer).

## How we can do this
Using Stencil's e2e tests, we can use the library [axe-core/puppeteer](https://www.npmjs.com/package/@axe-core/puppeteer) to run accessibility tests, this example runs a colour contrast test but can be expanded with [additional rules](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-21-level-a--aa-rules).

The e2e ends tests also allow testing the interactions of a component when it is loaded on a page. This example showcases a test of the `gc-ds-button` component being focused using keyboard navigation.

With a new GitHub action, when a pull request is authored/modified the tests will run for quality control.

## Modification that caused failure
The `--gcds-colour-utils-white` CSS variable has been modified from a value of `#FFFFFF` to `blue`. This causes the `gc-ds-button` to render with a text colour of `blue` and background of `#bf3230`, which causes a contrast ratio of 1.51:1 (4.5:1 required for WCAG AA)