### PR TITLE
gcds-fieldset

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -150,6 +150,32 @@ export namespace Components {
          */
         "messageId": string;
     }
+    interface GcdsFieldset {
+        /**
+          * Flag to disable fieldset and its contents
+         */
+        "disabled": boolean;
+        /**
+          * Error message for an invalid input element.
+         */
+        "errorMessage": string;
+        /**
+          * The unique identifier for the component
+         */
+        "fieldsetId": string;
+        /**
+          * Hint displayed below the label.
+         */
+        "hint": string;
+        /**
+          * The title for the contents of the fieldset
+         */
+        "legend": string;
+        /**
+          * Flag the contents are required
+         */
+        "required": boolean;
+    }
     interface GcdsFooter {
         /**
           * Top of page href
@@ -496,6 +522,12 @@ declare global {
         prototype: HTMLGcdsErrorMessageElement;
         new (): HTMLGcdsErrorMessageElement;
     };
+    interface HTMLGcdsFieldsetElement extends Components.GcdsFieldset, HTMLStencilElement {
+    }
+    var HTMLGcdsFieldsetElement: {
+        prototype: HTMLGcdsFieldsetElement;
+        new (): HTMLGcdsFieldsetElement;
+    };
     interface HTMLGcdsFooterElement extends Components.GcdsFooter, HTMLStencilElement {
     }
     var HTMLGcdsFooterElement: {
@@ -579,6 +611,7 @@ declare global {
         "gcds-button": HTMLGcdsButtonElement;
         "gcds-checkbox": HTMLGcdsCheckboxElement;
         "gcds-error-message": HTMLGcdsErrorMessageElement;
+        "gcds-fieldset": HTMLGcdsFieldsetElement;
         "gcds-footer": HTMLGcdsFooterElement;
         "gcds-grid": HTMLGcdsGridElement;
         "gcds-header": HTMLGcdsHeaderElement;
@@ -742,6 +775,32 @@ declare namespace LocalJSX {
           * Id attribute for the error message.
          */
         "messageId"?: string;
+    }
+    interface GcdsFieldset {
+        /**
+          * Flag to disable fieldset and its contents
+         */
+        "disabled"?: boolean;
+        /**
+          * Error message for an invalid input element.
+         */
+        "errorMessage"?: string;
+        /**
+          * The unique identifier for the component
+         */
+        "fieldsetId": string;
+        /**
+          * Hint displayed below the label.
+         */
+        "hint"?: string;
+        /**
+          * The title for the contents of the fieldset
+         */
+        "legend": string;
+        /**
+          * Flag the contents are required
+         */
+        "required"?: boolean;
     }
     interface GcdsFooter {
         /**
@@ -1100,6 +1159,7 @@ declare namespace LocalJSX {
         "gcds-button": GcdsButton;
         "gcds-checkbox": GcdsCheckbox;
         "gcds-error-message": GcdsErrorMessage;
+        "gcds-fieldset": GcdsFieldset;
         "gcds-footer": GcdsFooter;
         "gcds-grid": GcdsGrid;
         "gcds-header": GcdsHeader;
@@ -1123,6 +1183,7 @@ declare module "@stencil/core" {
             "gcds-button": LocalJSX.GcdsButton & JSXBase.HTMLAttributes<HTMLGcdsButtonElement>;
             "gcds-checkbox": LocalJSX.GcdsCheckbox & JSXBase.HTMLAttributes<HTMLGcdsCheckboxElement>;
             "gcds-error-message": LocalJSX.GcdsErrorMessage & JSXBase.HTMLAttributes<HTMLGcdsErrorMessageElement>;
+            "gcds-fieldset": LocalJSX.GcdsFieldset & JSXBase.HTMLAttributes<HTMLGcdsFieldsetElement>;
             "gcds-footer": LocalJSX.GcdsFooter & JSXBase.HTMLAttributes<HTMLGcdsFooterElement>;
             "gcds-grid": LocalJSX.GcdsGrid & JSXBase.HTMLAttributes<HTMLGcdsGridElement>;
             "gcds-header": LocalJSX.GcdsHeader & JSXBase.HTMLAttributes<HTMLGcdsHeaderElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -156,7 +156,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * Error message for an invalid input element.
+          * Error message for invalid form elements in group.
          */
         "errorMessage": string;
         /**
@@ -164,7 +164,7 @@ export namespace Components {
          */
         "fieldsetId": string;
         /**
-          * Hint displayed below the label.
+          * Hint displayed below the legend.
          */
         "hint": string;
         /**
@@ -782,7 +782,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * Error message for an invalid input element.
+          * Error message for invalid form elements in group.
          */
         "errorMessage"?: string;
         /**
@@ -790,7 +790,7 @@ declare namespace LocalJSX {
          */
         "fieldsetId": string;
         /**
-          * Hint displayed below the label.
+          * Hint displayed below the legend.
          */
         "hint"?: string;
         /**

--- a/src/components/gcds-fieldset/gcds-fieldset.css
+++ b/src/components/gcds-fieldset/gcds-fieldset.css
@@ -1,0 +1,35 @@
+:host {
+  display: block;
+
+  fieldset {
+    border: none;
+    padding-top: 0;
+    color: var(--gcds-fieldset-default-text);
+
+    legend {
+      font-size: var(--gcds-font-sizes-paragraph);
+      font-weight: var(--gcds-font-weights-semibold);
+      color: inherit;
+      margin-bottom: var(--gcds-spacing-50);
+    }
+
+    &:focus-within {
+      color: var(--gcds-fieldset-focus);
+    }
+    &.gcds-error:not(:focus-within) {
+      color: var(--gcds-fieldset-destructive);
+    }
+    &:disabled {
+      color: var(--gcds-fieldset-disabled-text);
+    }
+  }
+
+  .required {
+    margin: 0 0 0 var(--gcds-spacing-100);
+  }
+
+  slot {
+    display: block;
+    margin: 0;
+  }
+}

--- a/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -45,7 +45,7 @@ export class GcdsFieldset {
   /**
    * Flag to disable fieldset and its contents
    */
-  @Prop({ reflect: true, mutable: false }) disabled: boolean;
+  @Prop({ reflect: true, mutable: true }) disabled: boolean;
 
   @Watch('disabled')
   validateDisabledFieldset() {

--- a/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -1,0 +1,105 @@
+import { Component, Prop, Element, Host, Watch, h } from '@stencil/core';
+import { assignLanguage } from '../../utils/utils';
+
+@Component({
+  tag: 'gcds-fieldset',
+  styleUrl: 'gcds-fieldset.css',
+  shadow: true,
+})
+export class GcdsFieldset {
+
+  private lang: string;
+
+  @Element() el: HTMLElement;
+
+  /**
+   * The unique identifier for the component
+   */
+  @Prop({ reflect: true, mutable: false }) fieldsetId!: string;
+  /**
+   * The title for the contents of the fieldset
+   */
+  @Prop({ reflect: true, mutable: false }) legend!: string;
+
+  /**
+   * Flag the contents are required
+   */
+  @Prop({ reflect: true, mutable: false }) required: boolean;
+  /**
+   * Error message for an invalid input element.
+   */
+  @Prop({ reflect: true, mutable: true }) errorMessage: string;
+
+  @Watch('errorMessage')
+  validateErrorFieldset() {
+    if (this.disabled) {
+      this.errorMessage = "";
+    }
+  }
+
+  /**
+    * Hint displayed below the label.
+    */
+  @Prop({ reflect: true, mutable: false }) hint: string;
+
+  /**
+   * Flag to disable fieldset and its contents
+   */
+  @Prop({ reflect: true, mutable: false }) disabled: boolean;
+
+  @Watch('disabled')
+  validateDisabledFieldset() {
+    if (this.required) {
+      this.disabled = false;
+    }
+  }
+
+  async componentWillLoad() {
+    // Define lang attribute
+    this.lang = assignLanguage(this.el);
+
+    this.validateDisabledFieldset();
+    this.validateErrorFieldset();
+
+    if (this.disabled) {
+      for (var i = 0; i < this.el.children.length; i++) {
+        this.el.children[i].setAttribute("disabled", "");
+      }
+    }
+  }
+
+  render() {
+    const { lang, fieldsetId, legend, required, errorMessage, hint, disabled } = this;
+
+    const fieldsetAttrs = {
+      disabled
+    }
+
+    const requiredText = lang == "en" ? "required" : "obligatoire";
+    return (
+      <Host>
+        <fieldset
+          class={errorMessage ? "gcds-error" : null}
+          id={fieldsetId}
+          {...fieldsetAttrs}
+          aria-labelledby={hint ? `legend-${fieldsetId} hint-${fieldsetId}` : `legend-${fieldsetId}`}
+        >
+          <legend
+            id={`legend-${fieldsetId}`}
+          >
+            {legend}
+            {required ?
+                <strong class="required">({requiredText})</strong>
+              :
+                null
+            }
+          </legend>
+          {hint ? <gcds-hint hint={hint} hint-id={fieldsetId} />: null}
+          {errorMessage ? <gcds-error-message message-id={fieldsetId} message={errorMessage} /> : null}
+          <slot></slot>
+        </fieldset>
+      </Host>
+    );
+  }
+
+}

--- a/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -26,7 +26,7 @@ export class GcdsFieldset {
    */
   @Prop({ reflect: true, mutable: false }) required: boolean;
   /**
-   * Error message for an invalid input element.
+   * Error message for invalid form elements in group.
    */
   @Prop({ reflect: true, mutable: true }) errorMessage: string;
 
@@ -38,7 +38,7 @@ export class GcdsFieldset {
   }
 
   /**
-    * Hint displayed below the label.
+    * Hint displayed below the legend.
     */
   @Prop({ reflect: true, mutable: false }) hint: string;
 
@@ -52,6 +52,19 @@ export class GcdsFieldset {
     if (this.required) {
       this.disabled = false;
     }
+    if (this.disabled == true) {
+      for (var i = 0; i < this.el.children.length; i++) {
+        this.el.children[i].setAttribute("disabled", "");
+      }
+    }
+  }
+  @Watch('disabled')
+  handleDisabledChange(newValue: boolean, _oldValue: boolean) {
+    if (_oldValue && newValue != _oldValue) {
+      for (var i = 0; i < this.el.children.length; i++) {
+        this.el.children[i].removeAttribute("disabled");
+      }
+    }
   }
 
   async componentWillLoad() {
@@ -60,12 +73,6 @@ export class GcdsFieldset {
 
     this.validateDisabledFieldset();
     this.validateErrorFieldset();
-
-    if (this.disabled) {
-      for (var i = 0; i < this.el.children.length; i++) {
-        this.el.children[i].setAttribute("disabled", "");
-      }
-    }
   }
 
   render() {
@@ -94,7 +101,7 @@ export class GcdsFieldset {
                 null
             }
           </legend>
-          {hint ? <gcds-hint hint={hint} hint-id={fieldsetId} />: null}
+          {hint ? <gcds-hint hint={hint} hint-id={fieldsetId} /> : null}
           {errorMessage ? <gcds-error-message message-id={fieldsetId} message={errorMessage} /> : null}
           <slot></slot>
         </fieldset>

--- a/src/components/gcds-fieldset/test/gcds-fieldset.e2e.ts
+++ b/src/components/gcds-fieldset/test/gcds-fieldset.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('gcds-fieldset', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<gcds-fieldset></gcds-fieldset>');
+
+    const element = await page.find('gcds-fieldset');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/gcds-fieldset/test/gcds-fieldset.e2e.ts
+++ b/src/components/gcds-fieldset/test/gcds-fieldset.e2e.ts
@@ -8,4 +8,21 @@ describe('gcds-fieldset', () => {
     const element = await page.find('gcds-fieldset');
     expect(element).toHaveClass('hydrated');
   });
+  it('disable passed inputs', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+    <gcds-fieldset
+      legend="Fieldset legend"
+      fieldset-id="field"
+      disabled
+    >
+      <gcds-radio label="Choice 1" name="radio" radio-id="choice1"></gcds-radio>
+      <gcds-radio label="Choice 2" name="radio" radio-id="choice2"></gcds-radio>
+    </gcds-fieldset>
+    `);
+
+    const element = await page.find('gcds-fieldset');
+    const elementChild = await element.find('gcds-radio')
+    expect(elementChild).toHaveAttribute('disabled');
+  });
 });

--- a/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
+++ b/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GcdsFieldset } from '../gcds-fieldset';
+
+describe('gcds-fieldset', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [GcdsFieldset],
+      html: `<gcds-fieldset></gcds-fieldset>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-fieldset>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </gcds-fieldset>
+    `);
+  });
+});

--- a/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
+++ b/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
@@ -5,13 +5,99 @@ describe('gcds-fieldset', () => {
   it('renders', async () => {
     const page = await newSpecPage({
       components: [GcdsFieldset],
-      html: `<gcds-fieldset></gcds-fieldset>`,
+      html: `<gcds-fieldset fieldset-id="field" legend="Fieldset legend"></gcds-fieldset>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-fieldset>
+      <gcds-fieldset fieldset-id="field" legend="Fieldset legend">
         <mock:shadow-root>
-          <slot></slot>
+          <fieldset aria-labelledby="legend-field" id="field">
+            <legend id="legend-field">
+              Fieldset legend
+            </legend>
+            <slot></slot>
+          </fieldset>
         </mock:shadow-root>
+      </gcds-fieldset>
+    `);
+  });
+  it('renders - required', async () => {
+    const page = await newSpecPage({
+      components: [GcdsFieldset],
+      html: `<gcds-fieldset fieldset-id="field" legend="Fieldset legend" required></gcds-fieldset>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-fieldset fieldset-id="field" legend="Fieldset legend" required>
+        <mock:shadow-root>
+          <fieldset aria-labelledby="legend-field" id="field">
+            <legend id="legend-field">
+              Fieldset legend
+              <strong class="required">
+                (required)
+              </strong>
+            </legend>
+            <slot></slot>
+          </fieldset>
+        </mock:shadow-root>
+      </gcds-fieldset>
+    `);
+  });
+  it('renders - hint', async () => {
+    const page = await newSpecPage({
+      components: [GcdsFieldset],
+      html: `<gcds-fieldset fieldset-id="field" legend="Fieldset legend" hint="Fieldset hint"></gcds-fieldset>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-fieldset fieldset-id="field" legend="Fieldset legend" hint="Fieldset hint">
+        <mock:shadow-root>
+          <fieldset aria-labelledby="legend-field hint-field" id="field">
+            <legend id="legend-field">
+              Fieldset legend
+            </legend>
+            <gcds-hint hint="Fieldset hint" hint-id="field"></gcds-hint>
+            <slot></slot>
+          </fieldset>
+        </mock:shadow-root>
+      </gcds-fieldset>
+    `);
+  });
+  it('renders - error message', async () => {
+    const page = await newSpecPage({
+      components: [GcdsFieldset],
+      html: `<gcds-fieldset fieldset-id="field" legend="Fieldset legend" error-message="Fieldset error"></gcds-fieldset>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-fieldset fieldset-id="field" legend="Fieldset legend" error-message="Fieldset error">
+        <mock:shadow-root>
+          <fieldset aria-labelledby="legend-field" class="gcds-error" id="field">
+            <legend id="legend-field">
+              Fieldset legend
+            </legend>
+            <gcds-error-message message="Fieldset error" message-id="field"></gcds-error-message>
+            <slot></slot>
+          </fieldset>
+        </mock:shadow-root>
+      </gcds-fieldset>
+    `);
+  });
+  it('renders - passed radio button', async () => {
+    const page = await newSpecPage({
+      components: [GcdsFieldset],
+      html: `
+      <gcds-fieldset fieldset-id="field" legend="Fieldset legend">
+        <gcds-radio radio-id="radio" label="Radio button" name="radio"></gcds-radio>
+      </gcds-fieldset>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-fieldset fieldset-id="field" legend="Fieldset legend">
+        <mock:shadow-root>
+          <fieldset aria-labelledby="legend-field" id="field">
+            <legend id="legend-field">
+              Fieldset legend
+            </legend>
+            <slot></slot>
+          </fieldset>
+        </mock:shadow-root>
+        <gcds-radio label="Radio button" name="radio" radio-id="radio"></gcds-radio>
       </gcds-fieldset>
     `);
   });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,9 +1,8 @@
 /**
  * Do not edit directly
- * Generated on Tue, 02 Aug 2022 22:58:55 GMT
+ * Generated on Mon, 08 Aug 2022 19:27:38 GMT
  */
-
- :root {
+:root {
   --gcds-brand-default-text: #000000;
   --gcds-brand-focus: #303fc3;
   --gcds-brand-disabled-background: #f0f0f0;
@@ -57,7 +56,8 @@
   --gcds-spacing-800: 6.5rem;
   --gcds-spacing-900: 7.800000000000001rem;
   --gcds-spacing-1000: 9.1rem;
-  --gcds-base-font-size: 1.25; /* Sets base font size to 20px */
+  --gcds-base-font-size: 1.25;
+  /* Sets base font size to 20px */
   --gcds-base-line-height: 1.3;
   --gcds-base-scale: 1.125;
   --gcds-font-families-heading: Lato;
@@ -115,6 +115,10 @@
   --gcds-error-message-background: #f3e9e8;
   --gcds-error-message-border: #d3080c;
   --gcds-error-message-text: #000000;
+  --gcds-fieldset-default-text: #000000;
+  --gcds-fieldset-destructive: #d3080c;
+  --gcds-fieldset-disabled-text: #707070;
+  --gcds-fieldset-focus: #303fc3;
   --gcds-footer-brand-background: #f8f8f8;
   --gcds-footer-brand-text: #000000;
   --gcds-footer-landscape-background: #26374a;


### PR DESCRIPTION
# Summary | Résumé

Fieldset component for grouping form fields.

``` html
<gcds-fieldset
  fieldset-id="string"
  legend="string"
  required="boolean"
  disabled="boolean"
  hint="string"
  error-message="string"
>
  <Slot />
</gcds-fieldset>
```

## Using the fieldset

### Children elements

Pass form elements as children to the `gcds-fieldset` to be grouped together.

### Disabled

Disabling the fieldset will disable all children elements passed to the `gcds-fieldset`. 

### Error handling

Error styles currently only apply to fieldset and legend. Will expand with validators.