### PR TITLE
Update link type style to act more like other types

### DIFF
--- a/packages/web/src/components/gcds-button/gcds-button.css
+++ b/packages/web/src/components/gcds-button/gcds-button.css
@@ -6,6 +6,9 @@
   border: var(--gcds-button-border-width) solid;
   text-decoration: none;
   border-radius: var(--gcds-button-border-radius);
+  display: inline-block;
+  width: fit-content;
+  text-align: center;
   transition: all .15s ease-in-out;
 
   /* Button Role Styles */


### PR DESCRIPTION
# Summary | Résumé

Additional CSS for `gcds-button` to help `type="link"` buttons render the same as other button types.
