### PR TITLE
Add bilingual text for required label

### DIFF
--- a/src/components/gcds-input/gcds-input.spec.ts
+++ b/src/components/gcds-input/gcds-input.spec.ts
@@ -10,7 +10,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-renders">
         <fieldset>
-          <gcds-label label-for="input-renders" label="Label"></gcds-label>
+          <gcds-label label-for="input-renders" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-renders"
@@ -35,7 +35,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input type="email" label="Label" input-id="type-email">
         <fieldset>
-          <gcds-label label-for="type-email" label="Label"></gcds-label>
+          <gcds-label label-for="type-email" label="Label" lang="en"></gcds-label>
           <input
             type="email"
             id="type-email"
@@ -57,7 +57,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input type="number" label="Label" input-id="type-number">
         <fieldset>
-          <gcds-label label-for="type-number" label="Label"></gcds-label>
+          <gcds-label label-for="type-number" label="Label" lang="en"></gcds-label>
           <input
             type="number"
             id="type-number"
@@ -79,7 +79,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input type="password" label="Label" input-id="type-password">
         <fieldset>
-          <gcds-label label-for="type-password" label="Label"></gcds-label>
+          <gcds-label label-for="type-password" label="Label" lang="en"></gcds-label>
           <input
             type="password"
             id="type-password"
@@ -101,7 +101,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input type="search" label="Label" input-id="type-search">
         <fieldset>
-          <gcds-label label-for="type-search" label="Label"></gcds-label>
+          <gcds-label label-for="type-search" label="Label" lang="en"></gcds-label>
           <input
             type="search"
             id="type-search"
@@ -123,7 +123,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input type="text" label="Label" input-id="type-text">
         <fieldset>
-          <gcds-label label-for="type-text" label="Label"></gcds-label>
+          <gcds-label label-for="type-text" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="type-text"
@@ -145,7 +145,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input type="url" label="Label" input-id="type-url">
         <fieldset>
-          <gcds-label label-for="type-url" label="Label"></gcds-label>
+          <gcds-label label-for="type-url" label="Label" lang="en"></gcds-label>
           <input
             type="url"
             id="type-url"
@@ -170,7 +170,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-disabled" disabled="">
         <fieldset class="disabled">
-          <gcds-label label-for="input-disabled" label="Label"></gcds-label>
+          <gcds-label label-for="input-disabled" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-disabled"
@@ -196,7 +196,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-with-error" error-message="This is an error message.">
         <fieldset class="error">
-          <gcds-label label-for="input-with-error" label="Label"></gcds-label>
+          <gcds-label label-for="input-with-error" label="Label" lang="en"></gcds-label>
           <gcds-error-message message-id="input-with-error" message="This is an error message."></gcds-error-message>
           <input
             type="text"
@@ -223,7 +223,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-label-hidden" hide-label>
         <fieldset>
-          <gcds-label label-for="input-label-hidden" label="Label" hide-label></gcds-label>
+          <gcds-label label-for="input-label-hidden" label="Label" hide-label lang="en"></gcds-label>
           <input
             type="text"
             id="input-label-hidden"
@@ -248,7 +248,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-with-hint" hint="This is an input hint.">
         <fieldset>
-          <gcds-label label-for="input-with-hint" label="Label" ></gcds-label>
+          <gcds-label label-for="input-with-hint" label="Label" lang="en"></gcds-label>
           <gcds-hint hint-id="input-with-hint" hint="This is an input hint."></gcds-hint>
           <input
             type="text"
@@ -274,7 +274,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-renders-id">
         <fieldset>
-          <gcds-label label-for="input-renders-id" label="Label"></gcds-label>
+          <gcds-label label-for="input-renders-id" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-renders-id"
@@ -299,7 +299,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-renders-label">
         <fieldset>
-          <gcds-label label-for="input-renders-label" label="Label"></gcds-label>
+          <gcds-label label-for="input-renders-label" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-renders-label"
@@ -324,7 +324,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-required" required>
         <fieldset>
-          <gcds-label label-for="input-required" label="Label" required></gcds-label>
+          <gcds-label label-for="input-required" label="Label" required lang="en"></gcds-label>
           <input
             type="text"
             id="input-required"
