### PR TITLE
add gcds-alert component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcds-components",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "gcds components proof-of-concept",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -17,6 +17,10 @@ export namespace Components {
          */
         "alertRole"?: 'destructive' | 'info' | 'success' | 'warning';
         /**
+          * Callback when the close button is clicked.
+         */
+        "dismissHandler": () => void;
+        /**
           * Defines if the alert's close button is displayed or not.
          */
         "hideCloseBtn"?: boolean;
@@ -24,10 +28,6 @@ export namespace Components {
           * Defines the max width of the alert content.
          */
         "maxContentWidth"?: 'fluid' | 'lg' | 'md' | 'sm' | 'xs';
-        /**
-          * Callback when the close button is clicked.
-         */
-        "onDismiss": () => void;
         /**
           * Defines if the alert's position is fixed.
          */
@@ -819,6 +819,10 @@ declare namespace LocalJSX {
          */
         "alertRole"?: 'destructive' | 'info' | 'success' | 'warning';
         /**
+          * Callback when the close button is clicked.
+         */
+        "dismissHandler"?: () => void;
+        /**
           * Defines if the alert's close button is displayed or not.
          */
         "hideCloseBtn"?: boolean;
@@ -827,9 +831,9 @@ declare namespace LocalJSX {
          */
         "maxContentWidth"?: 'fluid' | 'lg' | 'md' | 'sm' | 'xs';
         /**
-          * Callback when the close button is clicked.
+          * Events
          */
-        "onDismiss"?: () => void;
+        "onGcdsDismiss"?: (event: CustomEvent<void>) => void;
         /**
           * Defines if the alert's position is fixed.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,6 +7,32 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Validator, ValidatorEntry } from "./validators";
 export namespace Components {
+    interface GcdsAlert {
+        /**
+          * Defines the alert heading.
+         */
+        "alertHeading": string;
+        /**
+          * Defines alert role.
+         */
+        "alertRole"?: 'destructive' | 'info' | 'success' | 'warning';
+        /**
+          * Defines if the alert's close button is displayed or not.
+         */
+        "hideCloseBtn"?: boolean;
+        /**
+          * Defines the max width of the alert content.
+         */
+        "maxContentWidth"?: 'fluid' | 'lg' | 'md' | 'sm' | 'xs';
+        /**
+          * Callback when the close button is clicked.
+         */
+        "onDismiss": () => void;
+        /**
+          * Defines if the alert's position is fixed.
+         */
+        "positionFixed"?: boolean;
+    }
     interface GcdsBanner {
         /**
           * Defines banner role.
@@ -625,6 +651,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLGcdsAlertElement extends Components.GcdsAlert, HTMLStencilElement {
+    }
+    var HTMLGcdsAlertElement: {
+        prototype: HTMLGcdsAlertElement;
+        new (): HTMLGcdsAlertElement;
+    };
     interface HTMLGcdsBannerElement extends Components.GcdsBanner, HTMLStencilElement {
     }
     var HTMLGcdsBannerElement: {
@@ -752,6 +784,7 @@ declare global {
         new (): HTMLGcdsVerifyBannerElement;
     };
     interface HTMLElementTagNameMap {
+        "gcds-alert": HTMLGcdsAlertElement;
         "gcds-banner": HTMLGcdsBannerElement;
         "gcds-button": HTMLGcdsButtonElement;
         "gcds-checkbox": HTMLGcdsCheckboxElement;
@@ -776,6 +809,32 @@ declare global {
     }
 }
 declare namespace LocalJSX {
+    interface GcdsAlert {
+        /**
+          * Defines the alert heading.
+         */
+        "alertHeading": string;
+        /**
+          * Defines alert role.
+         */
+        "alertRole"?: 'destructive' | 'info' | 'success' | 'warning';
+        /**
+          * Defines if the alert's close button is displayed or not.
+         */
+        "hideCloseBtn"?: boolean;
+        /**
+          * Defines the max width of the alert content.
+         */
+        "maxContentWidth"?: 'fluid' | 'lg' | 'md' | 'sm' | 'xs';
+        /**
+          * Callback when the close button is clicked.
+         */
+        "onDismiss"?: () => void;
+        /**
+          * Defines if the alert's position is fixed.
+         */
+        "positionFixed"?: boolean;
+    }
     interface GcdsBanner {
         /**
           * Defines banner role.
@@ -1457,6 +1516,7 @@ declare namespace LocalJSX {
         "positionFixed"?: boolean;
     }
     interface IntrinsicElements {
+        "gcds-alert": GcdsAlert;
         "gcds-banner": GcdsBanner;
         "gcds-button": GcdsButton;
         "gcds-checkbox": GcdsCheckbox;
@@ -1484,6 +1544,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "gcds-alert": LocalJSX.GcdsAlert & JSXBase.HTMLAttributes<HTMLGcdsAlertElement>;
             "gcds-banner": LocalJSX.GcdsBanner & JSXBase.HTMLAttributes<HTMLGcdsBannerElement>;
             "gcds-button": LocalJSX.GcdsButton & JSXBase.HTMLAttributes<HTMLGcdsButtonElement>;
             "gcds-checkbox": LocalJSX.GcdsCheckbox & JSXBase.HTMLAttributes<HTMLGcdsCheckboxElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -19,7 +19,7 @@ export namespace Components {
         /**
           * Callback when the close button is clicked.
          */
-        "dismissHandler": () => void;
+        "dismissHandler": Function;
         /**
           * Defines if the alert's close button is displayed or not.
          */
@@ -821,7 +821,7 @@ declare namespace LocalJSX {
         /**
           * Callback when the close button is clicked.
          */
-        "dismissHandler"?: () => void;
+        "dismissHandler"?: Function;
         /**
           * Defines if the alert's close button is displayed or not.
          */

--- a/src/components/gcds-alert/gcds-alert.css
+++ b/src/components/gcds-alert/gcds-alert.css
@@ -106,10 +106,28 @@
     }
 
     .alert-close-btn {
-      margin-left: var(--gcds-spacing-400);
+      flex: 0 0 2.75rem;
+      width: 2.75rem;
+      height: 2.75rem;
+      margin: -.75rem -.75rem 0 var(--gcds-spacing-400);
       padding: 0;
       background-color: transparent;
+      box-sizing: border-box;
       border: 0;
+      border-radius: 100%;
+      transition: all .15s ease-in-out;
+
+      @media only screen and (max-width: 550px) {
+        display: none;
+      }
+
+      &:focus {
+        background-color: var(--gcds-alert-button-focus-background);
+        box-shadow: 0 0 0 .125rem var(--gcds-alert-button-focus-text);
+        outline: .1875rem solid var(--gcds-alert-button-focus-background);
+        outline-offset: .125rem;
+        color: var(--gcds-alert-button-focus-text);
+      }
     }
   }
 

--- a/src/components/gcds-alert/gcds-alert.css
+++ b/src/components/gcds-alert/gcds-alert.css
@@ -1,0 +1,131 @@
+:host .gcds-alert {
+  text-align: left;
+  box-sizing: border-box;
+  color: var(--gcds-alert-text);
+  padding: var(--gcds-spacing-500);
+  border-left: 6px solid transparent;
+
+  /* Is Fixed */
+  &.is-fixed {
+    position: sticky;
+    top: 0;
+    width: 100%;
+    z-index: 9999;
+    border: 0;
+
+    @media only screen and (min-width: 767px) {
+      padding: var(--gcds-spacing-600);
+    }
+  }
+
+  /* Max content width */
+  .container-lg,
+  .container-md,
+  .container-sm,
+  .container-xs {
+    width: 90%;
+    margin: 0 auto;
+  }
+
+  .container-fluid {
+    max-width: var(--gcds-container-500);
+    padding-inline: var(--gcds-spacing-300);
+  }
+
+  .container-lg {
+    max-width: var(--gcds-container-400);
+  }
+
+  .container-md {
+    max-width: var(--gcds-container-300);
+  }
+
+  .container-sm {
+    max-width: var(--gcds-container-200);
+  }
+
+  .container-xs {
+    max-width: var(--gcds-container-100);
+
+    .alert-content {
+      margin-inline: 0;
+    }
+  }
+
+  /* Role */
+  &.role-destructive {
+    background-color: var(--gcds-alert-destructive-background);
+    border-color: var(--gcds-alert-destructive-icon);
+
+    .alert-icon {
+      color: var(--gcds-alert-destructive-icon);
+    }
+  }
+
+  &.role-info {
+    background-color: var(--gcds-alert-info-background);
+    border-color: var(--gcds-alert-info-icon);
+
+    .alert-icon {
+      color: var(--gcds-alert-info-icon);
+    }
+  }
+
+  &.role-success {
+    background-color: var(--gcds-alert-success-background);
+    border-color: var(--gcds-alert-success-icon);
+
+    .alert-icon {
+      color: var(--gcds-alert-success-icon);
+    }
+  }
+
+  &.role-warning {
+    background-color: var(--gcds-alert-warning-background);
+    border-color: var(--gcds-alert-warning-icon);
+
+    .alert-icon {
+      color: var(--gcds-alert-warning-icon);
+    }
+  }
+
+  /* Content */
+  .alert-heading {
+    display: flex;
+    align-items: flex-start;
+    font-size: var(--gcds-font-sizes-h5);
+    line-height: var(--gcds-line-heights-h5);
+    margin: 0 0 var(--gcds-spacing-400);
+
+    .alert-icon {
+      margin-right: var(--gcds-spacing-400);
+    }
+
+    span {
+      flex: 1 1 auto;
+    }
+
+    .alert-close-btn {
+      margin-left: var(--gcds-spacing-400);
+      padding: 0;
+      background-color: transparent;
+      border: 0;
+
+      &:focus {
+        background-color: red;
+      }
+    }
+  }
+
+  .alert-content {
+    font-size: var(--gcds-font-sizes-paragraph);
+
+    @media only screen and (min-width: 767px) {
+      margin-inline: var(--gcds-spacing-500);
+    }
+
+    ::slotted(p:last-child) {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/components/gcds-alert/gcds-alert.css
+++ b/src/components/gcds-alert/gcds-alert.css
@@ -120,8 +120,18 @@
       margin-inline: var(--gcds-spacing-500);
     }
 
+    ::slotted(*:not(:last-child)) {
+      margin-bottom: var(--gcds-spacing-400);
+    }
+
     ::slotted(p:last-child) {
       margin-bottom: 0;
+    }
+
+    ::slotted(ol),
+    ::slotted(ul) {
+      margin: 0 0 0 var(--gcds-spacing-400);
+      padding: 0;
     }
   }
 }

--- a/src/components/gcds-alert/gcds-alert.css
+++ b/src/components/gcds-alert/gcds-alert.css
@@ -110,10 +110,6 @@
       padding: 0;
       background-color: transparent;
       border: 0;
-
-      &:focus {
-        background-color: red;
-      }
     }
   }
 

