### PR TITLE
Gcds-icon font-awesome rendering fix

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "gcds-components",
-  "version": "0.1.17",
+  "name": "@cdssnc/gcds-components",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "gcds-components",
-      "version": "0.1.17",
+      "name": "@cdssnc/gcds-components",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.7.0",
@@ -18,10 +18,12 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
+        "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
         "@stencil/angular-output-target": "^0.4.0",
         "@stencil/postcss": "^2.1.0",
+        "@stencil/sass": "^3.0.0-0",
         "@storybook/addon-actions": "^6.5.16",
         "@storybook/addon-essentials": "^6.5.16",
         "@storybook/addon-interactions": "^6.5.16",
@@ -2190,6 +2192,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.3.0.tgz",
+      "integrity": "sha512-qVtd5i1Cc7cdrqnTWqTObKQHjPWAiRwjUPaXObaeNPcy7+WKxJumGBx66rfSFgK6LNpIasVKkEgW8oyf0tmPLA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -2924,6 +2936,15 @@
       "integrity": "sha512-6d9pPhyajFfdxkqU/pPP2SzI7wn+EklySQc4KXlI/xcdvC2H9BzLmhmR40fR1q2TQoJbJui/nvSWhbYqkE3OBQ==",
       "peerDependencies": {
         "@stencil/core": "^2.9.0"
+      }
+    },
+    "node_modules/@stencil/sass": {
+      "version": "3.0.0-0",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.0-0.tgz",
+      "integrity": "sha512-mAqHxgFLHFYlpBj3xb7Yr73SGqwO/lLaRvScvnVMipjujmiPntpXaNjFQeTUQfnKRpikx8XlffNxbiPfC31Knw==",
+      "dev": true,
+      "peerDependencies": {
+        "@stencil/core": ">=2.0.0 || >=3.0.0-beta.0"
       }
     },
     "node_modules/@storybook/addon-actions": {
@@ -26444,6 +26465,12 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.3.0.tgz",
+      "integrity": "sha512-qVtd5i1Cc7cdrqnTWqTObKQHjPWAiRwjUPaXObaeNPcy7+WKxJumGBx66rfSFgK6LNpIasVKkEgW8oyf0tmPLA==",
+      "dev": true
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -27044,6 +27071,13 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.3.1.tgz",
       "integrity": "sha512-6d9pPhyajFfdxkqU/pPP2SzI7wn+EklySQc4KXlI/xcdvC2H9BzLmhmR40fR1q2TQoJbJui/nvSWhbYqkE3OBQ==",
+      "requires": {}
+    },
+    "@stencil/sass": {
+      "version": "3.0.0-0",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.0-0.tgz",
+      "integrity": "sha512-mAqHxgFLHFYlpBj3xb7Yr73SGqwO/lLaRvScvnVMipjujmiPntpXaNjFQeTUQfnKRpikx8XlffNxbiPfC31Knw==",
+      "dev": true,
       "requires": {}
     },
     "@storybook/addon-actions": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,10 +37,12 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.3.2",
     "@babel/core": "^7.20.12",
+    "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",
     "@stencil/angular-output-target": "^0.4.0",
     "@stencil/postcss": "^2.1.0",
+    "@stencil/sass": "^3.0.0-0",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-interactions": "^6.5.16",

--- a/packages/web/src/components/gcds-icon/gcds-icon.scss
+++ b/packages/web/src/components/gcds-icon/gcds-icon.scss
@@ -1,4 +1,4 @@
-@import url('https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.1/css/all.min.css');
+@use '../../../node_modules/@fortawesome/fontawesome-free/css/all.min.css';
 
 :host .gcds-icon {
   font-family: var(--gcds-icon-font-family);

--- a/packages/web/src/components/gcds-icon/gcds-icon.tsx
+++ b/packages/web/src/components/gcds-icon/gcds-icon.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 
 @Component({
   tag: 'gcds-icon',
-  styleUrl: 'gcds-icon.css',
+  styleUrl: 'gcds-icon.scss',
   shadow: true,
 })
 export class GcdsIcon {

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -1,5 +1,6 @@
 import { Config } from '@stencil/core';
 import { postcss } from '@stencil/postcss';
+import { sass } from '@stencil/sass';
 import { inlineSvg } from 'stencil-inline-svg';
 import { reactOutputTarget as react } from '@stencil/react-output-target';
 import { angularOutputTarget } from '@stencil/angular-output-target';
@@ -37,7 +38,8 @@ export const config: Config = {
         require('cssnano')
       ]
     }),
-    inlineSvg()
+    inlineSvg(),
+    sass()
   ],
   testing: {
     transform: {


### PR DESCRIPTION
# Summary | Résumé

Add `@stencil/sass` to handle importing font-awesome into the `gcds-icon` CSS to solve issue with `@import` being blocked by browsers.