@@ -350,7 +350,7 @@ describe('gcds-input', () => {
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-with-value" value="Input value">
         <fieldset>
-          <gcds-label label-for="input-with-value" label="Label" ></gcds-label>
+          <gcds-label label-for="input-with-value" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-with-value"

--- a/src/components/gcds-input/gcds-input.tsx
+++ b/src/components/gcds-input/gcds-input.tsx
@@ -9,6 +9,8 @@ import { Component, Element, Event, EventEmitter, Host, Prop, h } from '@stencil
 export class GcdsInput {
   @Element() el: HTMLElement;
 
+  private lang: string;
+
   /**
    * Input props
    */
@@ -98,8 +100,23 @@ export class GcdsInput {
     this.gcdsChange.emit(this.value);
   }
 
+  async componentWillLoad() {
+    // Define lang attribute
+    if(!this.el.getAttribute('lang')) {
+      if (document.documentElement.getAttribute('lang') == 'en' || !document.documentElement.getAttribute('lang')) {
+        this.lang = 'en';
+      } else {
+        this.lang = 'fr';
+      }
+    } else if(this.el.getAttribute('lang') == 'en') {
+      this.lang = 'en';
+    } else {
+      this.lang = 'fr';
+    }
+  }
+
   render() {
-    const { disabled, errorMessage, hideLabel, hint, inputId, label, required, size, type, value } = this;
+    const { disabled, errorMessage, hideLabel, hint, inputId, label, required, size, type, value, lang } = this;
 
     const attrsInput = {
       disabled,
@@ -121,6 +138,7 @@ export class GcdsInput {
             {...attrsLabel}
             hide-label={hideLabel}
             label-for={inputId}
+            lang={lang}
           />
 
           {hint ? <gcds-hint hint={hint} hint-id={inputId} /> : null}

--- a/src/components/gcds-input/gcds-input.tsx
+++ b/src/components/gcds-input/gcds-input.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
+import { assignLanguage } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-input',
@@ -102,17 +103,7 @@ export class GcdsInput {
 
   async componentWillLoad() {
     // Define lang attribute
-    if(!this.el.getAttribute('lang')) {
-      if (document.documentElement.getAttribute('lang') == 'en' || !document.documentElement.getAttribute('lang')) {
-        this.lang = 'en';
-      } else {
-        this.lang = 'fr';
-      }
-    } else if(this.el.getAttribute('lang') == 'en') {
-      this.lang = 'en';
-    } else {
-      this.lang = 'fr';
-    }
+    this.lang = assignLanguage(this.el);
   }
 
   render() {

--- a/src/components/gcds-label/gcds-label.tsx
+++ b/src/components/gcds-label/gcds-label.tsx
@@ -9,6 +9,8 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 export class GcdsLabel {
   @Element() el: HTMLElement;
 
+  private lang: string;
+
   /**
    * Specifies if the label is hidden or not.
    */
@@ -29,8 +31,24 @@ export class GcdsLabel {
    */
   @Prop() required?: boolean;
 
+  async componentWillLoad() {
+    // Define lang attribute
+    if(!this.el.getAttribute('lang')) {
+      if (document.documentElement.getAttribute('lang') == 'en' || !document.documentElement.getAttribute('lang')) {
+        this.lang = 'en';
+      } else {
+        this.lang = 'fr';
+      }
+    } else if(this.el.getAttribute('lang') == 'en') {
+      this.lang = 'en';
+    } else {
+      this.lang = 'fr';
+    }
+  }
+
   render() {
-    const { hideLabel, labelFor, label, required } = this;
+    const { hideLabel, labelFor, label, required, lang } = this;
+    const requiredText = lang == "en" ? "required" : "obligatoire";
 
     return (
       <Host id={`label-for-${labelFor}`}>
@@ -40,7 +58,7 @@ export class GcdsLabel {
         >
           <span>{label}</span>
           {required ?
-            <strong class="required">(required)</strong>
+            <strong class="required">({requiredText})</strong>
           : null}
         </label>
       </Host>

--- a/src/components/gcds-site-menu/gcds-site-menu.tsx
+++ b/src/components/gcds-site-menu/gcds-site-menu.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Host, Prop, Watch, h } from '@stencil/core';
+import { assignLanguage } from '../../utils/utils';
 import { 
   h2MenuAddUpDownArrowsToMainMenuItems, 
   h2MenuTabOrder, 
@@ -147,17 +148,7 @@ export class GcdsSiteMenu {
 
   async componentWillLoad() {
     // Define lang attribute
-    if(!this.el.getAttribute("lang")) {
-      if (document.documentElement.getAttribute("lang") == "en" || !document.documentElement.getAttribute("lang")) {
-        this.lang = "en";
-      } else {
-        this.lang = "fr";
-      }
-    } else if(this.el.getAttribute("lang") == "en") {
-      this.lang = "en";
-    } else {
-      this.lang = "fr";
-    }
+    this.lang = assignLanguage(this.el);
 
     this.validateDesktopLayout(this.menuDesktopLayout);
     this.validateMobileLayout(this.menuMobileLayout);

--- a/src/components/gcds-textarea/gcds-textarea.spec.ts
+++ b/src/components/gcds-textarea/gcds-textarea.spec.ts
@@ -10,7 +10,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-renders">
         <fieldset>
-          <gcds-label label-for="textarea-renders" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-renders" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-renders"
             name="textarea-renders"
@@ -35,7 +35,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-disabled" disabled="">
         <fieldset class="disabled">
-          <gcds-label label-for="textarea-disabled" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-disabled" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-disabled"
             name="textarea-disabled"
@@ -61,7 +61,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-with-error" error-message="This is an error message.">
         <fieldset class="error">
-          <gcds-label label-for="textarea-with-error" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-with-error" label="Label" lang="en"></gcds-label>
           <gcds-error-message message-id="textarea-with-error" message="This is an error message."></gcds-error-message>
           <textarea
             id="textarea-with-error"
@@ -88,7 +88,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-label-hidden" hide-label>
         <fieldset>
-          <gcds-label label-for="textarea-label-hidden" label="Label" hide-label></gcds-label>
+          <gcds-label label-for="textarea-label-hidden" label="Label" hide-label lang="en"></gcds-label>
           <textarea
             id="textarea-label-hidden"
             name="textarea-label-hidden"
@@ -113,7 +113,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-renders-label">
         <fieldset>
-          <gcds-label label-for="textarea-renders-label" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-renders-label" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-renders-label"
             name="textarea-renders-label"
@@ -138,7 +138,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-required" required>
         <fieldset>
-          <gcds-label label-for="textarea-required" label="Label" required></gcds-label>
+          <gcds-label label-for="textarea-required" label="Label" required lang="en"></gcds-label>
           <textarea
             id="textarea-required"
             name="textarea-required"
@@ -164,7 +164,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="character-count-no-value" textarea-character-count="10">
         <fieldset>
-          <gcds-label label-for="character-count-no-value" label="Label"></gcds-label>
+          <gcds-label label-for="character-count-no-value" label="Label" lang="en"></gcds-label>
           <textarea
             id="character-count-no-value"
             name="character-count-no-value"
@@ -188,7 +188,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="character-count-value" value="Value Test" textarea-character-count="22">
         <fieldset>
-          <gcds-label label-for="character-count-value" label="Label"></gcds-label>
+          <gcds-label label-for="character-count-value" label="Label" lang="en"></gcds-label>
           <textarea
             id="character-count-value"
             name="character-count-value"
@@ -215,7 +215,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-cols" cols="10">
         <fieldset>
-          <gcds-label label-for="textarea-cols" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-cols" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-cols"
             name="textarea-cols"
@@ -241,7 +241,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-with-hint" hint="This is a textarea hint.">
         <fieldset>
-          <gcds-label label-for="textarea-with-hint" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-with-hint" label="Label" lang="en"></gcds-label>
           <gcds-hint hint="This is a textarea hint." hint-id="textarea-with-hint"></gcds-hint>
           <textarea
             id="textarea-with-hint"
@@ -267,7 +267,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-renders-id">
         <fieldset>
-          <gcds-label label-for="textarea-renders-id" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-renders-id" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-renders-id"
             name="textarea-renders-id"
@@ -292,7 +292,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-rows" rows="2">
         <fieldset>
-          <gcds-label label-for="textarea-rows" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-rows" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-rows"
             name="textarea-rows"
@@ -317,7 +317,7 @@ describe('gcds-textarea', () => {
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-with-value" value="Textarea value">
         <fieldset>
-          <gcds-label label-for="textarea-with-value" label="Label"></gcds-label>
+          <gcds-label label-for="textarea-with-value" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-with-value"
             name="textarea-with-value"

--- a/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/src/components/gcds-textarea/gcds-textarea.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
+import { assignLanguage } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-textarea',
@@ -107,17 +108,7 @@ export class GcdsTextarea {
 
   async componentWillLoad() {
     // Define lang attribute
-    if(!this.el.getAttribute('lang')) {
-      if (document.documentElement.getAttribute('lang') == 'en' || !document.documentElement.getAttribute('lang')) {
-        this.lang = 'en';
-      } else {
-        this.lang = 'fr';
-      }
-    } else if(this.el.getAttribute('lang') == 'en') {
-      this.lang = 'en';
-    } else {
-      this.lang = 'fr';
-    }
+    this.lang = assignLanguage(this.el);
   }
 
   render() {

--- a/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/src/components/gcds-textarea/gcds-textarea.tsx
@@ -121,7 +121,7 @@ export class GcdsTextarea {
   }
 
   render() {
-    const { cols, disabled, errorMessage, hideLabel, hint, label, required, rows, textareaCharacterCount, textareaId, value } = this;
+    const { cols, disabled, errorMessage, hideLabel, hint, label, required, rows, textareaCharacterCount, textareaId, value, lang } = this;
     
     const attrsLabel = {
       label,
@@ -142,6 +142,7 @@ export class GcdsTextarea {
             {...attrsLabel}
             hide-label={hideLabel}
             label-for={textareaId}
+            lang={lang}
           />
 
           {hint ? <gcds-hint hint={hint} hint-id={textareaId} /> : null}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -17,3 +17,20 @@ export const inheritAttributes = (el: HTMLElement, attributes: string[] = []) =>
 
   return attributeObject;
 }
+
+export const assignLanguage = (el: HTMLElement) => {
+  let lang = "";
+  if(!el.getAttribute('lang')) {
+    if (document.documentElement.getAttribute('lang') == 'en' || !document.documentElement.getAttribute('lang')) {
+      lang = 'en';
+    } else {
+      lang = 'fr';
+    }
+  } else if(el.getAttribute('lang') == 'en') {
+    lang = 'en';
+  } else {
+    lang = 'fr';
+  }
+
+  return lang;
+}


### PR DESCRIPTION
# Summary | Résumé

Added  passing lang attributes from gcds-input and gcds-textarea to gcds-label. When required field needs to show, it should now be bilingual. 
