### PR TITLE
Site menu styles

### DIFF
--- a/src/components/gcds-site-menu/gcds-site-menu.css
+++ b/src/components/gcds-site-menu/gcds-site-menu.css
@@ -36,7 +36,7 @@
   display: inline;
 }
 :host([menu-mobile-layout*=drawer]) [data-h2-menu] {
-  background: #0a0a14;
+  background: #EDEDED;
   display: none;
   height: 100vh;
   top: 0;
@@ -165,15 +165,15 @@
   outline: none;
 }
 :host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
-  background: #EDEDED;
+  background: rgba(210, 210, 210, 0.5);
 }
 @media screen and (min-width: 64em) {
   :host([menu-mobile-layout*=drawer]) [data-h2-menu] {
-    background: #EDEDED;
+    background: rgba(210, 210, 210, 0.5);
   }
 
   :host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
-    background: #EDEDED;
+    background: rgba(210, 210, 210, 0.5);
   }
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu].h2-mobile-menu-active {
@@ -357,22 +357,22 @@
   color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
-  border-top: 1px solid #EDEDED;
+  border-top: 1px solid rgba(0, 0, 0, 0.3);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] + [data-h2-menulist] > li > [role=menuitem] {
-  border-top: 1px solid #EDEDED;
+  border-top: 1px solid rgba(0, 0, 0, 0.3);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > a:hover {
   color: #8ffff3;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
-  background-color: rgba(167, 167, 167, 0.2);
+  background-color: rgba(180, 180, 180, 0.3);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
-  background-color: #dadada;
+  background-color: rgba(210, 210, 210, 0.5);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
-  border-top-color: rgba(255, 255, 255, 0.3);
+  border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
@@ -392,13 +392,13 @@
   color: #8ffff3;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
-  background-color: rgba(255, 255, 255, 0.4);
+  background-color: rgba(180, 180, 180, 0.3);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] {
-  background-color: #EDEDED;
+  background-color: rgba(210, 210, 210, 0.5);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
-  border-top-color: rgba(255, 255, 255, 0.3);
+  border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
@@ -423,7 +423,7 @@
   background-color: #111116;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
-  border-top-color: rgba(255, 255, 255, 0.3);
+  border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
@@ -445,7 +445,7 @@
   background-color: #060608;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
-  border-top-color: rgba(255, 255, 255, 0.3);
+  border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
@@ -467,7 +467,7 @@
   background-color: black;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
-  border-top-color: rgba(255, 255, 255, 0.3);
+  border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
@@ -516,11 +516,12 @@
   }
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li {
     display: inline-block;
-    margin-left: -4px;
+    margin-left: 1.5rem;
+    margin-right: -1.5rem;
     position: relative;
   }
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:last-child) {
-    border-right: 1px solid #EDEDED;
+    border-right: 1px solid rgba(0, 0, 0, 0.2);
   }
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [role=menuitem] {
     border: none !important;
@@ -573,6 +574,7 @@
 
 [data-optional-left] {
   color: #000000;
+  font-weight: 600;
 }
 [data-optional-right] {
   color: #000000;
@@ -693,5 +695,12 @@
     margin-right: 25%;
     overflow-x: hidden;
     width: 75%;
+  }
+}
+
+
+@media screen and (max-width: 76.625em) {
+  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] {
+    max-width: 90%;
   }
 }

--- a/src/components/gcds-site-menu/gcds-site-menu.css
+++ b/src/components/gcds-site-menu/gcds-site-menu.css
@@ -1,5 +1,5 @@
 :host([data-h2-menu-wrapper]) {
-  font-family: sans-serif;
+  font-family: 'Lato', sans-serif;
 }
 
 .h2-mobile-menu-body-lock {
@@ -24,11 +24,11 @@
   }
 }
 
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:last-child > [role="menuitem"] {
- margin-right: 0 !important;
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:last-child > [role='menuitem'] {
+  margin-right: 0 !important;
 }
 
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:first-child) > [role="menuitem"] {
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:first-child) > [role='menuitem'] {
   margin-right: -5px;
 }
 
