### PR TITLE
Required field validators

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,6 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { Validator, ValidatorEntry } from "./validators";
 export namespace Components {
     interface GcdsBanner {
         /**
@@ -303,6 +304,14 @@ export namespace Components {
           * Set Input types
          */
         "type": 'email' | 'number' | 'password' | 'search' | 'text' | 'url';
+        /**
+          * Set event to call validator
+         */
+        "validateOn": 'blur' | 'submit';
+        /**
+          * Array of validators to run
+         */
+        "validator": Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Default value for an input element.
          */
@@ -941,6 +950,14 @@ declare namespace LocalJSX {
           * Set Input types
          */
         "type"?: 'email' | 'number' | 'password' | 'search' | 'text' | 'url';
+        /**
+          * Set event to call validator
+         */
+        "validateOn"?: 'blur' | 'submit';
+        /**
+          * Array of validators to run
+         */
+        "validator"?: Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Default value for an input element.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -305,11 +305,15 @@ export namespace Components {
          */
         "type": 'email' | 'number' | 'password' | 'search' | 'text' | 'url';
         /**
+          * Call any active validators
+         */
+        "validate": () => Promise<void>;
+        /**
           * Set event to call validator
          */
-        "validateOn": 'blur' | 'submit';
+        "validateOn": 'blur' | 'submit' | 'other';
         /**
-          * Array of validators to run
+          * Array of validators
          */
         "validator": Array<string | ValidatorEntry | Validator<string>>;
         /**
@@ -490,6 +494,18 @@ export namespace Components {
           * Id + name attribute for a textarea element.
          */
         "textareaId": string;
+        /**
+          * Call any active validators
+         */
+        "validate": () => Promise<void>;
+        /**
+          * Set event to call validator
+         */
+        "validateOn": 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator": Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Default value for an input element.
          */
@@ -953,9 +969,9 @@ declare namespace LocalJSX {
         /**
           * Set event to call validator
          */
-        "validateOn"?: 'blur' | 'submit';
+        "validateOn"?: 'blur' | 'submit' | 'other';
         /**
-          * Array of validators to run
+          * Array of validators
          */
         "validator"?: Array<string | ValidatorEntry | Validator<string>>;
         /**
@@ -1156,6 +1172,14 @@ declare namespace LocalJSX {
           * Id + name attribute for a textarea element.
          */
         "textareaId"?: string;
+        /**
+          * Set event to call validator
+         */
+        "validateOn"?: 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator"?: Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Default value for an input element.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -117,10 +117,6 @@ export namespace Components {
          */
         "errorMessage": string;
         /**
-          * Specifies if the input is invalid.
-         */
-        "hasError": boolean;
-        /**
           * Hint displayed below the label.
          */
         "hint": string;
@@ -378,10 +374,6 @@ export namespace Components {
           * Specifies if an input element is disabled or not.
          */
         "disabled": boolean;
-        /**
-          * Specifies if the input is invalid.
-         */
-        "hasError": boolean;
         /**
           * Hint displayed below the label.
          */
@@ -791,10 +783,6 @@ declare namespace LocalJSX {
          */
         "errorMessage"?: string;
         /**
-          * Specifies if the input is invalid.
-         */
-        "hasError"?: boolean;
-        /**
           * Hint displayed below the label.
          */
         "hint"?: string;
@@ -866,6 +854,14 @@ declare namespace LocalJSX {
           * The title for the contents of the fieldset
          */
         "legend": string;
+        /**
+          * Emitted when the fieldset has a validation error.
+         */
+        "onGcdsGroupError"?: (event: CustomEvent<string>) => void;
+        /**
+          * Emitted when the fieldset has a validation error.
+         */
+        "onGcdsGroupErrorClear"?: (event: CustomEvent<void>) => void;
         /**
           * Flag the contents are required
          */
@@ -1064,10 +1060,6 @@ declare namespace LocalJSX {
           * Specifies if an input element is disabled or not.
          */
         "disabled"?: boolean;
-        /**
-          * Specifies if the input is invalid.
-         */
-        "hasError"?: boolean;
         /**
           * Hint displayed below the label.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -211,10 +211,6 @@ export namespace Components {
          */
         "errorMessage": string;
         /**
-          * Specifies if the file uploader is invalid.
-         */
-        "hasError": boolean;
-        /**
           * Hint displayed below the label.
          */
         "hint": string;
@@ -234,6 +230,18 @@ export namespace Components {
           * Id attribute for a file uploader element.
          */
         "uploaderId": string;
+        /**
+          * Call any active validators
+         */
+        "validate": () => Promise<void>;
+        /**
+          * Set event to call validator
+         */
+        "validateOn": 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator": Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Value for a file uploader element.
          */
@@ -988,10 +996,6 @@ declare namespace LocalJSX {
          */
         "errorMessage"?: string;
         /**
-          * Specifies if the file uploader is invalid.
-         */
-        "hasError"?: boolean;
-        /**
           * Hint displayed below the label.
          */
         "hint"?: string;
@@ -1027,6 +1031,14 @@ declare namespace LocalJSX {
           * Id attribute for a file uploader element.
          */
         "uploaderId": string;
+        /**
+          * Set event to call validator
+         */
+        "validateOn"?: 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator"?: Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Value for a file uploader element.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -137,6 +137,18 @@ export namespace Components {
          */
         "required": boolean;
         /**
+          * Call any active validators
+         */
+        "validate": () => Promise<void>;
+        /**
+          * Set event to call validator
+         */
+        "validateOn": 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator": Array<string | ValidatorEntry | Validator<string>>;
+        /**
           * Value for an input element.
          */
         "value": string;
@@ -176,6 +188,18 @@ export namespace Components {
           * Flag the contents are required
          */
         "required": boolean;
+        /**
+          * Call any active validators
+         */
+        "validate": () => Promise<void>;
+        /**
+          * Set event to call validator
+         */
+        "validateOn": 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator": Array<string | ValidatorEntry | Validator<string>>;
     }
     interface GcdsFooter {
         /**
@@ -783,9 +807,29 @@ declare namespace LocalJSX {
          */
         "name": string;
         /**
+          * Emitted when the checkbox loses focus.
+         */
+        "onGcdsBlur"?: (event: CustomEvent<void>) => void;
+        /**
+          * Update value based on user input.
+         */
+        "onGcdsChange"?: (event: CustomEvent<any>) => void;
+        /**
+          * Emitted when the checkbox has focus.
+         */
+        "onGcdsFocus"?: (event: CustomEvent<void>) => void;
+        /**
           * Specifies if a form field is required or not.
          */
         "required"?: boolean;
+        /**
+          * Set event to call validator
+         */
+        "validateOn"?: 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator"?: Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Value for an input element.
          */
@@ -826,6 +870,14 @@ declare namespace LocalJSX {
           * Flag the contents are required
          */
         "required"?: boolean;
+        /**
+          * Set event to call validator
+         */
+        "validateOn"?: 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator"?: Array<string | ValidatorEntry | Validator<string>>;
     }
     interface GcdsFooter {
         /**
@@ -1028,6 +1080,14 @@ declare namespace LocalJSX {
           * Name attribute for an input element.
          */
         "name": string;
+        /**
+          * Emitted when the radio loses focus.
+         */
+        "onGcdsBlur"?: (event: CustomEvent<void>) => void;
+        /**
+          * Emitted when the radio has focus.
+         */
+        "onGcdsFocus"?: (event: CustomEvent<void>) => void;
         /**
           * Emitted when the radio button is checked
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -473,10 +473,6 @@ export namespace Components {
          */
         "errorMessage": string;
         /**
-          * Specifies if the select is invalid.
-         */
-        "hasError": boolean;
-        /**
           * Hint displayed below the label.
          */
         "hint": string;
@@ -492,6 +488,18 @@ export namespace Components {
           * Id attribute for a select element.
          */
         "selectId": string;
+        /**
+          * Call any active validators
+         */
+        "validate": () => Promise<void>;
+        /**
+          * Set event to call validator
+         */
+        "validateOn": 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator": Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Value for a select element.
          */
@@ -1278,10 +1286,6 @@ declare namespace LocalJSX {
          */
         "errorMessage"?: string;
         /**
-          * Specifies if the select is invalid.
-         */
-        "hasError"?: boolean;
-        /**
           * Hint displayed below the label.
          */
         "hint"?: string;
@@ -1289,6 +1293,14 @@ declare namespace LocalJSX {
           * Form field label.
          */
         "label": string;
+        /**
+          * Emitted when the select loses focus.
+         */
+        "onGcdsBlur"?: (event: CustomEvent<void>) => void;
+        /**
+          * Emitted when the select has focus.
+         */
+        "onGcdsFocus"?: (event: CustomEvent<void>) => void;
         /**
           * Update value based on user selection.
          */
@@ -1301,6 +1313,14 @@ declare namespace LocalJSX {
           * Id attribute for a select element.
          */
         "selectId": string;
+        /**
+          * Set event to call validator
+         */
+        "validateOn"?: 'blur' | 'submit' | 'other';
+        /**
+          * Array of validators
+         */
+        "validator"?: Array<string | ValidatorEntry | Validator<string>>;
         /**
           * Value for a select element.
          */

--- a/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -14,7 +14,7 @@ export class GcdsCheckbox {
 
   private lang: string;
 
-  _validator: Validator<string> = defaultValidator;
+  _validator: Validator<any> = defaultValidator;
 
   /**
    * Id attribute for an input element.
@@ -162,8 +162,7 @@ export class GcdsCheckbox {
    */
   @Method()
   async validate() {
-    let isChecked = this.checked ? "true" : "false";
-    if (!this._validator.validate(isChecked) && this._validator.errorMessage) {
+    if (!this._validator.validate(this.checked) && this._validator.errorMessage) {
       this.errorMessage = this._validator.errorMessage[this.lang];
     } else {
       this.errorMessage = "";

--- a/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -119,7 +119,7 @@ export class GcdsCheckbox {
   @State() parentError: string;
 
   /**
-   * Specifies if the input is invalid.
+   * Specifies if the checkbox is invalid.
    */
   @State() hasError: boolean;
   @Watch('hasError')

--- a/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -177,6 +177,7 @@ export class GcdsCheckbox {
     this.validateDisabledCheckbox();
     this.validateHasError();
     this.validateErrorMessage();
+    this.validateValidator();
 
     // Assign required validator if needed
     requiredValidator(this.el, "checkbox");

--- a/src/components/gcds-checkbox/test/gcds-checkbox.e2e.ts
+++ b/src/components/gcds-checkbox/test/gcds-checkbox.e2e.ts
@@ -23,7 +23,7 @@ describe('gcds-checkbox', () => {
   it('aria-invalid', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<gcds-checkbox label="Label" checkbox-id="aria-invalid" has-error />');
+    await page.setContent('<gcds-checkbox label="Label" checkbox-id="aria-invalid" error-message="Has error" />');
     const element = await (await page.find('gcds-checkbox input'));
     expect(element.getAttribute('aria-invalid')).toEqual('true');
   });

--- a/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
+++ b/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
@@ -53,7 +53,7 @@ describe('gcds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <gcds-checkbox checkbox-id="checkbox" hint="this is a hint" label="checkbox" name="checkbox">
         <div class="gcds-checkbox-wrapper">
-           <input aria-describedby="hint-checkbox " id="checkbox" name="checkbox" type="checkbox">
+           <input aria-describedby="hint-checkbox  " id="checkbox" name="checkbox" type="checkbox">
            <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
            <gcds-hint hint="this is a hint" hint-id="checkbox"></gcds-hint>
          </div>
@@ -71,30 +71,11 @@ describe('gcds-checkbox', () => {
         ></gcds-checkbox>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-checkbox checkbox-id="checkbox" error-message="This needs to be checked" has-error="" label="checkbox" name="checkbox">
+      <gcds-checkbox checkbox-id="checkbox" error-message="This needs to be checked" label="checkbox" name="checkbox">
         <div class="gcds-checkbox-wrapper gcds-error">
-           <input aria-describedby=" error-message-checkbox" aria-invalid="true" id="checkbox" name="checkbox" type="checkbox">
+           <input aria-describedby=" error-message-checkbox " aria-invalid="true" id="checkbox" name="checkbox" type="checkbox">
            <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
            <gcds-error-message message="This needs to be checked" message-id="checkbox"></gcds-error-message>
-         </div>
-      </gcds-checkbox>
-    `);
-  });
-  it('renders w/ has-error', async () => {
-    const page = await newSpecPage({
-      components: [GcdsCheckbox],
-      html: `<gcds-checkbox
-          label="checkbox"
-          name="checkbox"
-          checkbox-id="checkbox"
-          has-error
-        ></gcds-checkbox>`,
-    });
-    expect(page.root).toEqualHtml(`
-      <gcds-checkbox checkbox-id="checkbox" has-error="" label="checkbox" name="checkbox">
-        <div class="gcds-checkbox-wrapper gcds-error">
-           <input aria-invalid="true" id="checkbox" name="checkbox" type="checkbox">
-           <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
          </div>
       </gcds-checkbox>
     `);

--- a/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -151,6 +151,7 @@ export class GcdsFieldset {
 
     this.validateDisabledFieldset();
     this.validateErrorMessage();
+    this.validateValidator();
 
     // Assign required validator if needed
     requiredValidator(this.el, "fieldset");

--- a/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -13,7 +13,7 @@ export class GcdsFileUploader {
 
   private lang: string;
 
-  _validator: Validator<string> = defaultValidator;
+  _validator: Validator<any> = defaultValidator;
 
   /**
    * Id attribute for a file uploader element.
@@ -172,7 +172,7 @@ export class GcdsFileUploader {
   */
   @Method()
   async validate() {
-    if (!this._validator.validate(this.uploaderId) && this._validator.errorMessage) {
+    if (!this._validator.validate(this.value.length) && this._validator.errorMessage) {
       this.errorMessage = this._validator.errorMessage[this.lang];
     } else {
       this.errorMessage = "";

--- a/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -58,7 +58,7 @@ describe('gcds-file-uploader', () => {
       html: `<gcds-file-uploader label="file-uploader" uploader-id="file-uploader" error-message="This is an error message."></gcds-file-uploader>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-file-uploader uploader-id="file-uploader" label="file-uploader" error-message="This is an error message." has-error="">
+      <gcds-file-uploader uploader-id="file-uploader" label="file-uploader" error-message="This is an error message.">
         <div class="gcds-file-uploader-wrapper gcds-error">
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <gcds-error-message message="This is an error message." message-id="file-uploader"></gcds-error-message>

--- a/src/components/gcds-input/gcds-input.tsx
+++ b/src/components/gcds-input/gcds-input.tsx
@@ -86,7 +86,7 @@ export class GcdsInput {
   /**
    * Set event to call validator
    */
-  @Prop({ mutable: true }) validateOn: 'blur' | 'submit' | 'other' = 'blur';
+  @Prop({ mutable: true }) validateOn: 'blur' | 'submit' | 'other';
 
   /**
   * Events

--- a/src/components/gcds-input/gcds-input.tsx
+++ b/src/components/gcds-input/gcds-input.tsx
@@ -75,7 +75,6 @@ export class GcdsInput {
    */
   @Prop({ mutable: true }) validator: Array<string | ValidatorEntry | Validator<string>>;
 
-
   @Watch('validator')
   validateValidator() {
     if (this.validator && !this.validateOn) {
@@ -142,6 +141,8 @@ export class GcdsInput {
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.validateValidator();
 
     // Assign required validator if needed
     requiredValidator(this.el, "input");

--- a/src/components/gcds-radio/gcds-radio.tsx
+++ b/src/components/gcds-radio/gcds-radio.tsx
@@ -174,7 +174,7 @@ export class GcdsRadio {
           >
           </gcds-label>
           {hint ? <gcds-hint hint={hint} hint-id={radioId} />: null}
-          {parentError ? <span id={`parent-error-${radioId}`} hidden>{parentError}</span> : null}
+          {parentError && <span id={`parent-error-${radioId}`} hidden>{parentError}</span>}
         </div>
       </Host>
     );

--- a/src/components/gcds-radio/gcds-radio.tsx
+++ b/src/components/gcds-radio/gcds-radio.tsx
@@ -63,6 +63,25 @@ export class GcdsRadio {
    */
   @Event() gcdsRadioChange!: EventEmitter<void>;
 
+  /**
+   * Emitted when the radio has focus.
+   */
+  @Event() gcdsFocus!: EventEmitter<void>;
+
+  private onFocus = () => {
+    this.gcdsFocus.emit();
+  }
+
+  /**
+  * Emitted when the radio loses focus.
+  */
+  @Event() gcdsBlur!: EventEmitter<void>;
+
+  private onBlur = () => {
+    this.gcdsBlur.emit();
+
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
@@ -110,6 +129,8 @@ export class GcdsRadio {
             type="radio"
             {...attrsInput}
             onChange={() => this.onChange(name)}
+            onBlur={this.onBlur}
+            onFocus={this.onFocus}
             ref={element => this.shadowElement = element as HTMLInputElement}
           />
           <gcds-label

--- a/src/components/gcds-radio/gcds-radio.tsx
+++ b/src/components/gcds-radio/gcds-radio.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, State, Prop, Listen, Host, h } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, State, Prop, Listen, Watch, Host, h } from '@stencil/core';
 import { assignLanguage, elementGroupCheck } from '../../utils/utils';
 
 @Component({
@@ -55,9 +55,15 @@ export class GcdsRadio {
   @Prop({ reflect: true, mutable: false }) hint: string;
 
   /**
-   * Specifies if the input is invalid.
+   * Specifies if the radio is invalid.
    */
    @State() hasError: boolean;
+   @Watch('hasError')
+   validateHasError() {
+     if (this.disabled) {
+       this.hasError = false;
+     }
+   }
    
   /**
    * State to handle when errors are passed down to component

--- a/src/components/gcds-radio/gcds-radio.tsx
+++ b/src/components/gcds-radio/gcds-radio.tsx
@@ -117,7 +117,7 @@ export class GcdsRadio {
   * Event listener for gcds-fieldset errors
   */
   @Listen('gcdsGroupError', { target: 'body'})
-  gcdsgroupError(e) {
+  gcdsGroupError(e) {
     if (e.srcElement.contains(this.el) && elementGroupCheck(this.name)) {
       this.hasError = true;
       this.parentError = e.detail;
@@ -127,7 +127,7 @@ export class GcdsRadio {
     }
   }
   @Listen('gcdsGroupErrorClear', { target: 'body'})
-  gcdsgroupErrorClear(e) {
+  gcdsGroupErrorClear(e) {
     if (e.srcElement.contains(this.el) && this.hasError) {
       this.hasError = false;
       this.parentError = "";

--- a/src/components/gcds-radio/test/gcds-radio.e2e.ts
+++ b/src/components/gcds-radio/test/gcds-radio.e2e.ts
@@ -18,17 +18,6 @@ describe('gcds-radio', () => {
 
  describe('gcds-radio a11y tests', () => {
   /**
-   * Aria-invalid true if error test
-   */
-  it('aria-invalid', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<gcds-radio label="Label" radio-id="aria-invalid" has-error />');
-    const element = await (await page.find('gcds-radio input'));
-    expect(element.getAttribute('aria-invalid')).toEqual('true');
-  });
-
-  /**
    * Colour contrast test
    */
   it('colour contrast', async () => {

--- a/src/components/gcds-radio/test/gcds-radio.spec.tsx
+++ b/src/components/gcds-radio/test/gcds-radio.spec.tsx
@@ -53,28 +53,9 @@ describe('gcds-radio', () => {
     expect(page.root).toEqualHtml(`
       <gcds-radio radio-id="radio" hint="this is a hint" label="radio" name="radio">
         <div class="gcds-radio-wrapper">
-           <input aria-describedby="hint-radio" id="radio" name="radio" type="radio">
+           <input aria-describedby="hint-radio " id="radio" name="radio" type="radio">
            <gcds-label label="radio" label-for="radio" lang="en"></gcds-label>
            <gcds-hint hint="this is a hint" hint-id="radio"></gcds-hint>
-         </div>
-      </gcds-radio>
-    `);
-  });
-  it('renders w/ has-error', async () => {
-    const page = await newSpecPage({
-      components: [GcdsRadio],
-      html: `<gcds-radio
-          label="radio"
-          name="radio"
-          radio-id="radio"
-          has-error
-        ></gcds-radio>`,
-    });
-    expect(page.root).toEqualHtml(`
-      <gcds-radio radio-id="radio" has-error="" label="radio" name="radio">
-        <div class="gcds-radio-wrapper gcds-error">
-           <input aria-invalid="true" id="radio" name="radio" type="radio">
-           <gcds-label label="radio" label-for="radio" lang="en"></gcds-label>
          </div>
       </gcds-radio>
     `);

--- a/src/components/gcds-select/gcds-select.tsx
+++ b/src/components/gcds-select/gcds-select.tsx
@@ -155,6 +155,7 @@ export class GcdsSelect {
     this.validateDisabledSelect();
     this.validateHasError();
     this.validateErrorMessage();
+    this.validateValidator();
 
     // Assign required validator if needed
     requiredValidator(this.el, "select");

--- a/src/components/gcds-select/gcds-select.tsx
+++ b/src/components/gcds-select/gcds-select.tsx
@@ -1,5 +1,6 @@
-import { Component, Element, Event, EventEmitter, Prop, Watch, Host, h } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Prop, Watch, State, Method, Host, h } from '@stencil/core';
 import { assignLanguage } from '../../utils/utils';
+import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 
 @Component({
   tag: 'gcds-select',
@@ -11,6 +12,8 @@ export class GcdsSelect {
   @Element() el: HTMLElement;
 
   private lang: string;
+
+  _validator: Validator<string> = defaultValidator;
 
   /**
    * Id attribute for a select element.
@@ -50,17 +53,6 @@ export class GcdsSelect {
   @Prop({ mutable: true }) value: string;
 
   /**
-   * Specifies if the select is invalid.
-   */
-  @Prop({ reflect: true, mutable: true }) hasError: boolean;
-  @Watch('hasError')
-  validateHasError() {
-    if (this.disabled) {
-      this.hasError = false;
-    }
-  }
-
-  /**
    * Error message for an invalid select element.
    */
   @Prop({ reflect: true, mutable: true }) errorMessage: string;
@@ -70,6 +62,8 @@ export class GcdsSelect {
       this.errorMessage = "";
     } else if (!this.hasError && this.errorMessage) {
       this.hasError = true;
+    } else if (this.errorMessage == "") {
+      this.hasError = false;
     }
   }
 
@@ -79,9 +73,73 @@ export class GcdsSelect {
   @Prop({ reflect: true, mutable: false }) hint: string;
 
   /**
+   * Array of validators
+   */
+  @Prop({ mutable: true }) validator: Array<string | ValidatorEntry | Validator<string>>;
+
+
+  @Watch('validator')
+  validateValidator() {
+    if (this.validator && !this.validateOn) {
+      this.validateOn = "blur";
+    }
+  }
+
+  /**
+  * Set event to call validator
+  */
+  @Prop({ mutable: true }) validateOn: 'blur' | 'submit' | 'other';
+
+  /**
+   * Specifies if the select is invalid.
+   */
+  @State() hasError: boolean;
+  @Watch('hasError')
+  validateHasError() {
+    if (this.disabled) {
+      this.hasError = false;
+    }
+  }
+
+  /**
     * Update value based on user selection.
     */
   @Event() gcdsSelectChange: EventEmitter;
+
+  /**
+  * Emitted when the select has focus.
+  */
+  @Event() gcdsFocus!: EventEmitter<void>;
+
+  private onFocus = () => {
+    this.gcdsFocus.emit();
+  }
+
+  /**
+   * Emitted when the select loses focus.
+   */
+  @Event() gcdsBlur!: EventEmitter<void>;
+
+  private onBlur = () => {
+    if (this.validateOn == "blur") {
+      this.validate();
+    }
+
+    this.gcdsBlur.emit();
+
+  }
+
+  /**
+   * Call any active validators
+   */
+  @Method()
+  async validate() {
+    if (!this._validator.validate(this.value) && this._validator.errorMessage) {
+      this.errorMessage = this._validator.errorMessage[this.lang];
+    } else {
+      this.errorMessage = "";
+    }
+  }
 
   handleChange = (e) => {
     let val = e.target && e.target.value;
@@ -97,6 +155,19 @@ export class GcdsSelect {
     this.validateDisabledSelect();
     this.validateHasError();
     this.validateErrorMessage();
+
+    // Assign required validator if needed
+    requiredValidator(this.el, "select");
+
+    if (this.validator) {
+      this._validator = getValidator(this.validator);
+    }
+  }
+
+  componentWillUpdate() {
+    if (this.validator) {
+      this._validator = getValidator(this.validator);
+    }
   }
 
   render() {
@@ -139,6 +210,8 @@ export class GcdsSelect {
             {...attrsInput}
             id={selectId}
             name={selectId}
+            onBlur={this.onBlur}
+            onFocus={this.onFocus}
             onChange={(e) => this.handleChange(e)}
             aria-invalid={hasError ? 'true' : 'false'}
           >

--- a/src/components/gcds-select/test/gcds-select.spec.tsx
+++ b/src/components/gcds-select/test/gcds-select.spec.tsx
@@ -46,7 +46,7 @@ describe('gcds-select', () => {
       html: `<gcds-select label="select" select-id="select" error-message="This is an error message."></gcds-select>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-select select-id="select" label="select" has-error="" error-message="This is an error message.">
+      <gcds-select select-id="select" label="select" error-message="This is an error message.">
         <div class="gcds-select-wrapper gcds-error">
           <gcds-label label="select" label-for="select" lang="en"></gcds-label>
           <gcds-error-message message="This is an error message." message-id="select"></gcds-error-message>

--- a/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/src/components/gcds-textarea/gcds-textarea.tsx
@@ -89,7 +89,7 @@ export class GcdsTextarea {
   /**
    * Set event to call validator
    */
-  @Prop({ mutable: true }) validateOn: 'blur' | 'submit' | 'other' = 'blur';
+  @Prop({ mutable: true }) validateOn: 'blur' | 'submit' | 'other';
 
   /**
   * Events

--- a/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/src/components/gcds-textarea/gcds-textarea.tsx
@@ -145,8 +145,11 @@ export class GcdsTextarea {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
 
+    this.validateValidator();
+
     // Assign required validator if needed
-    requiredValidator(this.el, "input");
+    requiredValidator(this.el, "textarea");
+
 
     if (this.validator) {
       this._validator = getValidator(this.validator);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -34,3 +34,14 @@ export const assignLanguage = (el: HTMLElement) => {
 
   return lang;
 }
+ // For validation - check if element has a checked checkbox/radio sibling
+export const elementGroupCheck = (name) => {
+  let hasCheck = false;
+  const element = document.querySelectorAll<HTMLFormElement>(`input[name=${name}]`);
+  for (var i = 0; i < element.length; i++) {
+    if (element[i].checked) {
+      hasCheck = true;
+    }
+  }
+  return !hasCheck;
+}

--- a/src/validators/checkbox-validators/checkbox-validators.ts
+++ b/src/validators/checkbox-validators/checkbox-validators.ts
@@ -1,0 +1,8 @@
+import { Validator } from "../validator";
+
+export const requiredCheck: Validator<string> = {
+    validate: (value: string) => {
+        return value != null && value == "true" ? true : false;
+    },
+    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+}

--- a/src/validators/checkbox-validators/checkbox-validators.ts
+++ b/src/validators/checkbox-validators/checkbox-validators.ts
@@ -4,5 +4,5 @@ export const requiredCheck: Validator<string> = {
     validate: (value: string) => {
         return value != null && value == "true" ? true : false;
     },
-    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+    errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }

--- a/src/validators/checkbox-validators/checkbox-validators.ts
+++ b/src/validators/checkbox-validators/checkbox-validators.ts
@@ -1,8 +1,8 @@
 import { Validator } from "../validator";
 
-export const requiredCheck: Validator<string> = {
-    validate: (value: string) => {
-        return value != null && value == "true" ? true : false;
+export const requiredCheck: Validator<boolean> = {
+    validate: (value: boolean) => {
+        return value ? true : false;
     },
     errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }

--- a/src/validators/checkbox-validators/checkbox-validators.ts
+++ b/src/validators/checkbox-validators/checkbox-validators.ts
@@ -2,7 +2,7 @@ import { Validator } from "../validator";
 
 export const requiredCheck: Validator<boolean> = {
     validate: (value: boolean) => {
-        return value ? true : false;
+        return value;
     },
     errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }

--- a/src/validators/checkbox-validators/test/checkbox-validators.spec.tsx
+++ b/src/validators/checkbox-validators/test/checkbox-validators.spec.tsx
@@ -1,0 +1,13 @@
+import { requiredCheck } from "../checkbox-validators";
+
+describe('Required checkbox validator', () => {
+    let results: Array<{value: boolean, res: boolean}> = [
+        {value: true, res: true},
+        {value: false, res: false},
+    ];
+    results.forEach(i => 
+        it(`Should return ${i.res} for ${i.value}`, () => {
+            expect(requiredCheck.validate(i.value)).toEqual(i.res);
+        })
+    );
+});

--- a/src/validators/fieldset-validators/fieldset-validators.ts
+++ b/src/validators/fieldset-validators/fieldset-validators.ts
@@ -9,7 +9,7 @@ export const requiredFieldset: Validator<string> = {
 
         return isValid.includes(false) ? false : true;
     },
-    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+    errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }
 
 export function validateFieldsetElements(element, nodeList) {

--- a/src/validators/fieldset-validators/fieldset-validators.ts
+++ b/src/validators/fieldset-validators/fieldset-validators.ts
@@ -1,0 +1,70 @@
+import { Validator } from "../validator";
+
+export const requiredFieldset: Validator<string> = {
+    validate: (id: string) => {
+        const el = document.querySelector(`gcds-fieldset[fieldset-id=${id}]`);
+        const elChildren = el.children;
+
+        let isValid = validateFieldsetElements(el, elChildren);
+
+        return isValid.includes(false) ? false : true;
+    },
+    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+}
+
+function validateFieldsetElements(element, nodeList) {
+    let isValid = [];
+
+    for (var i = 0; i < nodeList.length; i++) {
+        switch(nodeList[i].nodeName) {
+            case('GCDS-FIELDSET'):
+                let validfieldsetChildren = validateFieldsetElements(nodeList[i], nodeList[i].children);
+                for (var fc = 0; fc < validfieldsetChildren.length; fc++) {
+                    isValid.push(validfieldsetChildren[fc]);
+                }
+                break;
+            case('GCDS-CHECKBOX'):
+            case('GCDS-RADIO'):
+
+                // Radio/checkbox can share name property
+                let inputName = nodeList[i].getAttribute('name');
+                // Find all inputs with shared name
+                const sameNameInputs = element.querySelectorAll(`[name=${inputName}]`);
+                let childGroupValid = false;
+
+                // Check if there is more than one input with this name
+                if (sameNameInputs.length > 1) {
+                    // Validate as group
+                    for (var c = 0; c < sameNameInputs.length; c++) {
+                        if (sameNameInputs[c].hasAttribute("checked")) {
+                            childGroupValid = true;
+                        }
+                    }
+                    if (childGroupValid) {
+                        isValid.push(true);
+                    } else {
+                        isValid.push(false);
+                    }
+                } else {
+                    // Validate as single input
+                    if (nodeList[i].hasAttribute('checked')) {
+                        isValid.push(true);
+                    } else {
+                        isValid.push(false);
+                    }
+                }
+                break;
+            case('GCDS-INPUT'):
+            case('GCDS-TEXTAREA'):
+            case('GCDS-SELECT'):
+            if (nodeList[i].value.trim() != "") {
+                isValid.push(true);
+            } else {
+                isValid.push(false);
+            }
+                break;
+        }
+    }
+
+    return isValid;
+}

--- a/src/validators/fieldset-validators/fieldset-validators.ts
+++ b/src/validators/fieldset-validators/fieldset-validators.ts
@@ -7,7 +7,7 @@ export const requiredFieldset: Validator<string> = {
 
         let isValid = validateFieldsetElements(el, elChildren);
 
-        return isValid.includes(false) ? false : true;
+        return !isValid.includes(false);
     },
     errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }

--- a/src/validators/fieldset-validators/fieldset-validators.ts
+++ b/src/validators/fieldset-validators/fieldset-validators.ts
@@ -18,9 +18,9 @@ export function validateFieldsetElements(element, nodeList) {
     for (var i = 0; i < nodeList.length; i++) {
         switch(nodeList[i].nodeName) {
             case('GCDS-FIELDSET'):
-                let validfieldsetChildren = validateFieldsetElements(nodeList[i], nodeList[i].children);
-                for (var fc = 0; fc < validfieldsetChildren.length; fc++) {
-                    isValid.push(validfieldsetChildren[fc]);
+                let validFieldsetChildren = validateFieldsetElements(nodeList[i], nodeList[i].children);
+                for (var fc = 0; fc < validFieldsetChildren.length; fc++) {
+                    isValid.push(validFieldsetChildren[fc]);
                 }
                 break;
             case('GCDS-CHECKBOX'):

--- a/src/validators/fieldset-validators/fieldset-validators.ts
+++ b/src/validators/fieldset-validators/fieldset-validators.ts
@@ -12,7 +12,7 @@ export const requiredFieldset: Validator<string> = {
     errorMessage: { "en": "Error required",  "fr": "Error required french" }
 }
 
-function validateFieldsetElements(element, nodeList) {
+export function validateFieldsetElements(element, nodeList) {
     let isValid = [];
 
     for (var i = 0; i < nodeList.length; i++) {

--- a/src/validators/fieldset-validators/test/fieldset-validators.spec.tsx
+++ b/src/validators/fieldset-validators/test/fieldset-validators.spec.tsx
@@ -1,0 +1,149 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { requiredFieldset } from "../fieldset-validators";
+
+import { GcdsFieldset } from "../../../components/gcds-fieldset/gcds-fieldset";
+import { GcdsRadio } from "../../../components/gcds-radio/gcds-radio";
+import { GcdsCheckbox } from "../../../components/gcds-checkbox/gcds-checkbox";
+
+describe('gcds-fieldset invalid - Radio buttons', () => {
+    it('renders', async () => {
+      await newSpecPage({
+        components: [GcdsFieldset, GcdsRadio],
+        html: `
+        <gcds-fieldset
+            fieldset-id="test-fieldset"
+            legend="Fieldset legend"
+            required
+        >
+            <gcds-radio
+                label="radio 1"
+                name="radio"
+                radio-id="radio1"
+            ></gcds-radio>
+            <gcds-radio
+                label="radio 2"
+                name="radio"
+                radio-id="radio2"
+            ></gcds-radio>
+            <gcds-radio
+                label="radio 3"
+                name="radio"
+                radio-id="radio3"
+            ></gcds-radio>
+            <gcds-radio
+                label="radio 4"
+                name="radio"
+                radio-id="radio4"
+            ></gcds-radio>
+        </gcds-fieldset>`,
+      });
+      expect(requiredFieldset.validate("test-fieldset")).toEqual(false);
+    });
+});
+describe('gcds-fieldset valid - Radio buttons', () => {
+    it('renders', async () => {
+      await newSpecPage({
+        components: [GcdsFieldset, GcdsRadio],
+        html: `
+        <gcds-fieldset
+            fieldset-id="test-fieldset"
+            legend="Fieldset legend"
+            required
+        >
+            <gcds-radio
+                label="radio 1"
+                name="radio"
+                radio-id="radio1"
+            ></gcds-radio>
+            <gcds-radio
+                label="radio 2"
+                name="radio"
+                radio-id="radio2"
+            ></gcds-radio>
+            <gcds-radio
+                label="radio 3"
+                name="radio"
+                radio-id="radio3"
+                checked
+            ></gcds-radio>
+            <gcds-radio
+                label="radio 4"
+                name="radio"
+                radio-id="radio4"
+            ></gcds-radio>
+        </gcds-fieldset>`,
+      });
+      expect(requiredFieldset.validate("test-fieldset")).toEqual(true);
+    });
+});
+describe('gcds-fieldset invalid - Checkboxes', () => {
+    it('renders', async () => {
+      await newSpecPage({
+        components: [GcdsFieldset, GcdsCheckbox],
+        html: `
+        <gcds-fieldset
+            fieldset-id="test-fieldset"
+            legend="Fieldset legend"
+            required
+        >
+            <gcds-checkbox
+                checkbox-id="check1"
+                label="check 1"
+                name="check"
+            ></gcds-checkbox>
+            <gcds-checkbox
+                checkbox-id="check2"
+                label="check 2"
+                name="check"
+            ></gcds-checkbox>
+            <gcds-checkbox
+                checkbox-id="check3"
+                label="check 3"
+                name="check"
+            ></gcds-checkbox>
+            <gcds-checkbox
+                checkbox-id="check3"
+                label="check 3"
+                name="check"
+            ></gcds-checkbox>
+        </gcds-fieldset>`,
+      });
+      expect(requiredFieldset.validate("test-fieldset")).toEqual(false);
+    });
+});
+describe('gcds-fieldset valid - Checkboxes', () => {
+    it('renders', async () => {
+      await newSpecPage({
+        components: [GcdsFieldset, GcdsCheckbox],
+        html: `
+        <gcds-fieldset
+            fieldset-id="test-fieldset"
+            legend="Fieldset legend"
+            required
+        >
+            <gcds-checkbox
+                checkbox-id="check1"
+                label="check 1"
+                name="check"
+            ></gcds-checkbox>
+            <gcds-checkbox
+                checkbox-id="check2"
+                label="check 2"
+                name="check"
+                checked
+            ></gcds-checkbox>
+            <gcds-checkbox
+                checkbox-id="check3"
+                label="check 3"
+                name="check"
+            ></gcds-checkbox>
+            <gcds-checkbox
+                checkbox-id="check3"
+                label="check 3"
+                name="check"
+            ></gcds-checkbox>
+        </gcds-fieldset>`,
+      });
+      expect(requiredFieldset.validate("test-fieldset")).toEqual(true);
+    });
+});

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,0 +1,2 @@
+export * from './validator';
+export * from './validator.factory';

--- a/src/validators/input-validators/input-validators.ts
+++ b/src/validators/input-validators/input-validators.ts
@@ -1,0 +1,8 @@
+import { Validator } from "../validator";
+
+export const requiredInput: Validator<string> = {
+    validate: (value: string) => {
+        return value != null && value.trim() != "" ? true : false;
+    },
+    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+}

--- a/src/validators/input-validators/input-validators.ts
+++ b/src/validators/input-validators/input-validators.ts
@@ -1,6 +1,6 @@
 import { Validator } from "../validator";
 
-export const requiredInput: Validator<string> = {
+export const requiredField: Validator<string> = {
     validate: (value: string) => {
         return value != null && value.trim() != "" ? true : false;
     },

--- a/src/validators/input-validators/input-validators.ts
+++ b/src/validators/input-validators/input-validators.ts
@@ -6,3 +6,11 @@ export const requiredInput: Validator<string> = {
     },
     errorMessage: { "en": "Error required",  "fr": "Error required french" }
 }
+
+export const requiredFileInput: Validator<string> = {
+    validate: (id: string) => {
+        const el = document.querySelector<HTMLFormElement>(`#${id}`);
+        return el.value.length > 0 ? true : false;
+    },
+    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+}

--- a/src/validators/input-validators/input-validators.ts
+++ b/src/validators/input-validators/input-validators.ts
@@ -4,7 +4,7 @@ export const requiredInput: Validator<string> = {
     validate: (value: string) => {
         return value != null && value.trim() != "" ? true : false;
     },
-    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+    errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }
 
 export const requiredFileInput: Validator<string> = {
@@ -12,5 +12,5 @@ export const requiredFileInput: Validator<string> = {
         const el = document.querySelector<HTMLFormElement>(`#${id}`);
         return el.value.length > 0 ? true : false;
     },
-    errorMessage: { "en": "Error required",  "fr": "Error required french" }
+    errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }

--- a/src/validators/input-validators/input-validators.ts
+++ b/src/validators/input-validators/input-validators.ts
@@ -7,10 +7,9 @@ export const requiredInput: Validator<string> = {
     errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }
 
-export const requiredFileInput: Validator<string> = {
-    validate: (id: string) => {
-        const el = document.querySelector<HTMLFormElement>(`#${id}`);
-        return el.value.length > 0 ? true : false;
+export const requiredFileInput: Validator<number> = {
+    validate: (value: number) => {
+        return value > 0 ? true : false;
     },
     errorMessage: { "en": "Please complete the required field to continue.",  "fr": "Veuillez compléter les champs obligatoires afin de continuer." }
 }

--- a/src/validators/input-validators/test/input-validators.spec.tsx
+++ b/src/validators/input-validators/test/input-validators.spec.tsx
@@ -1,0 +1,26 @@
+import { requiredInput, requiredFileInput } from "../input-validators";
+
+describe('Required input validator', () => {
+    let results: Array<{value: string, res: boolean}> = [
+        {value: "Text field value", res: true},
+        {value: "", res: false},
+        {value: " ", res: false},
+    ];
+    results.forEach(i => 
+        it(`Should return ${i.res} for ${i.value}`, () => {
+            expect(requiredInput.validate(i.value)).toEqual(i.res);
+        })
+    );
+});
+describe('Required file input validator', () => {
+    let results: Array<{value: number, res: boolean}> = [
+        {value: 2, res: true},
+        {value: 1, res: true},
+        {value: 0, res: false},
+    ];
+    results.forEach(i => 
+        it(`Should return ${i.res} for ${i.value}`, () => {
+            expect(requiredFileInput.validate(i.value)).toEqual(i.res);
+        })
+    );
+});

--- a/src/validators/input-validators/test/input-validators.spec.tsx
+++ b/src/validators/input-validators/test/input-validators.spec.tsx
@@ -1,4 +1,4 @@
-import { requiredInput, requiredFileInput } from "../input-validators";
+import { requiredField, requiredFileInput } from "../input-validators";
 
 describe('Required input validator', () => {
     let results: Array<{value: string, res: boolean}> = [
@@ -8,7 +8,7 @@ describe('Required input validator', () => {
     ];
     results.forEach(i => 
         it(`Should return ${i.res} for ${i.value}`, () => {
-            expect(requiredInput.validate(i.value)).toEqual(i.res);
+            expect(requiredField.validate(i.value)).toEqual(i.res);
         })
     );
 });

--- a/src/validators/validator.factory.ts
+++ b/src/validators/validator.factory.ts
@@ -1,11 +1,9 @@
-import { Validator, ValidatorEntry, defaultValidator, combineValidators, FruitValidator, getLengthValidator } from './validator'
+import { Validator, ValidatorEntry, defaultValidator, combineValidators } from './validator'
 import { requiredInput, requiredFileInput } from './input-validators/input-validators';
 import { requiredCheck } from './checkbox-validators/checkbox-validators';
 import { requiredFieldset } from './fieldset-validators/fieldset-validators';
 
 export enum ValidatorsName {
-    fruit = "fruit",
-    length = "length",
     requiredInput = "requiredInput",
     requiredCheck = "requiredCheck",
     requiredFieldset = "requiredFieldset",
@@ -36,10 +34,12 @@ export function validatorFactory(name: string, options: any): Validator<any> {
             return requiredFieldset;
         case (ValidatorsName.requiredFileInput):
             return requiredFileInput;
-        case (ValidatorsName.fruit):
-            return FruitValidator;
+        /*
+        Formatting for parameter validator
+        
         case (ValidatorsName.length):
             return getLengthValidator(options.min, options.max);
+        */
         default:
             return defaultValidator;
     }

--- a/src/validators/validator.factory.ts
+++ b/src/validators/validator.factory.ts
@@ -1,5 +1,5 @@
 import { Validator, ValidatorEntry, defaultValidator, combineValidators, FruitValidator, getLengthValidator } from './validator'
-import { requiredInput } from './input-validators/input-validators';
+import { requiredInput, requiredFileInput } from './input-validators/input-validators';
 import { requiredCheck } from './checkbox-validators/checkbox-validators';
 import { requiredFieldset } from './fieldset-validators/fieldset-validators';
 
@@ -9,6 +9,7 @@ export enum ValidatorsName {
     requiredInput = "requiredInput",
     requiredCheck = "requiredCheck",
     requiredFieldset = "requiredFieldset",
+    requiredFileInput = "requiredFileInput",
 }
 
 export function getValidator<A>(list: Array<string | ValidatorEntry | Validator<A>>): Validator<A> {
@@ -33,6 +34,8 @@ export function validatorFactory(name: string, options: any): Validator<any> {
             return requiredCheck;
         case (ValidatorsName.requiredFieldset):
             return requiredFieldset;
+        case (ValidatorsName.requiredFileInput):
+            return requiredFileInput;
         case (ValidatorsName.fruit):
             return FruitValidator;
         case (ValidatorsName.length):

--- a/src/validators/validator.factory.ts
+++ b/src/validators/validator.factory.ts
@@ -1,0 +1,35 @@
+import { requiredInput } from './input-validators/input-validators';
+import { Validator, ValidatorEntry, defaultValidator, combineValidators, FruitValidator, getLengthValidator } from './validator'
+
+export enum ValidatorsName {
+    fruit = "fruit",
+    length = "length",
+    requiredInput = "requiredInput",
+}
+
+export function getValidator<A>(list: Array<string | ValidatorEntry | Validator<A>>): Validator<A> {
+    return(list || []).map(v => {
+        if (typeof v === 'string') {
+            return validatorFactory(v, null);
+        } else if (v && (v as any).name) {
+            v = v as ValidatorEntry;
+            return validatorFactory(v.name, v.options);
+        } else {
+            return v as Validator<A>;
+        }
+    }).reduce(combineValidators, defaultValidator)
+}
+
+export function validatorFactory(name: string, options: any): Validator<any> {
+    options ? options : {};
+    switch (name) {
+        case (ValidatorsName.requiredInput):
+            return requiredInput;
+        case (ValidatorsName.fruit):
+            return FruitValidator;
+        case (ValidatorsName.length):
+            return getLengthValidator(options.min, options.max);
+        default:
+            return defaultValidator;
+    }
+}

--- a/src/validators/validator.factory.ts
+++ b/src/validators/validator.factory.ts
@@ -1,10 +1,10 @@
 import { Validator, ValidatorEntry, defaultValidator, combineValidators } from './validator'
-import { requiredInput, requiredFileInput } from './input-validators/input-validators';
+import { requiredField, requiredFileInput } from './input-validators/input-validators';
 import { requiredCheck } from './checkbox-validators/checkbox-validators';
 import { requiredFieldset } from './fieldset-validators/fieldset-validators';
 
 export enum ValidatorsName {
-    requiredInput = "requiredInput",
+    requiredField = "requiredField",
     requiredCheck = "requiredCheck",
     requiredFieldset = "requiredFieldset",
     requiredFileInput = "requiredFileInput",
@@ -26,8 +26,8 @@ export function getValidator<A>(list: Array<string | ValidatorEntry | Validator<
 export function validatorFactory(name: string, options: any): Validator<any> {
     options ? options : {};
     switch (name) {
-        case (ValidatorsName.requiredInput):
-            return requiredInput;
+        case (ValidatorsName.requiredField):
+            return requiredField;
         case (ValidatorsName.requiredCheck):
             return requiredCheck;
         case (ValidatorsName.requiredFieldset):

--- a/src/validators/validator.factory.ts
+++ b/src/validators/validator.factory.ts
@@ -1,10 +1,14 @@
-import { requiredInput } from './input-validators/input-validators';
 import { Validator, ValidatorEntry, defaultValidator, combineValidators, FruitValidator, getLengthValidator } from './validator'
+import { requiredInput } from './input-validators/input-validators';
+import { requiredCheck } from './checkbox-validators/checkbox-validators';
+import { requiredFieldset } from './fieldset-validators/fieldset-validators';
 
 export enum ValidatorsName {
     fruit = "fruit",
     length = "length",
     requiredInput = "requiredInput",
+    requiredCheck = "requiredCheck",
+    requiredFieldset = "requiredFieldset",
 }
 
 export function getValidator<A>(list: Array<string | ValidatorEntry | Validator<A>>): Validator<A> {
@@ -25,6 +29,10 @@ export function validatorFactory(name: string, options: any): Validator<any> {
     switch (name) {
         case (ValidatorsName.requiredInput):
             return requiredInput;
+        case (ValidatorsName.requiredCheck):
+            return requiredCheck;
+        case (ValidatorsName.requiredFieldset):
+            return requiredFieldset;
         case (ValidatorsName.fruit):
             return FruitValidator;
         case (ValidatorsName.length):

--- a/src/validators/validator.ts
+++ b/src/validators/validator.ts
@@ -46,6 +46,13 @@ export function requiredValidator(element, type) {
                 element.validator= ["requiredCheck"]
               }
               break;
+            case("fieldset"):
+              if (element.validator) {
+                element.validator.unshift("requiredFieldset");
+              } else {
+                element.validator= ["requiredFieldset"]
+              }
+              break;
         }
     }
 }

--- a/src/validators/validator.ts
+++ b/src/validators/validator.ts
@@ -33,11 +33,19 @@ export function requiredValidator(element, type) {
     if (element.required) {
         switch(type) {
             case("input"):
+            case("textarea"):
             case("select"):
               if (element.validator) {
                 element.validator.unshift("requiredInput");
               } else {
                 element.validator= ["requiredInput"]
+              }
+              break;
+            case("file"):
+              if (element.validator) {
+                element.validator.unshift("requiredFileInput");
+              } else {
+                element.validator= ["requiredFileInput"]
               }
               break;
             case("checkbox"):

--- a/src/validators/validator.ts
+++ b/src/validators/validator.ts
@@ -32,13 +32,14 @@ export function combineValidators<A>(v1: Validator<A>, v2: Validator<A>): Valida
 export function requiredValidator(element, type) {
     if (element.required) {
         switch(type) {
+            // Components all validate the "value" property
             case("input"):
             case("textarea"):
             case("select"):
               if (element.validator) {
-                element.validator.unshift("requiredInput");
+                element.validator.unshift("requiredField");
               } else {
-                element.validator= ["requiredInput"]
+                element.validator= ["requiredField"]
               }
               break;
             case("file"):

--- a/src/validators/validator.ts
+++ b/src/validators/validator.ts
@@ -1,0 +1,69 @@
+export interface Validator<A> {
+    validate: (x: A) => boolean;
+    errorMessage?: object;
+}
+
+export interface ValidatorEntry {
+    name: string,
+    options?: any;
+}
+
+export const defaultValidator: Validator<any> = {
+    validate: (_x: any) => true
+}
+
+export function combineValidators<A>(v1: Validator<A>, v2: Validator<A>): Validator<A> {
+    let combined: Validator<A>;
+    combined = {
+        validate: (x: A) => {
+            const res1: boolean = v1.validate(x);
+            const res2: boolean = v2.validate(x);
+            if (!res1) {
+                combined.errorMessage = v1.errorMessage;
+            } else if (!res2) {
+                combined.errorMessage = v2.errorMessage;
+            }
+            return res1 && res2;
+        },
+    }
+    return combined;
+}
+
+export const FruitValidator: Validator<string> = {
+    validate: (value: string) => {
+        let fruits = ['banana', 'apple'];
+        return fruits.find(a => a === value) ? true : false;
+    },
+    errorMessage: { "en": "Error",  "fr": "Error french" }
+}
+
+export function getLengthValidator(min: number, max: number): Validator<string> {
+    // Create errorMessage object
+    let errorMessage = {};
+    if (min && max) {
+        errorMessage["en"] = `You must enter between ${min} and ${max} characters`;
+        errorMessage["fr"] = `French You must enter between ${min} and ${max} characters`;
+    } else if (min) {
+        errorMessage["en"] = `You must enter at least ${min} characters`;
+        errorMessage["fr"] = `French You must enter at least ${min} characters`;
+    } else if (max) {
+        errorMessage["en"] = `You must enter less than ${max} characters`;
+        errorMessage["fr"] = `French You must enter less than ${max} characters`;
+    }
+    return {
+        validate: (value: string) => {
+            value = value || '';
+            if (min && max) {
+                return min <= value.length && value.length <= max;
+            }
+            if (min) {
+                return min <= value.length;
+            }
+            if (max) {
+                return value.length <= max;
+            } 
+            return true;
+        },
+        errorMessage
+    };
+}

--- a/src/validators/validator.ts
+++ b/src/validators/validator.ts
@@ -29,6 +29,27 @@ export function combineValidators<A>(v1: Validator<A>, v2: Validator<A>): Valida
     return combined;
 }
 
+export function requiredValidator(element, type) {
+    if (element.required) {
+        switch(type) {
+            case("input"):
+              if (element.validator) {
+                element.validator.unshift("requiredInput");
+              } else {
+                element.validator= ["requiredInput"]
+              }
+              break;
+            case("checkbox"):
+              if (element.validator) {
+                element.validator.unshift("requiredCheck");
+              } else {
+                element.validator= ["requiredCheck"]
+              }
+              break;
+        }
+    }
+}
+
 export const FruitValidator: Validator<string> = {
     validate: (value: string) => {
         let fruits = ['banana', 'apple'];

--- a/src/validators/validator.ts
+++ b/src/validators/validator.ts
@@ -66,13 +66,8 @@ export function requiredValidator(element, type) {
     }
 }
 
-export const FruitValidator: Validator<string> = {
-    validate: (value: string) => {
-        let fruits = ['banana', 'apple'];
-        return fruits.find(a => a === value) ? true : false;
-    },
-    errorMessage: { "en": "Error",  "fr": "Error french" }
-}
+/*
+Example of parameter validator
 
 export function getLengthValidator(min: number, max: number): Validator<string> {
     // Create errorMessage object
@@ -104,3 +99,4 @@ export function getLengthValidator(min: number, max: number): Validator<string> 
         errorMessage
     };
 }
+*/

--- a/src/validators/validator.ts
+++ b/src/validators/validator.ts
@@ -33,6 +33,7 @@ export function requiredValidator(element, type) {
     if (element.required) {
         switch(type) {
             case("input"):
+            case("select"):
               if (element.validator) {
                 element.validator.unshift("requiredInput");
               } else {


### PR DESCRIPTION
# Summary | Résumé

Add required prop fields to GCDS form components. If the form component is marked required, the validator will become active.

Validators check the form value and return either `true` or `false` based on if the value passes the validation criteria. If not, the `error-message` prop of the component displays the error message from the validator. 

The validators can be set to validate on `blur`, `submit` and `other`, currently  only `blur` and `other` work at the moment. If the `validate-on` prop is not set and a validator is assigned to the component, `validate-on` will default to `blur`.

## Components with required validators

- gcds-input
- gcds-textarea
- gcds-select
- gcds-file-uploader
- gcds-checkbox
- gcds-fieldset (currently only works with gcds-checkbox or gcds-radio)

## Other component changes

- `has-error` prop has been converted to internal state in all components
- `validate()` method has been added to components. This will allow developers to create custom validation events