### PR TITLE
Fix overwriting of inherited attributes

### DIFF
--- a/src/components/gcds-button/gcds-button.tsx
+++ b/src/components/gcds-button/gcds-button.tsx
@@ -165,7 +165,7 @@ export class GcdsButton {
     this.validateButtonRole(this.buttonRole);
     this.validateButtonStyle(this.buttonStyle);
 
-    this.inheritedAttributes = inheritAttributes(this.el, ['aria-label', 'aria-expanded', 'aria-haspopup']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-label', 'aria-expanded', 'aria-haspopup', 'aria-controls']);
   }
 
   componentDidLoad() {
@@ -203,7 +203,7 @@ export class GcdsButton {
     }
 
     // Has any inherited attributes changed on click
-    this.inheritedAttributes = inheritAttributes(this.el, ['aria-label', 'aria-expanded', 'aria-haspopup']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-label', 'aria-expanded', 'aria-haspopup', 'aria-controls']);
   }
 
   private onFocus = () => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,14 +2,14 @@ export function format(label: string): string {
   return (label ? ` ${label}` : 'Fallback Button Label');
 }
 
-export const inheritAttributes = (el: HTMLElement, attributes: string[] = []) => {
+export const inheritAttributes = (el: HTMLElement, shadowElement: HTMLElement, attributes: string[] = []) => {
   const attributeObject = {};
 
   attributes.forEach(attr => {
-    if (el.hasAttribute(attr)) {
-      const value = el.getAttribute(attr);
+    if (el.hasAttribute(attr) || (shadowElement && shadowElement.hasAttribute(attr))) {
+      const value = el.getAttribute(attr) || shadowElement.getAttribute(attr);
       if (value !== null) {
-        attributeObject[attr] = el.getAttribute(attr);
+        attributeObject[attr] = el.getAttribute(attr) || shadowElement.getAttribute(attr);
       }
       el.removeAttribute(attr);
     }


### PR DESCRIPTION
# Summary | Résumé

Fixed issue when changing an inherited attribute would remove all other inherited attributes from shadow element. inheritedAttributes now compares itself to the shadow element as well as the host element.