@@ -105,7 +105,7 @@
 :host([data-h2-menu-wrapper]) [data-h2-menu] h5,
 :host([data-h2-menu-wrapper]) [data-h2-menu] h6,
 :host([data-h2-menu-wrapper]) [data-h2-menu] p {
-  font-family: sans-serif;
+  font-family: 'Lato', sans-serif;
   font-weight: normal;
   line-height: 1.5;
   margin: 0;
@@ -126,11 +126,11 @@
   font-size: calc(1rem * 1.333);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] h6 {
-  font-size: 1rem;
+  font-size: 18px;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] p,
 :host([data-h2-menu-wrapper]) [data-h2-menu] div {
-  font-size: 1rem;
+  font-size: 18px;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] span,
 :host([data-h2-menu-wrapper]) [data-h2-menu] em,
@@ -172,7 +172,7 @@
 
 :host([data-h2-menu-wrapper]) [data-h2-menu] ul,
 :host([data-h2-menu-wrapper]) [data-h2-menu] ol {
-  font-family: sans-serif;
+  font-family: 'Lato', sans-serif;
   margin: 0;
   padding-left: 1.5rem;
 }
@@ -264,7 +264,7 @@
 }
 :host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role='menuitem'] {
   display: block;
-  font-size: 1rem;
+  font-size: 18px;
   line-height: 1.5;
   margin: 0;
   padding-left: 1.5rem;
@@ -274,7 +274,7 @@
 }
 :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role='menuitem'] {
   display: block;
-  font-size: 1rem;
+  font-size: 18px;
   line-height: 1.5;
   margin: 0 0.5rem;
   padding-top: 1.5rem;
@@ -283,7 +283,7 @@
 @media screen and (min-width: 64rem) {
   :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role='menuitem'] {
     display: block;
-    font-size: 1rem;
+    font-size: 18px;
     line-height: 1.5;
     margin: 0 1.5rem;
     padding-top: 1.5rem;
@@ -333,12 +333,12 @@
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon] {
   display: block;
-  font-size: 1rem;
+  font-size: 18px;
   line-height: 1.5;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
   display: none;
-  font-size: 1rem;
+  font-size: 18px;
   line-height: 1.5;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon] {

--- a/src/components/gcds-site-menu/gcds-site-menu.css
+++ b/src/components/gcds-site-menu/gcds-site-menu.css
@@ -390,11 +390,11 @@
   color: #8ffff3;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
-  background-color: rgba(180, 180, 180, 0.3);
+  background-color: rgba(130, 130, 130, 0.35);
   transition: all 0.2s ease-in-out;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger]:hover {
-  background-color: rgba(180, 180, 180, 0.8);
+  background-color: rgba(130, 130, 130, 0.7);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger]:focus {
   background-color: #303fc3;
@@ -448,10 +448,10 @@
   color: #8ffff3;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
-  background-color: rgba(180, 180, 180, 0.3);
+  background-color: rgba(130, 130, 130, 0.35);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger]:hover {
-  background-color: rgba(180, 180, 180, 0.8);
+  background-color: rgba(130, 130, 130, 0.7);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger]:focus {
   background-color: #303fc3;
@@ -609,7 +609,7 @@
   > [data-h2-menulist]
   > li
   > [data-h2-submenu-trigger] {
-  background-color: red;
+  background-color: rgba(255, 255, 255, 0.1);
 }
 :host([data-h2-menu-wrapper])
   [data-h2-menu]
@@ -919,9 +919,6 @@
   :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [role='menuitem'] {
     margin: 0;
     padding: calc(1.5rem / 1.5) calc(1.5rem * 3) calc(1.5rem / 1.5) 1.5rem;
-  }
-  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [role='menuitem']:focus {
-    outline: none;
   }
   :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [data-h2-submenu-trigger] {
     padding: calc(1.5rem / 1.5) 1.5rem;

--- a/src/components/gcds-site-menu/gcds-site-menu.css
+++ b/src/components/gcds-site-menu/gcds-site-menu.css
@@ -23,6 +23,15 @@
     display: none;
   }
 }
+
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:last-child > [role="menuitem"] {
+ margin-right: 0 !important;
+}
+
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:first-child) > [role="menuitem"] {
+  margin-right: -5px;
+}
+
 :host([data-h2-menu-wrapper]) [data-h2-mobile-menu-trigger] [data-h2-mobile-menu-trigger-open-label] {
   display: inline;
 }
@@ -409,7 +418,7 @@
   background-color: #595959;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
-  background-color: rgba(210, 210, 210, 0.5);
+  background-color: #ebebeb;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role='menuitem'] {
   border-top-color: rgba(0, 0, 0, 0.3);
