### PR TITLE
textarea and input focus update

### DIFF
--- a/src/components/gcds-input/gcds-input.css
+++ b/src/components/gcds-input/gcds-input.css
@@ -9,7 +9,7 @@
   margin: 0;
   padding: 0;
   border: 0;
-  transition: color ease-in-out .15s;
+  transition: color ease-in-out 0.15s;
 
   &:focus-within {
     color: var(--gcds-input-focus);
@@ -42,17 +42,18 @@
   border: 2px solid currentColor;
   border-radius: var(--gcds-spacing-50);
   box-sizing: border-box;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 
   &:focus {
-    outline: 0;
     border-color: var(--gcds-input-focus);
-    box-shadow: 0 0 0 2.5px var(--gcds-input-focus);
+    box-shadow: 0 0 0 2px var(--gcds-color-grayscale-0);
+    outline: 3px solid var(--gcds-input-focus);
+    outline-offset: 2px;
   }
 
   &:disabled {
     cursor: not-allowed;
-    background-color: var( --gcds-input-disabled-background);
+    background-color: var(--gcds-input-disabled-background);
     border-color: var(--gcds-input-disabled-text);
   }
 

--- a/src/components/gcds-textarea/gcds-textarea.css
+++ b/src/components/gcds-textarea/gcds-textarea.css
@@ -9,7 +9,7 @@
   margin: 0;
   padding: 0;
   border: 0;
-  transition: color ease-in-out .15s;
+  transition: color ease-in-out 0.15s;
 
   &:focus-within {
     color: var(--gcds-textarea-focus);
@@ -46,12 +46,13 @@
   border: 2px solid currentColor;
   border-radius: var(--gcds-spacing-50);
   box-sizing: border-box;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 
   &:focus {
-    outline: 0;
-    border-color: var(--gcds-textarea-focus);
-    box-shadow: 0 0 0 2.5px var(--gcds-textarea-focus);
+    border-color: var(--gcds-input-focus);
+    box-shadow: 0 0 0 2px var(--gcds-color-grayscale-0);
+    outline: 3px solid var(--gcds-input-focus);
+    outline-offset: 2px;
   }
 
   &:disabled {


### PR DESCRIPTION
# Summary | Résumé

Minor update to the focus styles for inputs and textareas to match the focus style that I've mocked up in figma for radio and checkboxes.

[Atoms page to see focus styles](https://www.figma.com/file/4KWj8wnnXoq6cA6yl0dnsR/GC-Components?node-id=479%3A310)

<img width="415" alt="Screen Shot 2022-07-04 at 12 16 38" src="https://user-images.githubusercontent.com/30609058/177191123-bcbdff68-a08e-4773-8bbd-1a63bcdee4fd.png">

<img width="195" alt="Screen Shot 2022-07-04 at 12 16 31" src="https://user-images.githubusercontent.com/30609058/177191124-92f0cd47-9126-413c-8f90-4de805b3251d.png">


