### PR TITLE
fix: update lock file maintenance to once a month

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "schedule": [
+      "before 6am on the first day of the month"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary 
Update the Renovate schedule so lock file maintenance is only performed once a month.

## Related
- cds-snc/platform-core-services#232