@@ -418,7 +427,7 @@
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [role='menuitem'] {
   color: #000000;
-  margin-left: 0;
+  margin-left: calc(1.5rem * 1.5);
 }
 
 :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li {

--- a/src/components/gcds-site-menu/gcds-site-menu.css
+++ b/src/components/gcds-site-menu/gcds-site-menu.css
@@ -35,18 +35,18 @@
 :host([data-h2-menu-wrapper]) [data-h2-mobile-menu-trigger].h2-active [data-h2-mobile-menu-trigger-close-label] {
   display: inline;
 }
-:host([menu-mobile-layout*=drawer]) [data-h2-menu] {
-  background: #EDEDED;
+:host([menu-mobile-layout*='drawer']) [data-h2-menu] {
+  background: #ededed;
   display: none;
   height: 100vh;
   top: 0;
   overflow: auto;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] {
   bottom: 0;
 }
-:host([menu-mobile-layout*=drawer]) [data-h2-menu],
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
+:host([menu-mobile-layout*='drawer']) [data-h2-menu],
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] {
   position: fixed;
   left: 0;
   width: 100vw;
@@ -56,7 +56,7 @@
   box-sizing: border-box;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] ::selection {
-  background: #F7B452 !important;
+  background: #f7b452 !important;
   color: #0a0a0c !important;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] blockquote,
@@ -89,31 +89,38 @@
     overflow: visible;
   }
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] h1, :host([data-h2-menu-wrapper]) [data-h2-menu] h2, :host([data-h2-menu-wrapper]) [data-h2-menu] h3, :host([data-h2-menu-wrapper]) [data-h2-menu] h4, :host([data-h2-menu-wrapper]) [data-h2-menu] h5, :host([data-h2-menu-wrapper]) [data-h2-menu] h6, :host([data-h2-menu-wrapper]) [data-h2-menu] p {
+:host([data-h2-menu-wrapper]) [data-h2-menu] h1,
+:host([data-h2-menu-wrapper]) [data-h2-menu] h2,
+:host([data-h2-menu-wrapper]) [data-h2-menu] h3,
+:host([data-h2-menu-wrapper]) [data-h2-menu] h4,
+:host([data-h2-menu-wrapper]) [data-h2-menu] h5,
+:host([data-h2-menu-wrapper]) [data-h2-menu] h6,
+:host([data-h2-menu-wrapper]) [data-h2-menu] p {
   font-family: sans-serif;
   font-weight: normal;
   line-height: 1.5;
   margin: 0;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] h1 {
-  font-size: calc(calc(calc(calc(calc(1rem*1.333)*1.333)*1.333)*1.333)*1.333);
+  font-size: calc(calc(calc(calc(calc(1rem * 1.333) * 1.333) * 1.333) * 1.333) * 1.333);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] h2 {
-  font-size: calc(calc(calc(calc(1rem*1.333)*1.333)*1.333)*1.333);
+  font-size: calc(calc(calc(calc(1rem * 1.333) * 1.333) * 1.333) * 1.333);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] h3 {
-  font-size: calc(calc(calc(1rem*1.333)*1.333)*1.333);
+  font-size: calc(calc(calc(1rem * 1.333) * 1.333) * 1.333);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] h4 {
-  font-size: calc(calc(1rem*1.333)*1.333);
+  font-size: calc(calc(1rem * 1.333) * 1.333);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] h5 {
-  font-size: calc(1rem*1.333);
+  font-size: calc(1rem * 1.333);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] h6 {
   font-size: 1rem;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] p, :host([data-h2-menu-wrapper]) [data-h2-menu] div {
+:host([data-h2-menu-wrapper]) [data-h2-menu] p,
+:host([data-h2-menu-wrapper]) [data-h2-menu] div {
   font-size: 1rem;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] span,
@@ -134,10 +141,26 @@
 }
 @media (hover: hover) {
   :host([data-h2-menu-wrapper]) [data-h2-menu] a:hover {
-    color: #0065fe !important;
-    transition: color 0.2s ease;
+    background-color: rgba(180, 180, 180, 0.5);
+    color: #000000 !important;
+    transition: all 0.2s ease;
   }
 }
+
+:host([data-h2-menu-wrapper]) [data-h2-menu] a:focus {
+  background-color: #303fc3;
+  color: #ffffff !important;
+  transition: all 0.2s ease;
+  outline: none;
+}
+
+:host([data-h2-menu-wrapper]) [data-h2-menu] a:active {
+  background-color: #595959;
+  color: #ffffff !important;
+  transition: all 0.2s ease;
+  outline: none;
+}
+
 :host([data-h2-menu-wrapper]) [data-h2-menu] ul,
 :host([data-h2-menu-wrapper]) [data-h2-menu] ol {
   font-family: sans-serif;
@@ -161,18 +184,18 @@
   margin-top: calc(1.5rem / 2);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-focus]:focus {
-  box-shadow: -1px -1px 0 #9D5CFF, 0 -1px 0 #9D5CFF, 1px -1px 0 #9D5CFF, 1px 0 0 #9D5CFF, 1px 1px 0 #9D5CFF, 0 1px 0 #9D5CFF, -1px 1px 0 #9D5CFF, -1px 0 0 #9D5CFF;
+  box-shadow: -1px -1px 0 #9d5cff, 0 -1px 0 #9d5cff, 1px -1px 0 #9d5cff, 1px 0 0 #9d5cff, 1px 1px 0 #9d5cff, 0 1px 0 #9d5cff, -1px 1px 0 #9d5cff, -1px 0 0 #9d5cff;
   outline: none;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] {
   background: rgba(210, 210, 210, 0.5);
 }
 @media screen and (min-width: 64em) {
-  :host([menu-mobile-layout*=drawer]) [data-h2-menu] {
+  :host([menu-mobile-layout*='drawer']) [data-h2-menu] {
     background: rgba(210, 210, 210, 0.5);
   }
 
-  :host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
+  :host([menu-mobile-layout*='toolbar']) [data-h2-menu] {
     background: rgba(210, 210, 210, 0.5);
   }
 }
@@ -193,53 +216,54 @@
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] {
   width: 100%;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] {
   display: flex;
   justify-content: space-evenly;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child {
   padding-bottom: 0;
 }
-:host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child {
+:host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child {
   padding-bottom: 6rem;
 }
 @media screen and (min-width: 64em) {
   :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child {
     padding-bottom: 0;
   }
-  :host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] {
+  :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] {
     display: block;
   }
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-toolbar-parent] {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-toolbar-parent] {
   display: none;
 }
 @media screen and (min-width: 64em) {
-  :host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-toolbar-parent] {
+  :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-toolbar-parent] {
     display: block;
   }
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li {
   position: relative;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li {
   width: 30%;
 }
 @media screen and (min-width: 64em) {
-  :host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li {
+  :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li {
     width: auto;
   }
 }
-:host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role=menuitem] {
+:host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role='menuitem'] {
   display: block;
   font-size: 1rem;
   line-height: 1.5;
-  margin: 0 1.5rem;
+  margin: 0;
+  padding-left: 1.5rem;
   padding-top: 1.5rem;
   padding-right: calc(1.5rem * 3);
   padding-bottom: 1.5rem;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role=menuitem] {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role='menuitem'] {
   display: block;
   font-size: 1rem;
   line-height: 1.5;
@@ -248,7 +272,7 @@
   padding-bottom: 1.5rem;
 }
 @media screen and (min-width: 64rem) {
-  :host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role=menuitem] {
+  :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role='menuitem'] {
     display: block;
     font-size: 1rem;
     line-height: 1.5;
@@ -258,7 +282,7 @@
     padding-bottom: 1.5rem;
   }
 }
-:host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] {
+:host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] {
   background: none;
   border: none;
   cursor: pointer;
@@ -268,7 +292,7 @@
   top: 1px;
   right: 1.5rem;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] {
   background: none;
   border: none;
   cursor: pointer;
@@ -279,7 +303,7 @@
   right: 0.5rem;
 }
 @media screen and (min-width: 64rem) {
-  :host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] {
+  :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li [data-h2-submenu-trigger] {
     background: none;
     border: none;
     cursor: pointer;
@@ -314,10 +338,10 @@
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
   display: block;
 }
-:host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] {
+:host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] {
   display: block;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] {
   position: fixed;
   left: 3rem;
   right: 3rem;
@@ -325,8 +349,8 @@
   height: auto;
   display: block;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] > li.h2-active > [data-h2-menulist] {
-  position:relative;
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] > li.h2-active > [data-h2-menulist] {
+  position: relative;
   left: 0;
   right: 0;
   bottom: 0;
@@ -334,7 +358,7 @@
   display: block;
 }
 @media screen and (min-width: 64rem) {
-  :host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] {
+  :host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li.h2-active > [data-h2-menulist] {
     display: block;
     position: relative;
     bottom: auto;
@@ -349,17 +373,17 @@
   margin-top: 0;
   text-align: left;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [role=menuitem] {
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [role='menuitem'] {
   color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
   color: #000000;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:first-child) > [role='menuitem'] {
   border-top: 1px solid rgba(0, 0, 0, 0.3);
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] + [data-h2-menulist] > li > [role=menuitem] {
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] + [data-h2-menulist] > li > [role='menuitem'] {
   border-top: 1px solid rgba(0, 0, 0, 0.3);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > a:hover {
@@ -367,25 +391,57 @@
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
   background-color: rgba(180, 180, 180, 0.3);
+  transition: all 0.2s ease-in-out;
+}
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger]:hover {
+  background-color: rgba(180, 180, 180, 0.8);
+}
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger]:focus {
+  background-color: #303fc3;
+  color: #ffffff !important;
+  outline: none;
+}
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger]:focus span {
+  color: #ffffff !important;
+  transition: all 0.4s ease-in-out;
+}
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger]:active {
+  background-color: #595959;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
   background-color: rgba(210, 210, 210, 0.5);
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role='menuitem'] {
   border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [role='menuitem'] {
   color: #000000;
-  margin-left: calc(1.5rem * 1.5);
+  margin-left: 0;
 }
 
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li {
   width: auto;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-add-icon],
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-remove-icon] {
   color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
@@ -394,23 +450,69 @@
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
   background-color: rgba(180, 180, 180, 0.3);
 }
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger]:hover {
+  background-color: rgba(180, 180, 180, 0.8);
+}
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger]:focus {
+  background-color: #303fc3;
+  color: #ffffff !important;
+  outline: none;
+}
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger]:focus span {
+  color: #ffffff !important;
+  transition: all 0.2s ease-in-out;
+}
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger]:active {
+  background-color: #595959;
+}
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] {
   background-color: rgba(210, 210, 210, 0.5);
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li:not(:first-child)
+  > [role='menuitem'] {
   border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role='menuitem'] {
   color: #000000;
-  margin-left: calc(1.5rem * 2);
+  margin-right: 0;
+  margin-left: 0 !important;
+  padding-left: 2.5rem !important;
 }
-:host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li {
+:host([menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li {
   width: auto;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-add-icon],
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-remove-icon] {
   color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
@@ -422,120 +524,384 @@
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] {
   background-color: #111116;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li:not(:first-child)
+  > [role='menuitem'] {
   border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [role='menuitem'] {
   color: #000000;
   margin-left: calc(1.5rem * 2.5);
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-add-icon],
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-remove-icon] {
   color: #000000;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > a:hover {
   color: #8ffff3;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
-  background-color: rgba(255, 255, 255, 0.1);
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger] {
+  background-color: red;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist] {
   background-color: #060608;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li:not(:first-child)
+  > [role='menuitem'] {
   border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [role='menuitem'] {
   color: #000000;
   margin-left: calc(1.5rem * 3);
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-add-icon],
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-remove-icon] {
   color: #000000;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > a:hover {
   color: #8ffff3;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger] {
   background-color: rgba(255, 255, 255, 0.1);
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist] {
   background-color: black;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li:not(:first-child)
+  > [role='menuitem'] {
   border-top-color: rgba(0, 0, 0, 0.3);
   border-top-style: solid;
   border-top-width: 1px;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [role='menuitem'] {
   color: #000000;
   margin-left: calc(1.5rem * 3.5);
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-add-icon],
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger]
+  [data-h2-submenu-trigger-remove-icon] {
   color: #000000;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > a:hover {
   color: #8ffff3;
 }
-:host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
+:host([data-h2-menu-wrapper])
+  [data-h2-menu]
+  [data-h2-menu-container]
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-menulist]
+  > li
+  > [data-h2-submenu-trigger] {
   background-color: rgba(255, 255, 255, 0.1);
 }
 
-:host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
+:host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
   margin: 1.5rem;
 }
-:host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
+:host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
   margin: 1.5rem;
 }
 @media screen and (min-width: 64em) {
-  :host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
+  :host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
     margin: 0;
   }
-  :host([menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
+  :host([menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
     margin: 0;
   }
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] {
     display: block;
     height: auto;
     overflow: visible;
     position: relative;
     width: 100%;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] {
     max-width: 68.75rem;
     margin-left: auto;
     margin-right: auto;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li {
     display: inline-block;
-    margin-left: 1.5rem;
+    margin-left: 1.188rem;
     margin-right: -1.5rem;
     position: relative;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:last-child) {
-    border-right: 1px solid rgba(0, 0, 0, 0.2);
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:last-child) {
+    border-right: 0 solid rgba(0, 0, 0, 0.2);
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [role=menuitem] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [role='menuitem'] {
     border: none !important;
     display: inline-block;
     margin: 0;
     padding: calc(1.5rem / 1.5) 1.5rem;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
     padding: calc(1.5rem / 1.5) 1.5rem;
     position: relative;
     top: auto;
     right: auto;
   }
-  :host([menu-desktop-layout*=topbar][menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
+  :host([menu-desktop-layout*='topbar'][menu-mobile-layout*='toolbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
     max-height: 70vh;
     min-width: 25rem;
     overflow: auto;
@@ -543,31 +909,73 @@
     left: auto;
     width: 25vw;
   }
-  :host([menu-desktop-layout*=topbar][menu-mobile-layout*=drawer]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
+  :host([menu-desktop-layout*='topbar'][menu-mobile-layout*='drawer']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
     max-height: 70vh;
     min-width: 25rem;
     overflow: auto;
     position: absolute;
     width: 25vw;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [role=menuitem] {
-    margin: 0 1.5rem;
-    padding: calc(1.5rem / 1.5) calc(1.5rem * 3) calc(1.5rem / 1.5) 0;
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [role='menuitem'] {
+    margin: 0;
+    padding: calc(1.5rem / 1.5) calc(1.5rem * 3) calc(1.5rem / 1.5) 1.5rem;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [data-h2-submenu-trigger] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [role='menuitem']:focus {
+    outline: none;
+  }
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li [data-h2-menulist] li > [data-h2-submenu-trigger] {
     padding: calc(1.5rem / 1.5) 1.5rem;
     right: 1.5rem;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role='menuitem'] {
     margin-left: calc(1.5rem * 1.5);
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+  :host([menu-desktop-layout*='topbar'])
+    [data-h2-menu]
+    [data-h2-menu-container]
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [role='menuitem'] {
     margin-left: calc(1.5rem * 2);
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+  :host([menu-desktop-layout*='topbar'])
+    [data-h2-menu]
+    [data-h2-menu-container]
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [role='menuitem'] {
     margin-left: calc(1.5rem * 2.5);
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
+  :host([menu-desktop-layout*='topbar'])
+    [data-h2-menu]
+    [data-h2-menu-container]
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [data-h2-menulist]
+    > li
+    > [role='menuitem'] {
     margin-left: calc(1.5rem * 3);
   }
 }
@@ -581,7 +989,7 @@
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=topbar][menu-sticky]) [data-h2-menu] {
+  :host([menu-desktop-layout*='topbar'][menu-sticky]) [data-h2-menu] {
     position: sticky;
     top: 0;
     left: 0;
@@ -589,63 +997,63 @@
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] {
     display: flex;
   }
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] [data-h2-menulist] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] [data-h2-menulist] {
     width: auto;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
     display: grid;
     align-content: center;
   }
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
     display: grid;
     align-content: center;
   }
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=topbar][menu-alignment*=center]) [data-h2-menu] [data-h2-menu-container] {
-   justify-content: space-between;
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='center']) [data-h2-menu] [data-h2-menu-container] {
+    justify-content: space-between;
   }
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=topbar][menu-alignment*=right]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] {
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='right']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] {
     margin-left: auto;
   }
-  :host([menu-desktop-layout*=topbar][menu-alignment*=right]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='right']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
     left: auto;
     right: 0;
   }
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=topbar][menu-alignment*=split]) [data-h2-menu] [data-h2-menu-container] {
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='split']) [data-h2-menu] [data-h2-menu-container] {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
   }
-  :host([menu-desktop-layout*=topbar][menu-alignment*=split]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:first-of-type {
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='split']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:first-of-type {
     margin-right: auto;
   }
-  :host([menu-desktop-layout*=topbar][menu-alignment*=split]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:first-child {
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='split']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:first-child {
     width: auto;
   }
-  :host([menu-desktop-layout*=topbar][menu-alignment*=split]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child {
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='split']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child {
     text-align: right;
   }
-  :host([menu-desktop-layout*=topbar][menu-alignment*=split]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child > li > [data-h2-menulist] {
+  :host([menu-desktop-layout*='topbar'][menu-alignment*='split']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist]:last-child > li > [data-h2-menulist] {
     right: 0;
   }
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=sidebar]) [data-h2-menu] {
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] {
     display: block;
     height: 100vh;
     overflow: auto;
@@ -655,42 +1063,43 @@
     right: auto;
     width: 25%;
   }
-  :host([menu-desktop-layout*=sidebar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li {
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li {
     position: relative;
   }
-  :host([menu-desktop-layout*=sidebar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role=menuitem] {
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [role='menuitem'] {
     padding: calc(1rem) calc(1.5rem * 3) calc(1rem) 0;
   }
-  :host([menu-desktop-layout*=sidebar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [data-h2-submenu-trigger] {
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] li > [data-h2-submenu-trigger] {
     padding: calc(1rem) 1.5rem;
     top: 1px;
   }
-  :host([menu-desktop-layout*=sidebar]) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
     margin: 1.5rem;
-   }
-  :host([menu-desktop-layout*=sidebar]) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
+  }
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
     margin: 1.5rem;
-   }
+  }
 }
 
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=sidebar]) [data-h2-menu] + ::slotted(div), :host([menu-desktop-layout*=sidebar]) [data-h2-menu] + ::slotted(main) {
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] + ::slotted(div),
+  :host([menu-desktop-layout*='sidebar']) [data-h2-menu] + ::slotted(main) {
     margin-left: 25%;
     overflow-x: hidden;
     width: 75%;
   }
 }
 
-
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=sidebar][menu-alignment*=right]) [data-h2-menu] {
+  :host([menu-desktop-layout*='sidebar'][menu-alignment*='right']) [data-h2-menu] {
     top: 0;
     left: auto;
     right: 0;
   }
 }
 @media screen and (min-width: 64em) {
-  :host([menu-desktop-layout*=sidebar][menu-alignment*=right]) [data-h2-menu] + ::slotted(div), :host([menu-desktop-layout*=sidebar][menu-alignment*=right]) [data-h2-menu] + ::slotted(main) {
+  :host([menu-desktop-layout*='sidebar'][menu-alignment*='right']) [data-h2-menu] + ::slotted(div),
+  :host([menu-desktop-layout*='sidebar'][menu-alignment*='right']) [data-h2-menu] + ::slotted(main) {
     margin-left: auto;
     margin-right: 25%;
     overflow-x: hidden;
@@ -698,9 +1107,8 @@
   }
 }
 
-
 @media screen and (max-width: 76.625em) {
-  :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] {
+  :host([menu-desktop-layout*='topbar']) [data-h2-menu] [data-h2-menu-container] {
     max-width: 90%;
   }
 }

--- a/src/components/gcds-site-menu/gcds-site-menu.css
+++ b/src/components/gcds-site-menu/gcds-site-menu.css
@@ -1,3 +1,7 @@
+:host([data-h2-menu-wrapper]) {
+  font-family: sans-serif;
+}
+
 .h2-mobile-menu-body-lock {
   overflow: hidden;
 }
@@ -130,7 +134,7 @@
 }
 @media (hover: hover) {
   :host([data-h2-menu-wrapper]) [data-h2-menu] a:hover {
-    color: #5CFFEE !important;
+    color: #0065fe !important;
     transition: color 0.2s ease;
   }
 }
@@ -161,15 +165,15 @@
   outline: none;
 }
 :host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
-  background: rgba(10, 10, 20, 1);
+  background: #EDEDED;
 }
 @media screen and (min-width: 64em) {
   :host([menu-mobile-layout*=drawer]) [data-h2-menu] {
-    background: rgba(10, 10, 20, 0.7);
+    background: #EDEDED;
   }
 
   :host([menu-mobile-layout*=toolbar]) [data-h2-menu] {
-    background: rgba(10, 10, 20, 0.7);
+    background: #EDEDED;
   }
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu].h2-mobile-menu-active {
@@ -346,26 +350,26 @@
   text-align: left;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [role=menuitem] {
-  color: #FFFFFF;
+  color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
-  color: #FFFFFF;
+  color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
-  border-top: 1px solid #613DC1;
+  border-top: 1px solid #EDEDED;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] + [data-h2-menulist] > li > [role=menuitem] {
-  border-top: 1px solid #613DC1;
+  border-top: 1px solid #EDEDED;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > a:hover {
   color: #8ffff3;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(167, 167, 167, 0.2);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] {
-  background-color: #282832;
+  background-color: #dadada;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
   border-top-color: rgba(255, 255, 255, 0.3);
@@ -373,7 +377,7 @@
   border-top-width: 1px;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
-  color: #FFFFFF;
+  color: #000000;
   margin-left: calc(1.5rem * 1.5);
 }
 
@@ -382,16 +386,16 @@
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
-  color: #FFFFFF;
+  color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
   color: #8ffff3;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.4);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] {
-  background-color: #1d1d24;
+  background-color: #EDEDED;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li:not(:first-child) > [role=menuitem] {
   border-top-color: rgba(255, 255, 255, 0.3);
@@ -399,7 +403,7 @@
   border-top-width: 1px;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
-  color: #FFFFFF;
+  color: #000000;
   margin-left: calc(1.5rem * 2);
 }
 :host([menu-mobile-layout*=toolbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li {
@@ -407,7 +411,7 @@
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
-  color: #FFFFFF;
+  color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
   color: #8ffff3;
@@ -424,12 +428,12 @@
   border-top-width: 1px;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
-  color: #FFFFFF;
+  color: #000000;
   margin-left: calc(1.5rem * 2.5);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
-  color: #FFFFFF;
+  color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
   color: #8ffff3;
@@ -446,12 +450,12 @@
   border-top-width: 1px;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
-  color: #FFFFFF;
+  color: #000000;
   margin-left: calc(1.5rem * 3);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
-  color: #FFFFFF;
+  color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
   color: #8ffff3;
@@ -468,12 +472,12 @@
   border-top-width: 1px;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [role=menuitem] {
-  color: #FFFFFF;
+  color: #000000;
   margin-left: calc(1.5rem * 3.5);
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-add-icon],
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-submenu-trigger] [data-h2-submenu-trigger-remove-icon] {
-  color: #FFFFFF;
+  color: #000000;
 }
 :host([data-h2-menu-wrapper]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > [data-h2-menulist] > li > a:hover {
   color: #8ffff3;
@@ -506,7 +510,7 @@
     width: 100%;
   }
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] {
-    max-width: 80rem;
+    max-width: 68.75rem;
     margin-left: auto;
     margin-right: auto;
   }
@@ -516,7 +520,7 @@
     position: relative;
   }
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li:not(:last-child) {
-    border-right: 1px solid #613DC1;
+    border-right: 1px solid #EDEDED;
   }
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] > [data-h2-menulist] > li > [role=menuitem] {
     border: none !important;
@@ -568,10 +572,10 @@
 }
 
 [data-optional-left] {
-  color: #fff;
+  color: #000000;
 }
 [data-optional-right] {
-  color: #fff;
+  color: #000000;
 }
 
 @media screen and (min-width: 64em) {
@@ -595,12 +599,10 @@
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] [data-optional-left] {
     display: grid;
     align-content: center;
-    margin-left: 1rem;
   }
   :host([menu-desktop-layout*=topbar]) [data-h2-menu] [data-h2-menu-container] [data-optional-right] {
     display: grid;
     align-content: center;
-    margin-right: 1rem;
   }
 }
 


### PR DESCRIPTION
Sorry this took so long, it was slow working :s

# Summary | Résumé

Restyling the site menu component. 
The main work that was done here was:
- Replacing the background colour with something more neutral (gray here)
- Aligning the site menu container with the current container
- Adding interactive states for each menu-item (Hover, active, focus)
- Added a media query to ensure the alignment of the site-menu with the container as screen width is reduced.

## Known issues

- There is an issue with the hover state for the `components` link and the submenu trigger clashing on smaller screens (they overlap) that probably can't be resolved without changing the actual structure of the component, so leaving as is for now and we can deal with it in the future