### PR TITLE
Add responsive sizing to gcds-grid

### DIFF
--- a/packages/web/src/components/gcds-grid/gcds-grid.css
+++ b/packages/web/src/components/gcds-grid/gcds-grid.css
@@ -1,6 +1,7 @@
 :host .gcds-grid {
   margin: 0;
   padding: 0;
+  grid-template-columns: var(--gcds-grid-columns, 1fr);
 
   &[class*='container'] {
     width: var(--gcds-grid-container-full);
@@ -239,5 +240,16 @@
 
   &.place-items-stretch {
     place-items: stretch;
+  }
+}
+
+@media screen and (min-width: 48em) {
+  :host .gcds-grid {
+    grid-template-columns: var(--gcds-grid-columns-tablet, var(--gcds-grid-columns, 1fr));
+  }
+}
+@media screen and (min-width: 64em) {
+  :host .gcds-grid {
+    grid-template-columns: var(--gcds-grid-columns-desktop, var(--gcds-grid-columns-tablet, var(--gcds-grid-columns, 1fr)));
   }
 }

--- a/packages/web/src/components/gcds-grid/gcds-grid.tsx
+++ b/packages/web/src/components/gcds-grid/gcds-grid.tsx
@@ -79,6 +79,7 @@ export class GcdsGrid {
 
     const Tag = tag;
 
+    // Set CSS variables in style attribute based on passed column properties
     function handleColumns() {
       let responsiveColumns = {};
 

--- a/packages/web/src/components/gcds-grid/gcds-grid.tsx
+++ b/packages/web/src/components/gcds-grid/gcds-grid.tsx
@@ -79,18 +79,20 @@ export class GcdsGrid {
 
     const Tag = tag;
 
-    // Set gridTemplateColumns based on screen size
-    const mediaQueryDesktop = window.matchMedia('(min-width: 991px)');
-    const mediaQueryTablet = window.matchMedia('(min-width: 768px)');
-
     function handleColumns() {
-      if (columnsDesktop && mediaQueryDesktop.matches) {
-        return {gridTemplateColumns: columnsDesktop}
-      } else if (columnsTablet && mediaQueryTablet.matches) {
-        return {gridTemplateColumns: columnsTablet}
-      } else {
-        return {gridTemplateColumns: columns}
+      let responsiveColumns = {};
+
+      if (columnsDesktop) {
+        responsiveColumns["--gcds-grid-columns-desktop"] = columnsDesktop;
       }
+      if (columnsTablet) {
+        responsiveColumns["--gcds-grid-columns-tablet"] = columnsTablet;
+      }
+      if (columns) {
+        responsiveColumns["--gcds-grid-columns"] = columns
+      }
+
+      return responsiveColumns;
     }
 
     return (

--- a/packages/web/src/components/gcds-grid/test/gcds-grid.spec.ts
+++ b/packages/web/src/components/gcds-grid/test/gcds-grid.spec.ts
@@ -2,7 +2,41 @@ import { newSpecPage } from '@stencil/core/testing';
 import { GcdsGrid} from '../gcds-grid';
 
 describe('gcds-grid', () => {
-  it('renders', async () => {
+  it('renders - desktop, tablet and mobile', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsGrid],
+      html: `
+        <gcds-grid columns-desktop="1fr 1fr 1fr 1fr" columns-tablet="1fr 1fr 1fr" columns="1fr 1fr" tag="ul" />
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-grid columns-desktop="1fr 1fr 1fr 1fr" columns-tablet="1fr 1fr 1fr" columns="1fr 1fr" tag="ul">
+        <mock:shadow-root>
+          <ul class="container-full display-grid gcds-grid" style="--gcds-grid-columns-desktop: 1fr 1fr 1fr 1fr; --gcds-grid-columns-tablet: 1fr 1fr 1fr; --gcds-grid-columns: 1fr 1fr;">
+            <slot></slot>
+          </ul>
+        </mock:shadow-root>
+      </gcds-grid>
+    `);
+  });
+  it('renders - tablet and mobile', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsGrid],
+      html: `
+        <gcds-grid columns-tablet="1fr 1fr 1fr" columns="1fr 1fr" tag="ul" />
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-grid columns-tablet="1fr 1fr 1fr" columns="1fr 1fr" tag="ul">
+        <mock:shadow-root>
+          <ul class="container-full display-grid gcds-grid" style="--gcds-grid-columns-tablet: 1fr 1fr 1fr; --gcds-grid-columns: 1fr 1fr;">
+            <slot></slot>
+          </ul>
+        </mock:shadow-root>
+      </gcds-grid>
+    `);
+  });
+  it('renders - mobile', async () => {
     const { root } = await newSpecPage({
       components: [GcdsGrid],
       html: `
@@ -12,7 +46,24 @@ describe('gcds-grid', () => {
     expect(root).toEqualHtml(`
       <gcds-grid columns="1fr 1fr" tag="ul">
         <mock:shadow-root>
-          <ul class="container-full display-grid gcds-grid" style="grid-template-columns: 1fr 1fr;">
+          <ul class="container-full display-grid gcds-grid" style="--gcds-grid-columns: 1fr 1fr;">
+            <slot></slot>
+          </ul>
+        </mock:shadow-root>
+      </gcds-grid>
+    `);
+  });
+  it('renders - no columns passed', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsGrid],
+      html: `
+        <gcds-grid tag="ul" />
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-grid tag="ul">
+        <mock:shadow-root>
+          <ul class="container-full display-grid gcds-grid" style>
             <slot></slot>
           </ul>
         </mock:shadow-root>


### PR DESCRIPTION
# Summary | Résumé

Remove `matchMedia` and switch to using inline css variables to enable responsive sizing with `gcds-grid`.
