### PR TITLE
improve breadcrumbs component

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -40,13 +40,13 @@ export declare interface GcdsBreadcrumbs extends Components.GcdsBreadcrumbs {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['currentPageTitle', 'hideCanadaLink']
+  inputs: ['hideCanadaLink']
 })
 @Component({
   selector: 'gcds-breadcrumbs',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['currentPageTitle', 'hideCanadaLink']
+  inputs: ['hideCanadaLink']
 })
 export class GcdsBreadcrumbs {
   protected el: HTMLElement;
@@ -61,13 +61,13 @@ export declare interface GcdsBreadcrumbsItem extends Components.GcdsBreadcrumbsI
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['href', 'isCurrentPage']
+  inputs: ['href']
 })
 @Component({
   selector: 'gcds-breadcrumbs-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['href', 'isCurrentPage']
+  inputs: ['href']
 })
 export class GcdsBreadcrumbsItem {
   protected el: HTMLElement;

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -40,13 +40,13 @@ export declare interface GcdsBreadcrumbs extends Components.GcdsBreadcrumbs {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['hideCanadaLink']
+  inputs: ['currentPageTitle', 'hideCanadaLink']
 })
 @Component({
   selector: 'gcds-breadcrumbs',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['hideCanadaLink']
+  inputs: ['currentPageTitle', 'hideCanadaLink']
 })
 export class GcdsBreadcrumbs {
   protected el: HTMLElement;

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -35,10 +35,6 @@ export namespace Components {
     }
     interface GcdsBreadcrumbs {
         /**
-          * Sets the title for the current page.
-         */
-        "currentPageTitle": string;
-        /**
           * Defines if the default canada.ca link should be displayed or not.
          */
         "hideCanadaLink": boolean;
@@ -47,11 +43,7 @@ export namespace Components {
         /**
           * Specifies the href of the breadcrumb item.
          */
-        "href"?: string | undefined;
-        /**
-          * Defines if the breadcrumb item is the current page or not.
-         */
-        "isCurrentPage"?: boolean;
+        "href": string | undefined;
     }
     interface GcdsButton {
         /**
@@ -1054,10 +1046,6 @@ declare namespace LocalJSX {
     }
     interface GcdsBreadcrumbs {
         /**
-          * Sets the title for the current page.
-         */
-        "currentPageTitle": string;
-        /**
           * Defines if the default canada.ca link should be displayed or not.
          */
         "hideCanadaLink"?: boolean;
@@ -1066,11 +1054,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the href of the breadcrumb item.
          */
-        "href"?: string | undefined;
-        /**
-          * Defines if the breadcrumb item is the current page or not.
-         */
-        "isCurrentPage"?: boolean;
+        "href": string | undefined;
     }
     interface GcdsButton {
         /**

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -35,6 +35,10 @@ export namespace Components {
     }
     interface GcdsBreadcrumbs {
         /**
+          * Sets the title for the current page.
+         */
+        "currentPageTitle": string;
+        /**
           * Defines if the default canada.ca link should be displayed or not.
          */
         "hideCanadaLink": boolean;
@@ -43,7 +47,7 @@ export namespace Components {
         /**
           * Specifies the href of the breadcrumb item.
          */
-        "href": string | undefined;
+        "href"?: string | undefined;
         /**
           * Defines if the breadcrumb item is the current page or not.
          */
@@ -1050,6 +1054,10 @@ declare namespace LocalJSX {
     }
     interface GcdsBreadcrumbs {
         /**
+          * Sets the title for the current page.
+         */
+        "currentPageTitle": string;
+        /**
           * Defines if the default canada.ca link should be displayed or not.
          */
         "hideCanadaLink"?: boolean;
@@ -1058,7 +1066,7 @@ declare namespace LocalJSX {
         /**
           * Specifies the href of the breadcrumb item.
          */
-        "href": string | undefined;
+        "href"?: string | undefined;
         /**
           * Defines if the breadcrumb item is the current page or not.
          */

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -2,7 +2,7 @@
   position: relative;
   display: inline-block;
   margin: var(--gcds-spacing-200) 0;
-  padding: var(--gcds-spacing-50) var(--gcds-spacing-50) var(--gcds-spacing-50) var(--gcds-spacing-450);
+  padding: 0 0 0 var(--gcds-spacing-400);
 
   &:before {
     position: absolute;
@@ -16,6 +16,7 @@
     display: inline-block;
     color: var(--gcds-breadcrumbs-default-text);
     outline: 0;
+    padding: var(--gcds-spacing-50);
     transition: background .35s ease-in-out, color .35s ease-in-out;
     white-space: normal;
   }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -1,44 +1,40 @@
 :host .gcds-breadcrumbs-item {
+  position: relative;
   display: inline-block;
   margin: var(--gcds-spacing-200) 0;
-  white-space: nowrap;
+  padding: var(--gcds-spacing-50) var(--gcds-spacing-50) var(--gcds-spacing-50) var(--gcds-spacing-450);
+
+  &:before {
+    position: absolute;
+    top: .25rem;
+    left: var(--gcds-spacing-50);
+    content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='0.4rem' height='0.8rem' viewBox='0 0 8 14'><path fill='26374a' d='M7.7,6.3c0.4,0.4,0.4,1,0,1.4l-6,6c-0.4,0.4-1,0.4-1.4,0s-0.4-1,0-1.4L5.6,7L0.3,1.7c-0.4-0.4-0.4-1,0-1.4s1-0.4,1.4,0 L7.7,6.3L7.7,6.3z'/></svg>");
+    transition: filter .35s ease-in-out;
+  }
 
   a {
-    position: relative;
     display: inline-block;
     color: var(--gcds-breadcrumbs-default-text);
     outline: 0;
-    margin: 0 var(--gcds-spacing-50) 0 0;
-    padding: var(--gcds-spacing-50) var(--gcds-spacing-400) var(--gcds-spacing-50) var(--gcds-spacing-50);
     transition: background .35s ease-in-out, color .35s ease-in-out;
     white-space: normal;
+  }
 
-    &:after {
-      position: absolute;
-      top: .25rem;
-      right: var(--gcds-spacing-50);
-      content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='0.4rem' height='0.8rem' viewBox='0 0 8 14'><path fill='26374a' d='M7.7,6.3c0.4,0.4,0.4,1,0,1.4l-6,6c-0.4,0.4-1,0.4-1.4,0s-0.4-1,0-1.4L5.6,7L0.3,1.7c-0.4-0.4-0.4-1,0-1.4s1-0.4,1.4,0 L7.7,6.3L7.7,6.3z'/></svg>");
-      transition: filter .35s ease-in-out;
+  &:focus-within:not(:hover) {
+    background-color: var(--gcds-breadcrumbs-focus-background);
+    color: var(--gcds-breadcrumbs-focus-text);
+
+    a {
+      color: inherit;
     }
 
-    &[aria-current="page"]{
-      padding: var(--gcds-spacing-50);
-
-      &:after {
-        display: none;
-      }
+    &:before {
+      filter: brightness(0) invert(1);
     }
+  }
 
-    &:focus:not(:hover) {
-      background-color: var(--gcds-breadcrumbs-focus-background);
-      color: var(--gcds-breadcrumbs-focus-text);
-
-      &:after {
-        filter: brightness(0) invert(1);
-      }
-    }
-
-    &:hover {
+  &:hover {
+    a {
       color: var(--gcds-breadcrumbs-hover-text);
     }
   }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
@@ -16,29 +16,18 @@ export class GcdsBreadcrumbsItem {
   /**
    * Specifies the href of the breadcrumb item.
    */
-  @Prop() href?: string | undefined;
-
-  /**
-   * Defines if the breadcrumb item is the current page or not.
-   */
-  @Prop() isCurrentPage?: boolean = false;
+  @Prop() href!: string | undefined;
 
   render() {
-    const { href, isCurrentPage } = this;
+    const { href } = this;
 
     return (
       <Host>
-        {isCurrentPage ?
-          <li class="gcds-breadcrumbs-item" aria-current="page">
+        <li class="gcds-breadcrumbs-item">
+          <a href={href}>
             <slot></slot>
-          </li>
-        :
-          <li class="gcds-breadcrumbs-item">
-            <a href={href}>
-              <slot></slot>
-            </a>
-          </li>
-        }
+          </a>
+        </li>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
@@ -16,7 +16,7 @@ export class GcdsBreadcrumbsItem {
   /**
    * Specifies the href of the breadcrumb item.
    */
-  @Prop() href!: string | undefined;
+  @Prop() href?: string | undefined;
 
   /**
    * Defines if the breadcrumb item is the current page or not.
@@ -28,14 +28,17 @@ export class GcdsBreadcrumbsItem {
 
     return (
       <Host>
-        <li class="gcds-breadcrumbs-item">
-          <a
-            href={href}
-            aria-current={isCurrentPage ? 'page' : false}
-          >
+        {isCurrentPage ?
+          <li class="gcds-breadcrumbs-item" aria-current="page">
             <slot></slot>
-          </a>
-        </li>
+          </li>
+        :
+          <li class="gcds-breadcrumbs-item">
+            <a href={href}>
+              <slot></slot>
+            </a>
+          </li>
+        }
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
@@ -1,4 +1,6 @@
 :host .gcds-breadcrumbs {
+  overflow-x: hidden;
+
   ol {
     font-size: var(--gcds-font-sizes-text);
     font-weight: var(--gcds-font-weights-medium);
@@ -6,5 +8,10 @@
     list-style: none;
     margin: 0;
     padding: 0;
+
+    &.has-canada-link gcds-breadcrumbs-item:first-child,
+    &:not(.has-canada-link) ::slotted(:first-child) {
+      margin: 0 0 0 calc(-1 * (var(--gcds-spacing-400) + var(--gcds-spacing-100)));
+    }
   }
 }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
@@ -11,7 +11,7 @@
 
     &.has-canada-link gcds-breadcrumbs-item:first-child,
     &:not(.has-canada-link) ::slotted(:first-child) {
-      margin: 0 0 0 calc(-1 * (var(--gcds-spacing-400) + var(--gcds-spacing-100)));
+      margin: 0 0 0 calc(-1 * var(--gcds-spacing-400));
     }
   }
 }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
@@ -17,6 +17,11 @@ export class GcdsBreadcrumbs {
    */
 
   /**
+   * Sets the title for the current page.
+   */
+  @Prop() currentPageTitle!: string;
+
+  /**
    * Defines if the default canada.ca link should be displayed or not.
    */
   @Prop({ reflect: false, mutable: false }) hideCanadaLink: boolean = false;
@@ -28,7 +33,7 @@ export class GcdsBreadcrumbs {
   }
 
   render() {
-    const { hideCanadaLink, lang } = this;
+    const { currentPageTitle, hideCanadaLink, lang } = this;
 
     return (
       <Host>
@@ -36,7 +41,7 @@ export class GcdsBreadcrumbs {
           aria-label={lang == 'en' ? 'Breadcrumb' : 'Chemin de navigation'}
           class="gcds-breadcrumbs"
         >
-          <ol>
+          <ol class={hideCanadaLink ? '' : 'has-canada-link'}>
             { !hideCanadaLink ?
               <gcds-breadcrumbs-item
                 href={`https://www.canada.ca/${lang == 'en' ? 'en' : 'fr'}.html`}
@@ -46,6 +51,10 @@ export class GcdsBreadcrumbs {
             : null }
 
             <slot></slot>
+
+            { currentPageTitle ?
+              <gcds-breadcrumbs-item is-current-page>{currentPageTitle}</gcds-breadcrumbs-item>
+            : null }
           </ol>
         </nav>
       </Host>

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
@@ -17,11 +17,6 @@ export class GcdsBreadcrumbs {
    */
 
   /**
-   * Sets the title for the current page.
-   */
-  @Prop() currentPageTitle!: string;
-
-  /**
    * Defines if the default canada.ca link should be displayed or not.
    */
   @Prop({ reflect: false, mutable: false }) hideCanadaLink: boolean = false;
@@ -33,7 +28,7 @@ export class GcdsBreadcrumbs {
   }
 
   render() {
-    const { currentPageTitle, hideCanadaLink, lang } = this;
+    const { hideCanadaLink, lang } = this;
 
     return (
       <Host>
@@ -51,10 +46,6 @@ export class GcdsBreadcrumbs {
             : null }
 
             <slot></slot>
-
-            { currentPageTitle ?
-              <gcds-breadcrumbs-item is-current-page>{currentPageTitle}</gcds-breadcrumbs-item>
-            : null }
           </ol>
         </nav>
       </Host>

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
@@ -33,7 +33,7 @@ export class GcdsBreadcrumbs {
     return (
       <Host>
         <nav
-          aria-label={lang == 'en' ? 'Breadcrumb' : 'Fil d\'Ariane'}
+          aria-label={lang == 'en' ? 'Breadcrumb' : 'Chemin de navigation'}
           class="gcds-breadcrumbs"
         >
           <ol>

--- a/packages/web/src/components/gcds-breadcrumbs/readme.md
+++ b/packages/web/src/components/gcds-breadcrumbs/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property            | Attribute         | Description                                                | Type      | Default     |
-| ------------------- | ----------------- | ---------------------------------------------------------- | --------- | ----------- |
-| `href` _(required)_ | `href`            | Specifies the href of the breadcrumb item.                 | `string`  | `undefined` |
-| `isCurrentPage`     | `is-current-page` | Defines if the breadcrumb item is the current page or not. | `boolean` | `false`     |
+| Property        | Attribute         | Description                                                | Type      | Default     |
+| --------------- | ----------------- | ---------------------------------------------------------- | --------- | ----------- |
+| `href`          | `href`            | Specifies the href of the breadcrumb item.                 | `string`  | `undefined` |
+| `isCurrentPage` | `is-current-page` | Defines if the breadcrumb item is the current page or not. | `boolean` | `false`     |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-breadcrumbs/readme.md
+++ b/packages/web/src/components/gcds-breadcrumbs/readme.md
@@ -7,10 +7,9 @@
 
 ## Properties
 
-| Property        | Attribute         | Description                                                | Type      | Default     |
-| --------------- | ----------------- | ---------------------------------------------------------- | --------- | ----------- |
-| `href`          | `href`            | Specifies the href of the breadcrumb item.                 | `string`  | `undefined` |
-| `isCurrentPage` | `is-current-page` | Defines if the breadcrumb item is the current page or not. | `boolean` | `false`     |
+| Property            | Attribute | Description                                | Type     | Default     |
+| ------------------- | --------- | ------------------------------------------ | -------- | ----------- |
+| `href` _(required)_ | `href`    | Specifies the href of the breadcrumb item. | `string` | `undefined` |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.e2e.ts
+++ b/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.e2e.ts
@@ -26,7 +26,7 @@ describe('gcds-breadcrumbs a11y tests', () => {
     await page.setContent(`
       <gcds-breadcrumbs>
         <nav aria-label="Breadcrumb" class="gcds-breadcrumbs">
-          <ol>
+          <ol class="has-canada-link">
             <gcds-breadcrumbs-item href="https://www.canada.ca/en.html">
               Canada.ca
             </gcds-breadcrumbs-item>

--- a/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.spec.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.spec.tsx
@@ -46,7 +46,7 @@ describe('gcds-breadcrumbs', () => {
     expect(page.root).toEqualHtml(`
       <gcds-breadcrumbs lang="fr">
         <mock:shadow-root>
-          <nav aria-label="Fil d\'Ariane" class="gcds-breadcrumbs">
+          <nav aria-label="Chemin de navigation" class="gcds-breadcrumbs">
             <ol>
               <gcds-breadcrumbs-item href="https://www.canada.ca/fr.html">
                 Canada.ca

--- a/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.spec.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.spec.tsx
@@ -17,7 +17,7 @@ describe('gcds-breadcrumbs', () => {
       <gcds-breadcrumbs>
         <mock:shadow-root>
           <nav aria-label="Breadcrumb" class="gcds-breadcrumbs">
-            <ol>
+            <ol class="has-canada-link">
               <gcds-breadcrumbs-item href="https://www.canada.ca/en.html">
                 Canada.ca
               </gcds-breadcrumbs-item>
@@ -47,7 +47,7 @@ describe('gcds-breadcrumbs', () => {
       <gcds-breadcrumbs lang="fr">
         <mock:shadow-root>
           <nav aria-label="Chemin de navigation" class="gcds-breadcrumbs">
-            <ol>
+            <ol class="has-canada-link">
               <gcds-breadcrumbs-item href="https://www.canada.ca/fr.html">
                 Canada.ca
               </gcds-breadcrumbs-item>

--- a/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.spec.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.spec.tsx
@@ -7,7 +7,7 @@ describe('gcds-breadcrumbs', () => {
       components: [GcdsBreadcrumbs],
       html: `
         <gcds-breadcrumbs>
-          <gcds-breadcrumbs-item is-current-page href="/contact">
+          <gcds-breadcrumbs-item href="/contact">
             Contact
           </gcds-breadcrumbs-item>
         </gcds-breadcrumbs>
@@ -25,7 +25,7 @@ describe('gcds-breadcrumbs', () => {
             </ol>
           </nav>
         </mock:shadow-root>
-        <gcds-breadcrumbs-item is-current-page href="/contact">
+        <gcds-breadcrumbs-item href="/contact">
           Contact
         </gcds-breadcrumbs-item>
       </gcds-breadcrumbs>
@@ -37,7 +37,7 @@ describe('gcds-breadcrumbs', () => {
       components: [GcdsBreadcrumbs],
       html: `
         <gcds-breadcrumbs lang="fr">
-          <gcds-breadcrumbs-item is-current-page href="/contact">
+          <gcds-breadcrumbs-item href="/contact">
             Contact
           </gcds-breadcrumbs-item>
         </gcds-breadcrumbs>
@@ -55,7 +55,7 @@ describe('gcds-breadcrumbs', () => {
             </ol>
           </nav>
         </mock:shadow-root>
-        <gcds-breadcrumbs-item is-current-page href="/contact">
+        <gcds-breadcrumbs-item href="/contact">
           Contact
         </gcds-breadcrumbs-item>
       </gcds-breadcrumbs>
@@ -67,7 +67,7 @@ describe('gcds-breadcrumbs', () => {
       components: [GcdsBreadcrumbs],
       html: `
         <gcds-breadcrumbs hide-canada-link>
-          <gcds-breadcrumbs-item is-current-page href="/contact">
+          <gcds-breadcrumbs-item href="/contact">
             Contact
           </gcds-breadcrumbs-item>
         </gcds-breadcrumbs>
@@ -82,7 +82,7 @@ describe('gcds-breadcrumbs', () => {
             </ol>
           </nav>
         </mock:shadow-root>
-        <gcds-breadcrumbs-item is-current-page href="/contact">
+        <gcds-breadcrumbs-item href="/contact">
           Contact
         </gcds-breadcrumbs-item>
       </gcds-breadcrumbs>

--- a/styles/global.css
+++ b/styles/global.css
@@ -41,6 +41,7 @@
   --gcds-spacing-200: 0.43333333333333335rem;
   --gcds-spacing-300: 0.65rem;
   --gcds-spacing-400: 1.3rem;
+  --gcds-spacing-450: 1.8rem;
   --gcds-spacing-500: 2.6rem;
   --gcds-spacing-600: 3.9000000000000004rem;
   --gcds-spacing-700: 5.2rem;


### PR DESCRIPTION
# Summary | Résumé

Improvements to breadcrumbs component:
- Nicholas recommended using `chemin de navigation` for breadcrumbs instead of `fil d'Ariane`. We'll include fil d'Ariane as an option for the `other names` section.
- Removed current page to avoid confusion with users.
