### PR TITLE
Component improvements + fixes

### DIFF
--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1232,11 +1232,11 @@ declare namespace LocalJSX {
         /**
           * Error message for an invalid form field.
          */
-        "message"?: string;
+        "message": string;
         /**
           * Id attribute for the error message.
          */
-        "messageId"?: string;
+        "messageId": string;
     }
     interface GcdsFieldset {
         /**

--- a/packages/web/src/components/gcds-alert/gcds-alert.tsx
+++ b/packages/web/src/components/gcds-alert/gcds-alert.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, State, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-alert',
@@ -9,9 +9,6 @@ import { assignLanguage } from '../../utils/utils';
 
 export class GcdsAlert {
   @Element() el: HTMLElement;
-
-  private lang: string;
-
 
   /**
    * Props
@@ -62,6 +59,10 @@ export class GcdsAlert {
    */
   @State() isOpen: boolean = true;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
 
   /**
    * Events
@@ -79,9 +80,23 @@ export class GcdsAlert {
     }
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   render() {

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, Prop, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-breadcrumbs',
@@ -8,9 +8,6 @@ import { assignLanguage } from '../../utils/utils';
 })
 export class GcdsBreadcrumbs {
   @Element() el: HTMLElement;
-
-  private lang: string;
-
 
   /**
    * Props
@@ -21,10 +18,28 @@ export class GcdsBreadcrumbs {
    */
   @Prop({ reflect: false, mutable: false }) hideCanadaLink: boolean = false;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
 
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   render() {

--- a/packages/web/src/components/gcds-button/gcds-button.tsx
+++ b/packages/web/src/components/gcds-button/gcds-button.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Method, Host, Watch, Prop, State, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 import { inheritAttributes} from '../../utils/utils';
 
 @Component({
@@ -10,7 +10,6 @@ import { inheritAttributes} from '../../utils/utils';
 export class GcdsButton {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private shadowElement?: HTMLElement;
 
 
@@ -134,6 +133,11 @@ export class GcdsButton {
    */
   @State() inheritedAttributes: Object = {};
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
 
   /**
    * Events
@@ -149,6 +153,18 @@ export class GcdsButton {
     */
   @Event() gcdsBlur!: EventEmitter<void>;
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   componentWillLoad() {
     // Validate attributes and set defaults
     this.validateType(this.type);
@@ -160,6 +176,8 @@ export class GcdsButton {
 
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   /**

--- a/packages/web/src/components/gcds-button/gcds-button.tsx
+++ b/packages/web/src/components/gcds-button/gcds-button.tsx
@@ -183,6 +183,9 @@ export class GcdsButton {
 
           const formButton = document.createElement('button');
           formButton.type = this.type;
+          if (this.name) {
+            formButton.name = this.name;
+          }
           formButton.style.display = 'none';
           form.appendChild(formButton);
           formButton.click();

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -290,7 +290,7 @@ export class GcdsCheckbox {
 
           {hint ? <gcds-hint hint={hint} hint-id={checkboxId} />: null}
 
-          {errorMessage ? <gcds-error-message message-id={checkboxId} message={errorMessage} /> : null}
+          {errorMessage ? <gcds-error-message messageId={checkboxId} message={errorMessage} /> : null}
 
           {parentError ? <span id={`parent-error-${checkboxId}`} hidden>{parentError}</span> : null}
         </div>

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Listen, Method, State, Prop, Watch, Host, h } from '@stencil/core';
-import { assignLanguage, elementGroupCheck, inheritAttributes } from '../../utils/utils';
+import { assignLanguage, elementGroupCheck, inheritAttributes, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 
 @Component({
@@ -11,7 +11,6 @@ import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredVali
 export class GcdsCheckbox {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private shadowElement?: HTMLElement;
 
   _validator: Validator<any> = defaultValidator;
@@ -156,6 +155,10 @@ export class GcdsCheckbox {
     }
   }
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
 
   /**
    * Events
@@ -208,9 +211,23 @@ export class GcdsCheckbox {
     }
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDisabledCheckbox();
     this.validateHasError();

--- a/packages/web/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
+++ b/packages/web/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
@@ -75,7 +75,7 @@ describe('gcds-checkbox', () => {
         <div class="gcds-checkbox gcds-checkbox--error">
            <input aria-describedby=" error-message-checkbox" aria-invalid="true" id="checkbox" name="checkbox" type="checkbox">
            <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
-           <gcds-error-message message="This needs to be checked" message-id="checkbox"></gcds-error-message>
+           <gcds-error-message message="This needs to be checked" messageid="checkbox"></gcds-error-message>
          </div>
       </gcds-checkbox>
     `);

--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-date-modified',
@@ -10,11 +10,28 @@ import { assignLanguage } from '../../utils/utils';
 export class GcdsDateModified {
   @Element() el: HTMLElement;
 
-  private lang: string;
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
 
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   render() {

--- a/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
+++ b/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
@@ -16,12 +16,12 @@ export class GcdsErrorMessage {
   /**
    * Id attribute for the error message.
    */
-  @Prop() messageId: string;
+  @Prop() messageId!: string;
 
   /**
    * Error message for an invalid form field.
    */
-  @Prop() message: string;
+  @Prop() message!: string;
 
   render() {
     const { messageId, message } = this;

--- a/packages/web/src/components/gcds-error-message/readme.md
+++ b/packages/web/src/components/gcds-error-message/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                              | Type     | Default     |
-| ----------- | ------------ | ---------------------------------------- | -------- | ----------- |
-| `message`   | `message`    | Error message for an invalid form field. | `string` | `undefined` |
-| `messageId` | `message-id` | Id attribute for the error message.      | `string` | `undefined` |
+| Property                 | Attribute    | Description                              | Type     | Default     |
+| ------------------------ | ------------ | ---------------------------------------- | -------- | ----------- |
+| `message` _(required)_   | `message`    | Error message for an invalid form field. | `string` | `undefined` |
+| `messageId` _(required)_ | `message-id` | Id attribute for the error message.      | `string` | `undefined` |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -210,7 +210,7 @@ export class GcdsFieldset {
 
           {hint ? <gcds-hint hint={hint} hint-id={fieldsetId} /> : null}
 
-          {errorMessage ? <gcds-error-message message-id={fieldsetId} message={errorMessage} /> : null}
+          {errorMessage ? <gcds-error-message messageId={fieldsetId} message={errorMessage} /> : null}
           <slot></slot>
         </fieldset>
       </Host>

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, Element, Method, Event, EventEmitter, Listen, State, Host, Watch, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 import { validateFieldsetElements } from '../../validators/fieldset-validators/fieldset-validators';
 
@@ -11,7 +11,6 @@ import { validateFieldsetElements } from '../../validators/fieldset-validators/f
 export class GcdsFieldset {
   @Element() el: HTMLElement;
 
-  private lang: string;
 
   _validator: Validator<string> = defaultValidator;
 
@@ -104,6 +103,10 @@ export class GcdsFieldset {
    */
   @State() hasError: boolean;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
 
   /**
    * Events
@@ -159,9 +162,23 @@ export class GcdsFieldset {
     }
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDisabledFieldset();
     this.validateErrorMessage();

--- a/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
+++ b/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
@@ -72,7 +72,7 @@ describe('gcds-fieldset', () => {
             <legend id="legend-field">
               Fieldset legend
             </legend>
-            <gcds-error-message message="Fieldset error" message-id="field"></gcds-error-message>
+            <gcds-error-message message="Fieldset error" messageid="field"></gcds-error-message>
             <slot></slot>
           </fieldset>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Prop, Watch, State, Method, Host, h } from '@stencil/core';
-import { assignLanguage, inheritAttributes } from '../../utils/utils';
+import { assignLanguage, inheritAttributes, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 
 @Component({
@@ -11,7 +11,6 @@ import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredVali
 export class GcdsFileUploader {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private shadowElement?: HTMLElement;
 
   _validator: Validator<any> = defaultValidator;
@@ -131,6 +130,10 @@ export class GcdsFileUploader {
    */
   @State() inheritedAttributes: Object = {};
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
 
   /**
    * Events
@@ -221,9 +224,23 @@ export class GcdsFileUploader {
     }
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDisabledSelect();
     this.validateHasError();

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -281,7 +281,7 @@ export class GcdsFileUploader {
           {hint ? <gcds-hint hint={hint} hint-id={uploaderId} />: null}
 
           {errorMessage ?
-            <gcds-error-message message-id={uploaderId} message={errorMessage} />
+            <gcds-error-message messageId={uploaderId} message={errorMessage} />
           : null}
 
           <div class={`file-uploader__input ${value.length > 0 ? "uploaded-files" : ''}`}>

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -201,8 +201,10 @@ export class GcdsFileUploader {
    */
   @Event() gcdsRemoveFile: EventEmitter;
   removeFile = (e) => {
+    e.preventDefault();
+    
     let filesContainer = this.value;
-    const file = filesContainer.indexOf(e.target.textContent);
+    const file = filesContainer.indexOf(e.target.closest('.file-uploader__uploaded-file').childNodes[0].textContent);
 
     if (file > -1) {
       filesContainer.splice(file, 1);
@@ -336,7 +338,7 @@ export class GcdsFileUploader {
               <span>{file}</span>
               <button onClick={(e) => this.removeFile(e)}>
                 { lang == 'en' ? 'Remove' : 'Supprimer' }
-                <gcds-icon name="times" size="text" margin-left="200" />
+                <gcds-icon name="times" size="text" margin-left="200"></gcds-icon>
               </button>
             </div>
           )) : null }

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -61,7 +61,7 @@ describe('gcds-file-uploader', () => {
       <gcds-file-uploader uploader-id="file-uploader" label="file-uploader" error-message="This is an error message.">
         <div class="gcds-file-uploader-wrapper gcds-error">
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
-          <gcds-error-message message="This is an error message." message-id="file-uploader"></gcds-error-message>
+          <gcds-error-message message="This is an error message." messageid="file-uploader"></gcds-error-message>
           <div class="file-uploader__input">
             <button tabindex="-1">
               Upload a file

--- a/packages/web/src/components/gcds-footer/gcds-footer.tsx
+++ b/packages/web/src/components/gcds-footer/gcds-footer.tsx
@@ -1,5 +1,5 @@
-import { Component, Host, Element, Watch, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Host, Element, Watch, Prop, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 import I18N from './i18n/i18n';
 
 @Component({
@@ -9,9 +9,6 @@ import I18N from './i18n/i18n';
 })
 export class GcdsFooter {
   @Element() el: HTMLElement;
-
-  private lang: string;
-
 
   /**
    * Props
@@ -77,9 +74,28 @@ export class GcdsFooter {
     }
   }
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDisplay;
 

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, Prop, h, State } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 const i18n = {
   "en": {
@@ -17,9 +17,6 @@ const i18n = {
 })
 export class GcdsHeader {
   @Element() el: HTMLElement;
-
-  private lang: string;
-
 
   /**
    * Props
@@ -44,9 +41,28 @@ export class GcdsHeader {
   */
   @Prop({ reflect: false, mutable: false }) skipToHref!: string;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   private get renderTopNav() {

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -28,7 +28,7 @@ export class GcdsHeader {
   /**
   * GcdsLangToggle - The href attribute specifies the URL of the opposite language page
   */
-  @Prop({ reflect: false, mutable: false }) langHref!: string;
+  @Prop({ reflect: true, mutable: false }) langHref!: string;
 
   /**
   * GcdsSignature - The variant of the Government of Canada signature

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, Watch, EventEmitter, State, Method, Host, Prop, h } from '@stencil/core';
-import { assignLanguage, inheritAttributes } from '../../utils/utils';
+import { assignLanguage, inheritAttributes, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 
 @Component({
@@ -11,7 +11,6 @@ import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredVali
 export class GcdsInput {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private shadowElement?: HTMLElement;
 
   _validator: Validator<string> = defaultValidator;
@@ -141,6 +140,11 @@ export class GcdsInput {
     }
   }
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
 
   /**
    * Events
@@ -204,9 +208,23 @@ export class GcdsInput {
     this.gcdsChange.emit(this.value);
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDisabledInput();
     this.validateHasError();

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -270,7 +270,7 @@ export class GcdsInput {
           {hint ? <gcds-hint hint={hint} hint-id={inputId} /> : null}
 
           {errorMessage ?
-            <gcds-error-message message-id={inputId} message={errorMessage} />
+            <gcds-error-message messageId={inputId} message={errorMessage} />
           : null}
 
           <input

--- a/packages/web/src/components/gcds-input/test/gcds-input.spec.ts
+++ b/packages/web/src/components/gcds-input/test/gcds-input.spec.ts
@@ -189,7 +189,7 @@ describe('gcds-input', () => {
       <gcds-input label="Label" input-id="input-with-error" error-message="This is an error message.">
         <div class="gcds-input-wrapper gcds-error">
           <gcds-label label-for="input-with-error" label="Label" lang="en"></gcds-label>
-          <gcds-error-message message-id="input-with-error" message="This is an error message."></gcds-error-message>
+          <gcds-error-message messageid="input-with-error" message="This is an error message."></gcds-error-message>
           <input
             type="text"
             id="input-with-error"

--- a/packages/web/src/components/gcds-label/gcds-label.tsx
+++ b/packages/web/src/components/gcds-label/gcds-label.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, Prop, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-label',
@@ -10,7 +10,6 @@ import { assignLanguage } from '../../utils/utils';
 export class GcdsLabel {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private focusEl?: HTMLElement;
 
 
@@ -38,9 +37,28 @@ export class GcdsLabel {
    */
   @Prop() required?: boolean;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   /**

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
@@ -19,7 +19,7 @@ export class GcdsLangToggle {
   /**
    * The href attribute specifies the URL of the opposite language page
    */
-  @Prop({ reflect: false, mutable: false }) href!: string;
+  @Prop({ reflect: true, mutable: false }) href!: string;
 
   async componentWillLoad() {
     // Define lang attribute

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, Prop, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-lang-toggle',
@@ -8,9 +8,6 @@ import { assignLanguage } from '../../utils/utils';
 })
 export class GcdsLangToggle {
   @Element() el: HTMLElement;
-
-  private lang: string;
-
 
   /**
    * Props
@@ -21,9 +18,28 @@ export class GcdsLangToggle {
    */
   @Prop({ reflect: true, mutable: false }) href!: string;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   render() {

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
@@ -81,6 +81,12 @@ export class GcdsPagination {
   * Language of rendered component
   */
   @State() lang: string;
+  @Watch('lang')
+  watchLang() {
+    if (this.display == "list") {
+      this.configureListPagination();
+    }
+  }
 
   /*
    * Events

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Prop, Event, EventEmitter, State, Watch, Host, h } from '@stencil/core';
 
-import { assignLanguage } from '../../utils/utils';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 import I18N from './i18n/i18n';
 import { constructHref, constructClasses } from './utils/render';
 
@@ -13,7 +13,6 @@ import { constructHref, constructClasses } from './utils/render';
 export class GcdsPagination {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private listitems = [];
   private mobilePrevNext = [];
 
@@ -77,6 +76,11 @@ export class GcdsPagination {
   @Prop() pageChangeHandler: Function;
 
   @State() currentStep: number;
+
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
 
   /*
    * Events
@@ -262,9 +266,23 @@ export class GcdsPagination {
     }
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     if (this.display == "list") {
       this.configureListPagination();

--- a/packages/web/src/components/gcds-radio/gcds-radio.tsx
+++ b/packages/web/src/components/gcds-radio/gcds-radio.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, State, Prop, Listen, Watch, Host, h } from '@stencil/core';
-import { assignLanguage, elementGroupCheck, inheritAttributes } from '../../utils/utils';
+import { assignLanguage, elementGroupCheck, inheritAttributes, observerConfig } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-radio',
@@ -10,7 +10,6 @@ import { assignLanguage, elementGroupCheck, inheritAttributes } from '../../util
 export class GcdsRadio {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private shadowElement?: HTMLInputElement;
 
 
@@ -94,6 +93,12 @@ export class GcdsRadio {
    */
   @State() inheritedAttributes: Object = {};
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+
 
   /**
    * Events
@@ -130,9 +135,23 @@ export class GcdsRadio {
     this.gcdsBlur.emit();
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-describedby']);
   }

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -248,7 +248,7 @@ export class GcdsSelect {
           {hint ? <gcds-hint hint={hint} hint-id={selectId} />: null}
 
           {errorMessage ?
-            <gcds-error-message message-id={selectId} message={errorMessage} />
+            <gcds-error-message messageId={selectId} message={errorMessage} />
           : null}
 
           <select

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Prop, Watch, State, Method, Host, h } from '@stencil/core';
-import { assignLanguage, inheritAttributes } from '../../utils/utils';
+import { assignLanguage, inheritAttributes, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 
 @Component({
@@ -11,7 +11,6 @@ import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredVali
 export class GcdsSelect {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private shadowElement?: HTMLElement;
 
   _validator: Validator<string> = defaultValidator;
@@ -126,6 +125,11 @@ export class GcdsSelect {
    */
   @State() inheritedAttributes: Object = {};
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
 
   /**
    * Events
@@ -189,9 +193,23 @@ export class GcdsSelect {
     this.gcdsSelectChange.emit(this.value);
   };
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDisabledSelect();
     this.validateHasError();

--- a/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
+++ b/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
@@ -49,7 +49,7 @@ describe('gcds-select', () => {
       <gcds-select select-id="select" label="select" error-message="This is an error message.">
         <div class="gcds-select-wrapper gcds-error">
           <gcds-label label="select" label-for="select" lang="en"></gcds-label>
-          <gcds-error-message message="This is an error message." message-id="select"></gcds-error-message>
+          <gcds-error-message message="This is an error message." messageid="select"></gcds-error-message>
           <select id="select" name="select" aria-invalid="true" aria-describedby=" error-message-select">
           </select>
         </div>

--- a/packages/web/src/components/gcds-signature/gcds-signature.tsx
+++ b/packages/web/src/components/gcds-signature/gcds-signature.tsx
@@ -1,5 +1,5 @@
-import { Component, Host, Element, Watch, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Host, Element, Watch, State, Prop, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 import SignatureEn from './assets/sig-blk-en.svg';
 import SignatureFr from './assets/sig-blk-fr.svg';
@@ -12,9 +12,6 @@ import WordmarkFr from './assets/wmms-spl-fr.svg';
 })
 export class GcdsSignature {
   @Element() el: HTMLElement;
-
-  private lang: string;
-
 
   /**
    * Props
@@ -49,12 +46,31 @@ export class GcdsSignature {
   */
   @Prop({ mutable: true }) hasLink: boolean;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
 
     this.validateType;
     this.validateVariant;
+
+    this.updateLang();
   }
 
   private get selectSVG() {

--- a/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
+++ b/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
@@ -66,6 +66,21 @@ export class GcdsSiteMenu {
   * Language of rendered component
   */
   @State() lang: string;
+  @Watch('lang')
+  watchLang() {
+    // Update text in submenu triggers
+    this.el.shadowRoot.querySelectorAll('span[data-h2-submenu-trigger-accessibility-text]').forEach((span) => {
+      var spanText = span.parentNode.parentNode.querySelector('span').textContent;
+      span.innerHTML = I18N[this.lang].submenuButtonText.replace('{$t}', spanText.trim());
+    });
+
+    // Update text in back buttons in sidebar
+    if (this.desktopLayout == "sidebar") {
+      this.el.shadowRoot.querySelectorAll('button[data-back-button]').forEach((button) => {
+        button.innerHTML = I18N[this.lang].back;
+      });
+    }
+  }
 
   /**
    * Method to apply multiple attributes to an element

--- a/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
+++ b/packages/web/src/components/gcds-site-menu/gcds-site-menu.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, Prop, Watch, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, Prop, Watch, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 import {
   h2MenuAddUpDownArrowsToMainMenuItems,
@@ -21,7 +21,6 @@ import I18N from './i18n/i18n';
 export class GcdsSiteMenu {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private submenu = 0;
 
 
@@ -62,6 +61,11 @@ export class GcdsSiteMenu {
    * Sticky navigation flag
    */
   @Prop() position: 'static' | 'sticky' = 'static';
+
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
 
   /**
    * Method to apply multiple attributes to an element
@@ -209,9 +213,23 @@ export class GcdsSiteMenu {
     }
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDesktopLayout(this.desktopLayout);
     this.validateMobileLayout(this.mobileLayout);

--- a/packages/web/src/components/gcds-stepper/gcds-stepper.tsx
+++ b/packages/web/src/components/gcds-stepper/gcds-stepper.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, Prop, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-stepper',
@@ -8,8 +8,6 @@ import { assignLanguage } from '../../utils/utils';
 })
 export class GcdsStepper {
   @Element() el: HTMLElement;
-
-  private lang: string;
 
 
   /**
@@ -26,9 +24,28 @@ export class GcdsStepper {
    */
   @Prop() totalSteps!: number;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   render() {

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, Method, Watch, EventEmitter, Host, State, Prop, h } from '@stencil/core';
-import { assignLanguage, inheritAttributes } from '../../utils/utils';
+import { assignLanguage, inheritAttributes, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 
 @Component({
@@ -11,7 +11,6 @@ import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredVali
 export class GcdsTextarea {
   @Element() el: HTMLElement;
 
-  private lang: string;
   private shadowElement?: HTMLElement;
 
   _validator: Validator<string> = defaultValidator;
@@ -140,6 +139,11 @@ export class GcdsTextarea {
     }
   }
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
 
   /**
    * Events
@@ -203,9 +207,23 @@ export class GcdsTextarea {
     this.gcdsChange.emit(this.value);
   }
 
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
 
     this.validateDisabledTextarea();
     this.validateHasError();

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -269,7 +269,7 @@ export class GcdsTextarea {
           {hint ? <gcds-hint hint={hint} hint-id={textareaId} /> : null}
 
           {errorMessage ?
-            <gcds-error-message message-id={textareaId} message={errorMessage} />
+            <gcds-error-message messageId={textareaId} message={errorMessage} />
           : null}
 
           <textarea

--- a/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
+++ b/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
@@ -111,7 +111,7 @@ describe('gcds-textarea', () => {
       <gcds-textarea label="Label" textarea-id="textarea-with-error" error-message="This is an error message.">
         <div class="gcds-textarea-wrapper gcds-error">
           <gcds-label label-for="textarea-with-error" label="Label" lang="en"></gcds-label>
-          <gcds-error-message message-id="textarea-with-error" message="This is an error message."></gcds-error-message>
+          <gcds-error-message messageid="textarea-with-error" message="This is an error message."></gcds-error-message>
           <textarea
             id="textarea-with-error"
             class="gcds-error"

--- a/packages/web/src/components/gcds-verify-banner/gcds-verify-banner.tsx
+++ b/packages/web/src/components/gcds-verify-banner/gcds-verify-banner.tsx
@@ -1,5 +1,5 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
-import { assignLanguage } from '../../utils/utils';
+import { Component, Element, Host, Prop, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
 
 import CanadaFlag from './assets/canada-flag.svg';
 import ContentToggleArrow from './assets/content-toggle-arrow.svg';
@@ -12,8 +12,6 @@ import Lock from './assets/lock.svg';
 })
 export class GcdsVerifyBanner {
   @Element() el: HTMLElement;
-
-  private lang: string;
 
 
   /**
@@ -30,9 +28,28 @@ export class GcdsVerifyBanner {
    */
   @Prop() isFixed?: boolean = false;
 
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
+
+    this.updateLang();
   }
 
   render() {

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -96,8 +96,6 @@
 
       <h2>Components</h2>
 
-      <gcds-error-message message-id="red" message="hello"></gcds-error-message>
-
       <!-- ------------- Alerts ------------- -->
 
       <h3 class="mt-500 mb-400 bb-1">Alerts</h3>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -96,6 +96,8 @@
 
       <h2>Components</h2>
 
+      <gcds-error-message message-id="red" message="hello"></gcds-error-message>
+
       <!-- ------------- Alerts ------------- -->
 
       <h3 class="mt-500 mb-400 bb-1">Alerts</h3>

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -34,6 +34,13 @@ export const assignLanguage = (el: HTMLElement) => {
 
   return lang;
 }
+
+export const observerConfig = {
+    attributes: true,
+    attributeOldValue: true,
+    attributeFilter: ['lang']
+  };
+
  // For validation - check if element has a checked checkbox/radio sibling
 export const elementGroupCheck = (name) => {
   let hasCheck = false;

--- a/packages/web/src/validators/fieldset-validators/fieldset-validators.ts
+++ b/packages/web/src/validators/fieldset-validators/fieldset-validators.ts
@@ -57,11 +57,8 @@ export function validateFieldsetElements(element, nodeList) {
             case('GCDS-INPUT'):
             case('GCDS-TEXTAREA'):
             case('GCDS-SELECT'):
-            if (nodeList[i].value.trim() != "") {
-                isValid.push(true);
-            } else {
-                isValid.push(false);
-            }
+            case('GCDS-FILE-UPLOADER'):
+                // Do nothing for now
                 break;
         }
     }


### PR DESCRIPTION
# Summary | Résumé

Apply bug fixes and improvements based on feedback from other teams.

## Bug fixes
- `gcds-button` will now include `name` property when using `type="submit"`
- `gcds-file-uploader` can remove files again. Was trying to remove `Remove` file when remove button was clicked
- Change the required validator for `gcds-fieldset` to now ignore any component but radio/checkbox. Was crashing in React when trying to validate a group of non radio/checkbox inputs

## Improvements
- All `gcds-components` with built in bilingual text will now re-render when `lang` attribute changes. Still only accepts `en` or `fr`.
  - Switched `lang` in components from private property to State and added a private Method, `updateLang()`, to watch for changes.
  - `gcds-pagination` and `gcds-site-menu` needed an additional Watch function to swap languages since they have a more complicated rendering.


**Note**: Tokens for `gcds-site-menu` will need to be adjusted, will do that in another pull request. Submenus appear with dark grey background colour, making ti hard to read. 
