### PR TITLE
Package changes + sitemenu fix

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "0.1.11"
+  "version": "0.1.12"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcds-components-repo",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "GCDS components repo",
   "scripts": {
     "compile": "gulp compile",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcds-components-react",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "React wrapper for gcds-components",
   "homepage": "https://cds-snc-design.netlify.app/",
@@ -42,6 +42,7 @@
     "typescript": "^4.2.0"
   },
   "dependencies": {
+    "gcds-components": "^0.1.11"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,7 @@
     "typescript": "^4.2.0"
   },
   "dependencies": {
-    "gcds-components": "^0.1.11"
+    "gcds-components": "^0.1.12"
   },
   "peerDependencies": {
     "react": "^17.0.2",

--- a/packages/react/src/components/stencil-generated/index.ts
+++ b/packages/react/src/components/stencil-generated/index.ts
@@ -5,8 +5,9 @@ import { createReactComponent } from './react-component-lib';
 
 import type { JSX } from 'gcds-components';
 
+import { defineCustomElements } from 'gcds-components/loader';
 
-
+defineCustomElements();
 export const GcdsAlert = /*@__PURE__*/createReactComponent<JSX.GcdsAlert, HTMLGcdsAlertElement>('gcds-alert');
 export const GcdsBanner = /*@__PURE__*/createReactComponent<JSX.GcdsBanner, HTMLGcdsBannerElement>('gcds-banner');
 export const GcdsButton = /*@__PURE__*/createReactComponent<JSX.GcdsButton, HTMLGcdsButtonElement>('gcds-button');

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcds-components",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Web components for the GCDS",
   "homepage": "https://cds-snc-design.netlify.app/",

--- a/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
+++ b/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
@@ -9,9 +9,7 @@ describe('gcds-hint', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-hint hint-id="input-renders" hint="Hint Test" id="hint-input-renders">
-        <mock:shadow-root>
-          <p class="hint">Hint Test</p>
-        </mock:shadow-root>
+        <p class="hint">Hint Test</p>
       </gcds-hint>
     `);
   });

--- a/packages/web/src/components/gcds-site-menu/gcds-site-menu.css
+++ b/packages/web/src/components/gcds-site-menu/gcds-site-menu.css
@@ -244,6 +244,11 @@
     > [data-h2-menulist]:first-of-type {
       margin-right: auto;
     }
+
+    > [data-h2-menulist]:not(:first-of-type) [data-h2-menulist] {
+      left: auto;
+      right: 0;
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
+++ b/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
@@ -285,13 +285,6 @@ export class GcdsSiteMenu {
     }
   }
 
-  private get hasOptionalLeft() {
-    return !!this.el.querySelector('[slot="left"]');
-  }
-  private get hasOptionalRight() {
-    return !!this.el.querySelector('[slot="left"]');
-  }
-
   render() {
     const sticky = this.menuPosition == 'sticky' ? true : false;
     const mobileMenutask = this.menuMobileLayout == 'drawer' ?

--- a/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
+++ b/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
@@ -320,23 +320,14 @@ export class GcdsSiteMenu {
           data-h2-menu
         >
           <div data-h2-menu-container>
-            {this.hasOptionalLeft ? 
-              <div data-optional-left>
-                <slot name="left" />
-              </div>
-            : 
-              null
-            }
+            <div data-optional-left>
+              <slot name="left" />
+            </div>
             <slot />
-            {this.hasOptionalRight ?
-              <div data-optional-right>
-                <slot name="right" />
-              </div>
-            :
-              null
-            }
+            <div data-optional-right>
+              <slot name="right" />
+            </div>
           </div>
-          
         </nav>
         {this.menuDesktopLayout == "sidebar" ?
           <div data-sidebar-backdrop hidden onClick={() => {h2MenuCloseOpenSubmenusHandler(this.el)}}></div>

--- a/packages/web/src/components/gcds-site-menu/test/gcds-site-menu.spec.tsx
+++ b/packages/web/src/components/gcds-site-menu/test/gcds-site-menu.spec.tsx
@@ -32,7 +32,13 @@ describe('gcds-site-menu', () => {
           </gcds-button>
           <nav aria-label="Main navigation - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu." data-h2-menu>
             <div data-h2-menu-container data-mobile>
+              <div data-optional-left>
+                <slot name="left"></slot>
+              </div>
               <slot></slot>
+              <div data-optional-right>
+                <slot name="right"></slot>
+              </div>
             </div>
           </nav>
           <slot name="main"></slot>
@@ -58,7 +64,13 @@ describe('gcds-site-menu', () => {
           </gcds-button>
           <nav aria-label="Navigation principale - Utiliser la touche d'entrée pour sélectionner un élément du menu et voyager à la page indiquée. Utiliser les flèches gauches et droites pour naviguer entre les éléments et les sous-éléments du menu. Ouvrir les sous-éléments du menu avec la flèche droite lorsqu'il sont disponible. Fermer le menu avec la flèche gauche ou la touche d'échappement." data-h2-menu>
             <div data-h2-menu-container data-mobile>
+              <div data-optional-left>
+                <slot name="left"></slot>
+              </div>
               <slot></slot>
+              <div data-optional-right>
+                <slot name="right"></slot>
+              </div>
             </div>
           </nav>
           <slot name="main"></slot>
@@ -108,6 +120,9 @@ describe('gcds-site-menu', () => {
           </gcds-button>
           <nav aria-label="Main navigation - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu." data-h2-menu>
             <div data-h2-menu-container data-mobile>
+              <div data-optional-left>
+                <slot name="left"></slot>
+              </div>
               <slot></slot>
               <ul data-h2-menulist role="menu">
                 <li role="presentation">
@@ -158,6 +173,9 @@ describe('gcds-site-menu', () => {
                   </button>
                 </li>
               </ul>
+              <div data-optional-right>
+                <slot name="right"></slot>
+              </div>
             </div>
           </nav>
           <slot name="main"></slot>
@@ -207,6 +225,9 @@ describe('gcds-site-menu', () => {
           </gcds-button>
           <nav aria-label="Main navigation - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu." data-h2-menu>
             <div data-h2-menu-container data-mobile>
+              <div data-optional-left>
+                <slot name="left"></slot>
+              </div>
               <slot></slot>
               <ul data-h2-menulist role="menu">
                 <li role="presentation">
@@ -262,6 +283,9 @@ describe('gcds-site-menu', () => {
                   </button>
                 </li>
               </ul>
+              <div data-optional-right>
+                <slot name="right"></slot>
+              </div>
             </div>
           </nav>
           <div data-sidebar-backdrop hidden=""></div>
@@ -312,6 +336,9 @@ describe('gcds-site-menu', () => {
           </gcds-button>
           <nav aria-label="Navigation principale - Utiliser la touche d'entrée pour sélectionner un élément du menu et voyager à la page indiquée. Utiliser les flèches gauches et droites pour naviguer entre les éléments et les sous-éléments du menu. Ouvrir les sous-éléments du menu avec la flèche droite lorsqu'il sont disponible. Fermer le menu avec la flèche gauche ou la touche d'échappement." data-h2-menu>
             <div data-h2-menu-container data-mobile>
+              <div data-optional-left>
+                <slot name="left"></slot>
+              </div>
               <slot></slot>
               <ul data-h2-menulist role="menu">
                 <li role="presentation">
@@ -367,6 +394,9 @@ describe('gcds-site-menu', () => {
                   </button>
                 </li>
               </ul>
+              <div data-optional-right>
+                <slot name="right"></slot>
+              </div>
             </div>
           </nav>
           <div data-sidebar-backdrop hidden=""></div>

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -11,6 +11,7 @@ export const config: Config = {
     react({
       componentCorePackage: 'gcds-components',
       proxiesFile: '../react/src/components/stencil-generated/index.ts',
+      includeDefineCustomElements: true,
     }),
     {
       type: 'dist',


### PR DESCRIPTION
# Summary | Résumé

- Fix broken tests
- Fix issue with `gcds-site-menu`: Topbar center alignment wouldn't work without `left` and `right` slot present 
- Fix issue with `gcds-site-menu`: dropdown alignment for second menu in `split` alignment
- More package changes for react package
