### PR TITLE
gcds-banner: remove destructive + warning role

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -11,7 +11,7 @@ export namespace Components {
         /**
           * Defines banner role.
          */
-        "bannerRole"?: 'destructive' | 'primary' | 'secondary' | 'warning';
+        "bannerRole"?: 'primary' | 'secondary';
         /**
           * Defines the max width of the banner content.
          */
@@ -780,7 +780,7 @@ declare namespace LocalJSX {
         /**
           * Defines banner role.
          */
-        "bannerRole"?: 'destructive' | 'primary' | 'secondary' | 'warning';
+        "bannerRole"?: 'primary' | 'secondary';
         /**
           * Defines the max width of the banner content.
          */

--- a/src/components/gcds-banner/gcds-banner.css
+++ b/src/components/gcds-banner/gcds-banner.css
@@ -38,11 +38,6 @@
   }
 
   /* Role */
-  &.role-destructive {
-    background-color: var(--gcds-banner-destructive-background);
-    color: var(--gcds-banner-destructive-text);
-  }
-
   &.role-primary {
     background-color: var(--gcds-banner-primary-background);
     color: var(--gcds-banner-primary-text);
@@ -50,10 +45,6 @@
 
   &.role-secondary {
     background-color: var(--gcds-banner-secondary-background);
-  }
-
-  &.role-warning {
-    background-color: var(--gcds-banner-warning-background);
   }
 
   /* General Styling */

--- a/src/components/gcds-banner/gcds-banner.tsx
+++ b/src/components/gcds-banner/gcds-banner.tsx
@@ -11,7 +11,7 @@ export class GcdsBanner {
   /**
    * Defines banner role.
    */
-  @Prop() bannerRole?: 'destructive' | 'primary' | 'secondary' | 'warning' = 'primary';
+  @Prop() bannerRole?: 'primary' | 'secondary' = 'primary';
 
   /**
    * Defines the max width of the banner content.
@@ -30,7 +30,7 @@ export class GcdsBanner {
       <Host>
         <div
           class={`gcds-banner role-${bannerRole} ${positionFixed ? 'is-fixed' : ''}`}
-          role={bannerRole === 'destructive' ? 'alert' : 'status'}
+          role="status"
           aria-label="Banner"
         >
           <div class={`banner-content ${maxContentWidth ? `container-${maxContentWidth}` : ''}`}>

--- a/src/components/gcds-banner/readme.md
+++ b/src/components/gcds-banner/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property          | Attribute           | Description                                  | Type                                                     | Default     |
-| ----------------- | ------------------- | -------------------------------------------- | -------------------------------------------------------- | ----------- |
-| `bannerRole`      | `banner-role`       | Defines banner role.                         | `"destructive" \| "primary" \| "secondary" \| "warning"` | `'primary'` |
-| `maxContentWidth` | `max-content-width` | Defines the max width of the banner content. | `"fluid" \| "lg" \| "md" \| "sm" \| "xs"`                | `'lg'`      |
-| `positionFixed`   | `position-fixed`    | Defines if the banner's position is fixed.   | `boolean`                                                | `undefined` |
+| Property          | Attribute           | Description                                  | Type                                      | Default     |
+| ----------------- | ------------------- | -------------------------------------------- | ----------------------------------------- | ----------- |
+| `bannerRole`      | `banner-role`       | Defines banner role.                         | `"primary" \| "secondary"`                | `'primary'` |
+| `maxContentWidth` | `max-content-width` | Defines the max width of the banner content. | `"fluid" \| "lg" \| "md" \| "sm" \| "xs"` | `'lg'`      |
+| `positionFixed`   | `position-fixed`    | Defines if the banner's position is fixed.   | `boolean`                                 | `undefined` |
 
 
 ----------------------------------------------

--- a/src/components/gcds-banner/test/gcds-banner.e2e.ts
+++ b/src/components/gcds-banner/test/gcds-banner.e2e.ts
@@ -48,32 +48,4 @@ describe('gcds-banner a11y tests', () => {
 
     expect(results.violations.length).toBe(0);
   });
-
-  it('colour contrast destructive banner', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <gcds-banner banner-role="destructive">
-        <span slot="banner-text"> This is an example of a destructive banner.</span>
-      </gcds-banner>
-    `);
-
-    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
-    let results = await colorContrastTest;
-
-    expect(results.violations.length).toBe(0);
-  });
-
-  it('colour contrast warning banner', async () => {
-    const page = await newE2EPage();
-    await page.setContent(`
-      <gcds-banner banner-role="warning">
-        <span slot="banner-text"> This is an example of a warning banner.</span>
-      </gcds-banner>
-    `);
-
-    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
-    let results = await colorContrastTest;
-
-    expect(results.violations.length).toBe(0);
-  });
 });

--- a/src/components/gcds-banner/test/gcds-banner.spec.tsx
+++ b/src/components/gcds-banner/test/gcds-banner.spec.tsx
@@ -93,64 +93,6 @@ describe('gcds-banner', () => {
     `);
   });
 
-  it('renders banner-role="destructive" + role="alert"', async () => {
-    const page = await newSpecPage({
-      components: [GcdsBanner],
-      html: `<gcds-banner banner-role="destructive"></gcds-banner>`,
-    });
-    expect(page.root).toEqualHtml(`
-      <gcds-banner banner-role="destructive">
-        <mock:shadow-root>
-          <div aria-label="Banner" class="gcds-banner role-destructive" role="alert">
-            <div class="banner-content container-lg">
-              <figure class="banner-icon icon-left">
-                <slot name="banner-icon-left"></slot>
-              </figure>
-
-              <div class="banner-details">
-                <p><slot name="banner-text"></slot></p>
-                <slot name="banner-cta"></slot>
-              </div>
-
-              <figure class="banner-icon icon-right">
-                <slot name="banner-icon-right"></slot>
-              </figure>
-            </div>
-          </div>
-        </mock:shadow-root>
-      </gcds-banner>
-    `);
-  });
-
-  it('renders banner-role="warning"', async () => {
-    const page = await newSpecPage({
-      components: [GcdsBanner],
-      html: `<gcds-banner banner-role="warning"></gcds-banner>`,
-    });
-    expect(page.root).toEqualHtml(`
-      <gcds-banner banner-role="warning">
-        <mock:shadow-root>
-          <div aria-label="Banner" class="gcds-banner role-warning" role="status">
-            <div class="banner-content container-lg">
-              <figure class="banner-icon icon-left">
-                <slot name="banner-icon-left"></slot>
-              </figure>
-
-              <div class="banner-details">
-                <p><slot name="banner-text"></slot></p>
-                <slot name="banner-cta"></slot>
-              </div>
-
-              <figure class="banner-icon icon-right">
-                <slot name="banner-icon-right"></slot>
-              </figure>
-            </div>
-          </div>
-        </mock:shadow-root>
-      </gcds-banner>
-    `);
-  });
-
   /**
     * Fixed position test
     */


### PR DESCRIPTION
# Summary | Résumé

Remove `destructive` and `warning` role from the banner component in order to better separate the alert and the banner component.