### PR TITLE
Update input and textarea components

### DIFF
--- a/src/components/gcds-input/gcds-input.css
+++ b/src/components/gcds-input/gcds-input.css
@@ -1,4 +1,4 @@
-:host fieldset {
+:host .gcds-input-wrapper {
   width: 75ch;
   max-width: 90%;
   font-family: var(--gcds-font-families-body);
@@ -15,11 +15,11 @@
     color: var(--gcds-input-focus);
   }
 
-  &.disabled {
+  &.gcds-disabled {
     color: var(--gcds-input-disabled-text);
   }
 
-  &.error:not(:focus-within) {
+  &.gcds-error:not(:focus-within) {
     color: var(--gcds-input-destructive);
   }
 }
@@ -57,7 +57,7 @@
     border-color: var(--gcds-input-disabled-text);
   }
 
-  &.error:not(:focus) {
+  &.gcds-error:not(:focus) {
     border-color: var(--gcds-input-destructive);
   }
 }

--- a/src/components/gcds-input/gcds-input.spec.ts
+++ b/src/components/gcds-input/gcds-input.spec.ts
@@ -9,17 +9,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-renders">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="input-renders" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-renders"
             name="input-renders"
             aria-labelledby="label-for-input-renders"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -34,17 +33,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input type="email" label="Label" input-id="type-email">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="type-email" label="Label" lang="en"></gcds-label>
           <input
             type="email"
             id="type-email"
             name="type-email"
             aria-labelledby="label-for-type-email"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -56,17 +54,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input type="number" label="Label" input-id="type-number">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="type-number" label="Label" lang="en"></gcds-label>
           <input
             type="number"
             id="type-number"
             name="type-number"
             aria-labelledby="label-for-type-number"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -78,17 +75,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input type="password" label="Label" input-id="type-password">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="type-password" label="Label" lang="en"></gcds-label>
           <input
             type="password"
             id="type-password"
             name="type-password"
             aria-labelledby="label-for-type-password"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -100,17 +96,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input type="search" label="Label" input-id="type-search">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="type-search" label="Label" lang="en"></gcds-label>
           <input
             type="search"
             id="type-search"
             name="type-search"
             aria-labelledby="label-for-type-search"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -122,17 +117,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input type="text" label="Label" input-id="type-text">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="type-text" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="type-text"
             name="type-text"
             aria-labelledby="label-for-type-text"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -144,17 +138,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input type="url" label="Label" input-id="type-url">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="type-url" label="Label" lang="en"></gcds-label>
           <input
             type="url"
             id="type-url"
             name="type-url"
             aria-labelledby="label-for-type-url"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -169,18 +162,17 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-disabled" disabled="">
-        <fieldset class="disabled">
+        <div class="gcds-input-wrapper gcds-disabled">
           <gcds-label label-for="input-disabled" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-disabled"
             name="input-disabled"
             aria-labelledby="label-for-input-disabled"
-            aria-describedby=" "
             aria-invalid="false"
             disabled=""
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -195,19 +187,19 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-with-error" error-message="This is an error message.">
-        <fieldset class="error">
+        <div class="gcds-input-wrapper gcds-error">
           <gcds-label label-for="input-with-error" label="Label" lang="en"></gcds-label>
           <gcds-error-message message-id="input-with-error" message="This is an error message."></gcds-error-message>
           <input
             type="text"
             id="input-with-error"
-            class="error"
+            class="gcds-error"
             name="input-with-error"
             aria-labelledby="label-for-input-with-error"
             aria-describedby=" error-message-input-with-error"
             aria-invalid="true"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -222,17 +214,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-label-hidden" hide-label>
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="input-label-hidden" label="Label" hide-label lang="en"></gcds-label>
           <input
             type="text"
             id="input-label-hidden"
             name="input-label-hidden"
             aria-labelledby="label-for-input-label-hidden"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -247,7 +238,7 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-with-hint" hint="This is an input hint.">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="input-with-hint" label="Label" lang="en"></gcds-label>
           <gcds-hint hint-id="input-with-hint" hint="This is an input hint."></gcds-hint>
           <input
@@ -258,7 +249,7 @@ describe('gcds-input', () => {
             aria-describedby="hint-input-with-hint "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -273,17 +264,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-renders-id">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="input-renders-id" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-renders-id"
             name="input-renders-id"
             aria-labelledby="label-for-input-renders-id"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -298,17 +288,16 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-renders-label">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="input-renders-label" label="Label" lang="en"></gcds-label>
           <input
             type="text"
             id="input-renders-label"
             name="input-renders-label"
             aria-labelledby="label-for-input-renders-label"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -323,18 +312,17 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-required" required>
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="input-required" label="Label" required lang="en"></gcds-label>
           <input
             type="text"
             id="input-required"
             name="input-required"
             aria-labelledby="label-for-input-required"
-            aria-describedby=" "
             aria-invalid="false"
             required
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });
@@ -349,7 +337,7 @@ describe('gcds-input', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-input label="Label" input-id="input-with-value" value="Input value">
-        <fieldset>
+        <div class="gcds-input-wrapper">
           <gcds-label label-for="input-with-value" label="Label" lang="en"></gcds-label>
           <input
             type="text"
@@ -357,10 +345,9 @@ describe('gcds-input', () => {
             name="input-with-value"
             value="Input value"
             aria-labelledby="label-for-input-with-value"
-            aria-describedby=" "
             aria-invalid="false"
           />
-        </fieldset>
+        </div>
       </gcds-input>
     `);
   });

--- a/src/components/gcds-input/gcds-input.tsx
+++ b/src/components/gcds-input/gcds-input.tsx
@@ -127,9 +127,15 @@ export class GcdsInput {
       required,
     }
 
+    if (hint || errorMessage) {
+      let hintID = hint ? `hint-${inputId}` : "";
+      let errorID = errorMessage ? `error-message-${inputId}` : "";
+      attrsInput["aria-describedby"] = `${hintID} ${errorID}`;
+    }
+
     return (
       <Host>
-        <fieldset class={`${disabled ? 'disabled' : ''} ${errorMessage ? 'error' : ''}`}>
+        <div class={`gcds-input-wrapper ${disabled ? 'gcds-disabled' : ''} ${errorMessage ? 'gcds-error' : ''}`}>
           <gcds-label
             {...attrsLabel}
             hide-label={hideLabel}
@@ -145,19 +151,18 @@ export class GcdsInput {
 
           <input
             {...attrsInput}
-            class={errorMessage ? 'error' : null}
+            class={errorMessage ? 'gcds-error' : null}
             id={inputId}
             name={inputId}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onInput={(e) => this.handleChange(e)}
             aria-labelledby={`label-for-${inputId}`}
-            aria-describedby={`${hint ? `hint-${inputId}` : ''} ${errorMessage ? `error-message-${inputId}` : ''}`}
             aria-invalid={errorMessage ? 'true' : 'false'}
             maxlength={size}
             style={size ? style : null}
           />
-        </fieldset>
+        </div>
       </Host>
     );
   }

--- a/src/components/gcds-textarea/gcds-textarea.css
+++ b/src/components/gcds-textarea/gcds-textarea.css
@@ -1,4 +1,4 @@
-:host fieldset {
+:host .gcds-textarea-wrapper {
   width: 100%;
   max-width: 75ch;
   font-family: var(--gcds-font-families-body);
@@ -15,11 +15,11 @@
     color: var(--gcds-textarea-focus);
   }
 
-  &.disabled {
+  &.gcds-disabled {
     color: var(--gcds-textarea-disabled-text);
   }
 
-  &.error:not(:focus-within) {
+  &.gcds-error:not(:focus-within) {
     color: var(--gcds-textarea-destructive);
   }
 
@@ -61,7 +61,7 @@
     border-color: var(--gcds-textarea-disabled-text);
   }
 
-  &.error:not(:focus) {
+  &.gcds-error:not(:focus) {
     border-color: var(--gcds-textarea-destructive);
   }
 }

--- a/src/components/gcds-textarea/gcds-textarea.spec.ts
+++ b/src/components/gcds-textarea/gcds-textarea.spec.ts
@@ -9,17 +9,16 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-renders">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-renders" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-renders"
             name="textarea-renders"
             aria-labelledby="label-for-textarea-renders"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -34,18 +33,17 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-disabled" disabled="">
-        <fieldset class="disabled">
+        <div class="gcds-textarea-wrapper gcds-disabled">
           <gcds-label label-for="textarea-disabled" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-disabled"
             name="textarea-disabled"
             aria-labelledby="label-for-textarea-disabled"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
             disabled=""
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -60,19 +58,19 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-with-error" error-message="This is an error message.">
-        <fieldset class="error">
+        <div class="gcds-textarea-wrapper gcds-error">
           <gcds-label label-for="textarea-with-error" label="Label" lang="en"></gcds-label>
           <gcds-error-message message-id="textarea-with-error" message="This is an error message."></gcds-error-message>
           <textarea
             id="textarea-with-error"
-            class="error"
+            class="gcds-error"
             name="textarea-with-error"
             aria-labelledby="label-for-textarea-with-error"
             aria-describedby=" error-message-textarea-with-error "
             aria-invalid="true"
             rows="5"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -87,17 +85,16 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-label-hidden" hide-label>
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-label-hidden" label="Label" hide-label lang="en"></gcds-label>
           <textarea
             id="textarea-label-hidden"
             name="textarea-label-hidden"
             aria-labelledby="label-for-textarea-label-hidden"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -112,17 +109,16 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-renders-label">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-renders-label" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-renders-label"
             name="textarea-renders-label"
             aria-labelledby="label-for-textarea-renders-label"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -137,18 +133,17 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-required" required>
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-required" label="Label" required lang="en"></gcds-label>
           <textarea
             id="textarea-required"
             name="textarea-required"
             aria-labelledby="label-for-textarea-required"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
             required
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -163,7 +158,7 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="character-count-no-value" textarea-character-count="10">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="character-count-no-value" label="Label" lang="en"></gcds-label>
           <textarea
             id="character-count-no-value"
@@ -175,7 +170,7 @@ describe('gcds-textarea', () => {
             maxlength="10"
           ></textarea>
           <p id="count-character-count-no-value" aria-live="polite">10 characters allowed</p>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -187,7 +182,7 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="character-count-value" value="Value Test" textarea-character-count="22">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="character-count-value" label="Label" lang="en"></gcds-label>
           <textarea
             id="character-count-value"
@@ -199,7 +194,7 @@ describe('gcds-textarea', () => {
             maxlength="22"
           >Value Test</textarea>
           <p id="count-character-count-value" aria-live="polite">12 characters left</p>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -214,18 +209,17 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-cols" cols="10">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-cols" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-cols"
             name="textarea-cols"
             aria-labelledby="label-for-textarea-cols"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
             style="max-width: 15ch;"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -240,7 +234,7 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-with-hint" hint="This is a textarea hint.">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-with-hint" label="Label" lang="en"></gcds-label>
           <gcds-hint hint="This is a textarea hint." hint-id="textarea-with-hint"></gcds-hint>
           <textarea
@@ -251,7 +245,7 @@ describe('gcds-textarea', () => {
             aria-invalid="false"
             rows="5"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -266,17 +260,16 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-renders-id">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-renders-id" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-renders-id"
             name="textarea-renders-id"
             aria-labelledby="label-for-textarea-renders-id"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -291,17 +284,16 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-rows" rows="2">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-rows" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-rows"
             name="textarea-rows"
             aria-labelledby="label-for-textarea-rows"
-            aria-describedby="  "
             aria-invalid="false"
             rows="2"
           ></textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });
@@ -316,17 +308,16 @@ describe('gcds-textarea', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-textarea label="Label" textarea-id="textarea-with-value" value="Textarea value">
-        <fieldset>
+        <div class="gcds-textarea-wrapper">
           <gcds-label label-for="textarea-with-value" label="Label" lang="en"></gcds-label>
           <textarea
             id="textarea-with-value"
             name="textarea-with-value"
             aria-labelledby="label-for-textarea-with-value"
-            aria-describedby="  "
             aria-invalid="false"
             rows="5"
           >Textarea value</textarea>
-        </fieldset>
+        </div>
       </gcds-textarea>
     `);
   });

--- a/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/src/components/gcds-textarea/gcds-textarea.tsx
@@ -130,9 +130,16 @@ export class GcdsTextarea {
       rows,
     };
 
+    if (hint || errorMessage || textareaCharacterCount) {
+      let hintID = hint ? `hint-${textareaId}` : "";
+      let errorID = errorMessage ? `error-message-${textareaId}` : "";
+      let countID = textareaCharacterCount ? `count-${textareaId}` : "";
+      attrsTextarea["aria-describedby"] = `${hintID} ${errorID} ${countID}`;
+    }
+
     return (
       <Host>
-        <fieldset class={`${disabled ? 'disabled' : ''} ${errorMessage ? 'error' : ''}`}>
+        <div class={`gcds-textarea-wrapper ${disabled ? 'gcds-disabled' : ''} ${errorMessage ? 'gcds-error' : ''}`}>
           <gcds-label
             {...attrsLabel}
             hide-label={hideLabel}
@@ -148,14 +155,13 @@ export class GcdsTextarea {
 
           <textarea
             {...attrsTextarea}
-            class={errorMessage ? 'error' : null}
+            class={errorMessage ? 'gcds-error' : null}
             id={textareaId}
             name={textareaId}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onInput={(e) => this.handleChange(e)}
             aria-labelledby={`label-for-${textareaId}`}
-            aria-describedby={`${hint ? `hint-${textareaId}` : ''} ${errorMessage ? `error-message-${textareaId}` : ''} ${textareaCharacterCount ? `count-${textareaId}` : ''}`}
             aria-invalid={errorMessage ? 'true' : 'false'}
             maxlength={textareaCharacterCount ? textareaCharacterCount : null}
             style={cols ? style : null}
@@ -172,7 +178,7 @@ export class GcdsTextarea {
               }
             </p>
           : null}
-        </fieldset>
+        </div>
       </Host>
     );
   }


### PR DESCRIPTION
# Summary | Résumé

Based off feedback from #27 update the internal classes of `gcds-input` and `gcds-textarea` to be name spaced classes.

## Additional changes

These have been done to avoid some potential issues with some accessibility tools.

- `aria-describedby` now only renders on components when need.
- Removed the `fieldset` in the components and replaced with `<div class="gcds-{component}-wrapper">`
