### PR TITLE
Change gcds-footer type prop to display

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -25,10 +25,10 @@
   ],
   "peerDependencies": {
     "@angular/common": "^14.2.0",
-    "@angular/core": "^14.2.0"
+    "@angular/core": "^14.2.0",
+    "gcds-components": "^0.1.13"
   },
   "dependencies": {
-    "gcds-components": "^0.1.13",
     "tslib": "^2.3.0"
   },
   "main": "dist/index.d.js",

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -247,13 +247,13 @@ export declare interface GcdsFooter extends Components.GcdsFooter {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['topHref', 'type', 'wordmarkVariant']
+  inputs: ['display', 'topHref', 'wordmarkVariant']
 })
 @Component({
   selector: 'gcds-footer',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['topHref', 'type', 'wordmarkVariant']
+  inputs: ['display', 'topHref', 'wordmarkVariant']
 })
 export class GcdsFooter {
   protected el: HTMLElement;

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -325,13 +325,13 @@ export namespace Components {
     }
     interface GcdsFooter {
         /**
+          * Display mode of the footer
+         */
+        "display": 'compact' | 'full';
+        /**
           * Top of page href
          */
         "topHref": string;
-        /**
-          * The type of graphic to render
-         */
-        "type": 'compact' | 'full';
         /**
           * GcdsSignature - The variant of the Government of Canada wordmark
          */
@@ -1304,13 +1304,13 @@ declare namespace LocalJSX {
     }
     interface GcdsFooter {
         /**
+          * Display mode of the footer
+         */
+        "display"?: 'compact' | 'full';
+        /**
           * Top of page href
          */
         "topHref"?: string;
-        /**
-          * The type of graphic to render
-         */
-        "type"?: 'compact' | 'full';
         /**
           * GcdsSignature - The variant of the Government of Canada wordmark
          */

--- a/packages/web/src/components/gcds-footer/gcds-footer.tsx
+++ b/packages/web/src/components/gcds-footer/gcds-footer.tsx
@@ -14,14 +14,14 @@ export class GcdsFooter {
   @Element() el: HTMLElement;
 
   /**
-  * The type of graphic to render
+  * Display mode of the footer
   */
-   @Prop({ reflect: true, mutable: true }) type: 'compact' | 'full';
+   @Prop({ reflect: true, mutable: true }) display: 'compact' | 'full';
 
-   @Watch('type')
-   validateType(newValue: string) {
+   @Watch('display')
+   validateDisplay(newValue: string) {
      if (newValue != 'compact' && newValue != 'full') {
-       this.type = 'compact';
+       this.display = 'compact';
      }
    }
 
@@ -39,7 +39,7 @@ export class GcdsFooter {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
 
-    this.validateType;
+    this.validateDisplay;
   }
 
   private get renderSignature() {
@@ -63,7 +63,7 @@ export class GcdsFooter {
   }
 
   render() {
-    const { lang, type, topHref, hasList, renderSignature } = this;
+    const { lang, display, topHref, hasList, renderSignature } = this;
     const govNav = I18N[lang].gov.menu;
     const siteNav = I18N[lang].site.menu;
     return (
@@ -71,7 +71,7 @@ export class GcdsFooter {
         <div class="container">
           <slot name="top"></slot>
         </div>
-        {type === "full" ? 
+        {display === "full" ? 
           (<div class="landscape">
             <nav class="container" aria-label={I18N[lang].gov.heading}>
               <h2>{I18N[lang].gov.heading}</h2>

--- a/packages/web/src/components/gcds-footer/readme.md
+++ b/packages/web/src/components/gcds-footer/readme.md
@@ -9,8 +9,8 @@
 
 | Property          | Attribute          | Description                                                      | Type                  | Default     |
 | ----------------- | ------------------ | ---------------------------------------------------------------- | --------------------- | ----------- |
+| `display`         | `display`          | Display mode of the footer                                       | `"compact" \| "full"` | `undefined` |
 | `topHref`         | `top-href`         | Top of page href                                                 | `string`              | `undefined` |
-| `type`            | `type`             | The type of graphic to render                                    | `"compact" \| "full"` | `undefined` |
 | `wordmarkVariant` | `wordmark-variant` | GcdsSignature - The variant of the Government of Canada wordmark | `"colour" \| "white"` | `undefined` |
 
 

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
@@ -5,10 +5,10 @@ describe('gcds-footer', () => {
   it('renders compact - English', async () => {
     const page = await newSpecPage({
       components: [GcdsFooter],
-      html: `<gcds-footer type="compact" lang="en"></gcds-footer>`,
+      html: `<gcds-footer display="compact" lang="en"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" type="compact" lang="en">
+      <gcds-footer role="contentinfo" display="compact" lang="en">
         <mock:shadow-root>
           <div class="container">
             <slot name="top"></slot>
@@ -60,10 +60,10 @@ describe('gcds-footer', () => {
   it('renders full - English', async () => {
     const page = await newSpecPage({
       components: [GcdsFooter],
-      html: `<gcds-footer type="full" lang="en"></gcds-footer>`,
+      html: `<gcds-footer display="full" lang="en"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" type="full" lang="en">
+      <gcds-footer role="contentinfo" display="full" lang="en">
         <mock:shadow-root>
           <div class="container">
             <slot name="top"></slot>
@@ -169,10 +169,10 @@ describe('gcds-footer', () => {
   it('renders compact - French', async () => {
     const page = await newSpecPage({
       components: [GcdsFooter],
-      html: `<gcds-footer type="compact" lang="fr"></gcds-footer>`,
+      html: `<gcds-footer display="compact" lang="fr"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" type="compact" lang="fr">
+      <gcds-footer role="contentinfo" display="compact" lang="fr">
         <mock:shadow-root>
           <div class="container">
             <slot name="top"></slot>
@@ -224,10 +224,10 @@ describe('gcds-footer', () => {
   it('renders full - French', async () => {
     const page = await newSpecPage({
       components: [GcdsFooter],
-      html: `<gcds-footer type="full" lang="fr"></gcds-footer>`,
+      html: `<gcds-footer display="full" lang="fr"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" type="full" lang="fr">
+      <gcds-footer role="contentinfo" display="full" lang="fr">
         <mock:shadow-root>
           <div class="container">
             <slot name="top"></slot>


### PR DESCRIPTION
# Summary | Résumé

Change `gcds-footer`'s  `type` prop to `display` to better reflect what the property does.