--- a/src/components/gcds-alert/gcds-alert.tsx
+++ b/src/components/gcds-alert/gcds-alert.tsx
@@ -25,7 +25,7 @@ export class GcdsAlert {
   /**
    * Callback when the close button is clicked.
    */
-  @Prop() dismissHandler: () => void;
+  @Prop() dismissHandler: Function;
 
   /**
    * Defines if the alert's close button is displayed or not.
@@ -59,11 +59,11 @@ export class GcdsAlert {
 
   @Event() gcdsDismiss!: EventEmitter<void>;
 
-  private onDismiss = () => {
+  private onDismiss = (e) => {
     this.gcdsDismiss.emit();
 
     if ( this.dismissHandler ) {
-      this.dismissHandler();
+      this.dismissHandler(e);
     } else {
       this.isOpen = false;
     }
@@ -114,7 +114,7 @@ export class GcdsAlert {
                 { !hideCloseBtn ?
                   <button
                     class="alert-close-btn"
-                    onClick={this.onDismiss}
+                    onClick={(e) => this.onDismiss(e)}
                     aria-label={ lang == 'en' ? 'Close alert.' : 'Fermer l\'alerte.'}
                   >
                     <gcds-icon aria-hidden="true" name="times" size="sm" />

--- a/src/components/gcds-alert/gcds-alert.tsx
+++ b/src/components/gcds-alert/gcds-alert.tsx
@@ -36,15 +36,15 @@ export class GcdsAlert {
    */
   @Prop() positionFixed?: boolean = true;
 
-
-  /**
-  * Events
-  */
-
   /**
    * Callback when the close button is clicked.
    */
   @Prop() onDismiss: () => void;
+
+
+  /**
+  * Events
+  */
 
   if ( onDismiss ) {
     onDismiss();
@@ -66,7 +66,12 @@ export class GcdsAlert {
           aria-label={
             lang == 'en' ?
               `This is ${ alertRole == 'info' ? 'an' : 'a'} ${alertRole} alert.`
-            : 'TO DO FRENCH'
+            : `Ceci est une alerte ${
+                alertRole === 'destructive' ? 'd\'effacement'
+                : alertRole === 'info' ? 'd\'information'
+                : alertRole === 'success' ? 'de succès'
+                : alertRole === 'warning' ? 'd\'avertissement'
+                : null }.`
           }
         >
           <div class={`alert-container ${positionFixed && maxContentWidth ? `container-${maxContentWidth}` : ''}`}>
@@ -85,7 +90,7 @@ export class GcdsAlert {
                 <button
                   class="alert-close-btn"
                   onClick={onDismiss ? onDismiss : null}
-                  aria-label={ lang == 'en' ? 'Close alert.' : 'TO DO FRENCH'}
+                  aria-label={ lang == 'en' ? 'Close alert.' : 'Fermer l\'alerte.'}
                 >
                   <gcds-icon aria-hidden="true" name="times" size="sm" />
                 </button>

--- a/src/components/gcds-alert/gcds-alert.tsx
+++ b/src/components/gcds-alert/gcds-alert.tsx
@@ -1,0 +1,103 @@
+import { Component, Element, Host, Prop, h } from '@stencil/core';
+import { assignLanguage } from '../../utils/utils';
+
+@Component({
+  tag: 'gcds-alert',
+  styleUrl: 'gcds-alert.css',
+  shadow: true,
+})
+export class GcdsAlert {
+  @Element() el: HTMLElement;
+
+  private lang: string;
+
+  /**
+   * Defines the alert heading.
+   */
+  @Prop() alertHeading!: string;
+
+  /**
+   * Defines alert role.
+   */
+  @Prop() alertRole?: 'destructive' | 'info' | 'success' | 'warning' = 'info';
+
+  /**
+   * Defines if the alert's close button is displayed or not.
+   */
+  @Prop() hideCloseBtn?: boolean = false;
+
+  /**
+   * Defines the max width of the alert content.
+   */
+  @Prop() maxContentWidth?: 'fluid' | 'lg' | 'md' | 'sm' | 'xs' = 'lg';
+
+  /**
+   * Defines if the alert's position is fixed.
+   */
+  @Prop() positionFixed?: boolean = true;
+
+
+  /**
+  * Events
+  */
+
+  /**
+   * Callback when the close button is clicked.
+   */
+  @Prop() onDismiss: () => void;
+
+  if ( onDismiss ) {
+    onDismiss();
+  }
+
+  async componentWillLoad() {
+    // Define lang attribute
+    this.lang = assignLanguage(this.el);
+  }
+
+  render() {
+    const { alertHeading, alertRole, hideCloseBtn, lang, maxContentWidth, onDismiss, positionFixed } = this;
+
+    return (
+      <Host>
+        <div
+          class={`gcds-alert role-${alertRole} ${positionFixed ? 'is-fixed' : ''}`}
+          role="alert"
+          aria-label={
+            lang == 'en' ?
+              `This is ${ alertRole == 'info' ? 'an' : 'a'} ${alertRole} alert.`
+            : 'TO DO FRENCH'
+          }
+        >
+          <div class={`alert-container ${positionFixed && maxContentWidth ? `container-${maxContentWidth}` : ''}`}>
+            <h2 class="alert-heading">
+              <gcds-icon aria-hidden="true" class="alert-icon" size="md" name={
+                alertRole === 'destructive' ? 'exclamation-circle'
+                : alertRole === 'info' ? 'info-circle'
+                : alertRole === 'success' ? 'check-circle'
+                : alertRole === 'warning' ? 'exclamation-triangle'
+                : null }
+              />
+
+              <span>{alertHeading}</span>
+
+              { !hideCloseBtn ?
+                <button
+                  class="alert-close-btn"
+                  onClick={onDismiss ? onDismiss : null}
+                  aria-label={ lang == 'en' ? 'Close alert.' : 'TO DO FRENCH'}
+                >
+                  <gcds-icon aria-hidden="true" name="times" size="sm" />
+                </button>
+              : null }
+            </h2>
+
+            <div class="alert-content">
+              <slot></slot>
+            </div>
+          </div>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/gcds-alert/readme.md
+++ b/src/components/gcds-alert/readme.md
@@ -11,10 +11,17 @@
 | --------------------------- | ------------------- | -------------------------------------------------------- | --------------------------------------------------- | ----------- |
 | `alertHeading` _(required)_ | `alert-heading`     | Defines the alert heading.                               | `string`                                            | `undefined` |
 | `alertRole`                 | `alert-role`        | Defines alert role.                                      | `"destructive" \| "info" \| "success" \| "warning"` | `'info'`    |
+| `dismissHandler`            | --                  | Callback when the close button is clicked.               | `() => void`                                        | `undefined` |
 | `hideCloseBtn`              | `hide-close-btn`    | Defines if the alert's close button is displayed or not. | `boolean`                                           | `false`     |
 | `maxContentWidth`           | `max-content-width` | Defines the max width of the alert content.              | `"fluid" \| "lg" \| "md" \| "sm" \| "xs"`           | `'lg'`      |
-| `onDismiss`                 | --                  | Callback when the close button is clicked.               | `() => void`                                        | `undefined` |
 | `positionFixed`             | `position-fixed`    | Defines if the alert's position is fixed.                | `boolean`                                           | `true`      |
+
+
+## Events
+
+| Event         | Description | Type                |
+| ------------- | ----------- | ------------------- |
+| `gcdsDismiss` | Events      | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/src/components/gcds-alert/readme.md
+++ b/src/components/gcds-alert/readme.md
@@ -1,0 +1,35 @@
+# gcds-alert
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property                    | Attribute           | Description                                              | Type                                                | Default     |
+| --------------------------- | ------------------- | -------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `alertHeading` _(required)_ | `alert-heading`     | Defines the alert heading.                               | `string`                                            | `undefined` |
+| `alertRole`                 | `alert-role`        | Defines alert role.                                      | `"destructive" \| "info" \| "success" \| "warning"` | `'info'`    |
+| `hideCloseBtn`              | `hide-close-btn`    | Defines if the alert's close button is displayed or not. | `boolean`                                           | `false`     |
+| `maxContentWidth`           | `max-content-width` | Defines the max width of the alert content.              | `"fluid" \| "lg" \| "md" \| "sm" \| "xs"`           | `'lg'`      |
+| `onDismiss`                 | --                  | Callback when the close button is clicked.               | `() => void`                                        | `undefined` |
+| `positionFixed`             | `position-fixed`    | Defines if the alert's position is fixed.                | `boolean`                                           | `true`      |
+
+
+## Dependencies
+
+### Depends on
+
+- [gcds-icon](../gcds-icon)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-alert --> gcds-icon
+  style gcds-alert fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/gcds-alert/readme.md
+++ b/src/components/gcds-alert/readme.md
@@ -11,7 +11,7 @@
 | --------------------------- | ------------------- | -------------------------------------------------------- | --------------------------------------------------- | ----------- |
 | `alertHeading` _(required)_ | `alert-heading`     | Defines the alert heading.                               | `string`                                            | `undefined` |
 | `alertRole`                 | `alert-role`        | Defines alert role.                                      | `"destructive" \| "info" \| "success" \| "warning"` | `'info'`    |
-| `dismissHandler`            | --                  | Callback when the close button is clicked.               | `() => void`                                        | `undefined` |
+| `dismissHandler`            | --                  | Callback when the close button is clicked.               | `Function`                                          | `undefined` |
 | `hideCloseBtn`              | `hide-close-btn`    | Defines if the alert's close button is displayed or not. | `boolean`                                           | `false`     |
 | `maxContentWidth`           | `max-content-width` | Defines the max width of the alert content.              | `"fluid" \| "lg" \| "md" \| "sm" \| "xs"`           | `'lg'`      |
 | `positionFixed`             | `position-fixed`    | Defines if the alert's position is fixed.                | `boolean`                                           | `true`      |

--- a/src/components/gcds-alert/test/gcds-alert.e2e.ts
+++ b/src/components/gcds-alert/test/gcds-alert.e2e.ts
@@ -1,0 +1,79 @@
+import { newE2EPage } from '@stencil/core/testing';
+const { AxePuppeteer } = require('@axe-core/puppeteer');
+
+describe('gcds-alert', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<gcds-alert></gcds-alert>');
+
+    const element = await page.find('gcds-alert');
+    expect(element).toHaveClass('hydrated');
+  });
+});
+
+
+/**
+   * Accessibility tests
+   * Axe-core rules: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-21-level-a--aa-rules
+   */
+
+describe('gcds-alert a11y tests', () => {
+  /**
+   * Colour contrast test
+   */
+  it('colour contrast destructive alert', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <gcds-alert alert-heading="Main notification title" alert-role="destructive">
+        <p>Testing slot content.</p>
+      </gcds-alert>
+    `);
+
+    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
+    let results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('colour contrast info alert', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <gcds-alert alert-heading="Main notification title" alert-role="info">
+        <p>Testing slot content.</p>
+      </gcds-alert>
+    `);
+
+    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
+    let results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('colour contrast success alert', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <gcds-alert alert-heading="Main notification title" alert-role="success">
+        <p>Testing slot content.</p>
+      </gcds-alert>
+    `);
+
+    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
+    let results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('colour contrast warning alert', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <gcds-alert alert-heading="Main notification title" alert-role="warning">
+        <p>Testing slot content.</p>
+      </gcds-alert>
+    `);
+
+    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
+    let results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+});

--- a/src/components/gcds-alert/test/gcds-alert.spec.tsx
+++ b/src/components/gcds-alert/test/gcds-alert.spec.tsx
@@ -44,7 +44,7 @@ describe('gcds-alert', () => {
     expect(page.root).toEqualHtml(`
       <gcds-alert alert-heading="Main notification title" alert-role="destructive">
         <mock:shadow-root>
-          <div aria-label="This is a destructive alert." class="gcds-alert role-destructive is-fixed" role="alert">
+          <div aria-label="This is a critical alert." class="gcds-alert role-destructive is-fixed" role="alert">
             <div class="alert-container container-lg">
               <h2 class="alert-heading">
                 <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="exclamation-circle"></gcds-icon>

--- a/src/components/gcds-alert/test/gcds-alert.spec.tsx
+++ b/src/components/gcds-alert/test/gcds-alert.spec.tsx
@@ -1,0 +1,445 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GcdsAlert } from '../gcds-alert';
+
+describe('gcds-alert', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  /**
+    * Role tests
+    */
+
+  it('renders alert-role="destructive"', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" alert-role="destructive"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" alert-role="destructive">
+        <mock:shadow-root>
+          <div aria-label="This is a destructive alert." class="gcds-alert role-destructive is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="exclamation-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders alert-role="info"', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" alert-role="info"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" alert-role="info">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders alert-role="success"', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" alert-role="success"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" alert-role="success">
+        <mock:shadow-root>
+          <div aria-label="This is a success alert." class="gcds-alert role-success is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="check-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders alert-role="warning"', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" alert-role="warning"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" alert-role="warning">
+        <mock:shadow-root>
+          <div aria-label="This is a warning alert." class="gcds-alert role-warning is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="exclamation-triangle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  /**
+    * Fixed position test
+    */
+
+  it('renders with position fixed by default', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders without position fixed', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert position-fixed="false" alert-heading="Main notification title"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert position-fixed="false" alert-heading="Main notification title">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info" role="alert">
+            <div class="alert-container">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  /**
+    * Max content width tests
+    */
+
+  it('renders max content width fluid', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" max-content-width="fluid"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" max-content-width="fluid">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-fluid">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders max content width lg', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" max-content-width="lg"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" max-content-width="lg">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders max content width md', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" max-content-width="md"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" max-content-width="md">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-md">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders max content width sm', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" max-content-width="sm"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" max-content-width="sm">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-sm">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders max content width xs', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" max-content-width="xs"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" max-content-width="xs">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-xs">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  /**
+    * Hide close button test
+    */
+
+  it('renders with close button hidden', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert alert-heading="Main notification title" hide-close-btn></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title" hide-close-btn>
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  /**
+    * Slot content test
+    */
+
+  it('renders with slot content', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `
+        <gcds-alert alert-heading="Main notification title">
+          <p>Testing slot content.</p>
+        </gcds-alert>
+      `,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert alert-heading="Main notification title">
+        <mock:shadow-root>
+          <div aria-label="This is an info alert." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Close alert.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+        <p>Testing slot content.</p>
+      </gcds-alert>
+    `);
+  });
+});

--- a/src/components/gcds-alert/test/gcds-alert.spec.tsx
+++ b/src/components/gcds-alert/test/gcds-alert.spec.tsx
@@ -157,6 +157,130 @@ describe('gcds-alert', () => {
   });
 
   /**
+    * Role tests french
+    */
+
+  it('renders alert-role="destructive" in french', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert lang="fr" alert-heading="Main notification title" alert-role="destructive"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert lang="fr" alert-heading="Main notification title" alert-role="destructive">
+        <mock:shadow-root>
+          <div aria-label="Ceci est une alerte d'effacement." class="gcds-alert role-destructive is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="exclamation-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Fermer l'alerte.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders alert-role="info" in french', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert lang="fr" alert-heading="Main notification title" alert-role="info"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert lang="fr" alert-heading="Main notification title" alert-role="info">
+        <mock:shadow-root>
+          <div aria-label="Ceci est une alerte d'information." class="gcds-alert role-info is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="info-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Fermer l'alerte.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders alert-role="success in french"', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert lang="fr" alert-heading="Main notification title" alert-role="success"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert lang="fr" alert-heading="Main notification title" alert-role="success">
+        <mock:shadow-root>
+          <div aria-label="Ceci est une alerte de succès." class="gcds-alert role-success is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="check-circle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Fermer l'alerte.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  it('renders alert-role="warning" in french', async () => {
+    const page = await newSpecPage({
+      components: [GcdsAlert],
+      html: `<gcds-alert lang="fr" alert-heading="Main notification title" alert-role="warning"></gcds-alert>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-alert lang="fr" alert-heading="Main notification title" alert-role="warning">
+        <mock:shadow-root>
+          <div aria-label="Ceci est une alerte d'avertissement." class="gcds-alert role-warning is-fixed" role="alert">
+            <div class="alert-container container-lg">
+              <h2 class="alert-heading">
+                <gcds-icon aria-hidden="true" class="alert-icon" size="md" name="exclamation-triangle"></gcds-icon>
+
+                <span>Main notification title</span>
+
+                <button class="alert-close-btn" aria-label="Fermer l'alerte.">
+                  <gcds-icon aria-hidden="true" name="times" size="sm"></gcds-icon>
+                </button>
+              </h2>
+
+              <div class="alert-content">
+                <slot></slot>
+              </div>
+            </div>
+          </div>
+        </mock:shadow-root>
+      </gcds-alert>
+    `);
+  });
+
+  /**
     * Fixed position test
     */
 

--- a/src/components/gcds-icon/readme.md
+++ b/src/components/gcds-icon/readme.md
@@ -19,11 +19,13 @@
 
 ### Used by
 
+ - [gcds-alert](../gcds-alert)
  - [gcds-file-uploader](../gcds-file-uploader)
 
 ### Graph
 ```mermaid
 graph TD;
+  gcds-alert --> gcds-icon
   gcds-file-uploader --> gcds-icon
   style gcds-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 31 Aug 2022 16:00:04 GMT
+ * Generated on Tue, 06 Sep 2022 21:26:11 GMT
  */
 :root {
   --gcds-brand-default-text: #000000;
@@ -86,6 +86,8 @@
   --gcds-line-heights-h3: 162.31672001219326%;
   --gcds-line-heights-h2: 144.28152889972733%;
   --gcds-line-heights-h1: 128.25024791086875%;
+  --gcds-alert-button-focus-background: #303fc3;
+  --gcds-alert-button-focus-text: #ffffff;
   --gcds-alert-text: #000000;
   --gcds-alert-destructive-background: #f3e9e8;
   --gcds-alert-destructive-icon: #bc3331;
@@ -123,6 +125,13 @@
   --gcds-checkbox-disabled-text: #707070;
   --gcds-checkbox-focus-text: #303fc3;
   --gcds-checkbox-focus-shadow: #ffffff;
+  --gcds-details-default-border: #c4c3c5;
+  --gcds-details-default-text: #2b496e;
+  --gcds-details-active-background: #000000;
+  --gcds-details-active-text: #ffffff;
+  --gcds-details-focus-background: #303fc3;
+  --gcds-details-focus-text: #ffffff;
+  --gcds-details-hover-background: #d4e6f2;
   --gcds-error-message-background: #f3e9e8;
   --gcds-error-message-border: #d3080c;
   --gcds-error-message-text: #000000;


### PR DESCRIPTION
# Summary | Résumé

Add gcds-alert component.

Alerts notify users of important and often time-sensitive changes. They are usually positioned at the top of the page to capture the user’s attention and therefore should be concise and used sparingly.

- **alert-heading**: Text for the alert heading
- **alert-role**: Defines the role of the alert
- **hide-close-btn**: Controls if the close button is displayed or not
- **onDismiss**: Callback when the close button is clicked
- **max-content-width**: Defines the container width for the alert content
- **position-fixed**: Controls if the alert is fixed to the top or not


Update: The french translations have been added.


