### PR TITLE
Update inheritAttributes function in form components

### DIFF
--- a/packages/web/src/components/gcds-button/gcds-button.tsx
+++ b/packages/web/src/components/gcds-button/gcds-button.tsx
@@ -172,7 +172,7 @@ export class GcdsButton {
     this.validateButtonStyle(this.buttonStyle);
     this.validateSize(this.size);
 
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-label', 'aria-expanded', 'aria-haspopup', 'aria-controls']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
 
     // Define lang attribute
     this.lang = assignLanguage(this.el);
@@ -213,7 +213,7 @@ export class GcdsButton {
     }
 
     // Has any inherited attributes changed on click
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-label', 'aria-expanded', 'aria-haspopup', 'aria-controls']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
   }
 
   private onFocus = (e) => {

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -241,7 +241,7 @@ export class GcdsCheckbox {
       this._validator = getValidator(this.validator);
     }
 
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-describedby']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
   }
 
   componentWillUpdate() {

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -138,7 +138,6 @@ export class GcdsFieldset {
 
   @Listen('gcdsBlur')
   blurValidate() {
-    console.log("red")
     if (this.validator && this.validateOn == "blur" && !this.el.matches(':focus-within')) {
       this.validate();
     }

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -138,6 +138,7 @@ export class GcdsFieldset {
 
   @Listen('gcdsBlur')
   blurValidate() {
+    console.log("red")
     if (this.validator && this.validateOn == "blur" && !this.el.matches(':focus-within')) {
       this.validate();
     }

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -256,7 +256,7 @@ export class GcdsFileUploader {
       this._validator = getValidator(this.validator);
     }
 
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-describedby']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
   }
 
   componentWillUpdate() {

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -238,7 +238,7 @@ export class GcdsInput {
       this._validator = getValidator(this.validator);
     }
 
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-describedby', 'placeholder']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['placeholder']);
   }
 
   componentWillUpdate() {

--- a/packages/web/src/components/gcds-radio/gcds-radio.tsx
+++ b/packages/web/src/components/gcds-radio/gcds-radio.tsx
@@ -153,7 +153,7 @@ export class GcdsRadio {
 
     this.updateLang();
 
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-describedby']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
   }
 
   private onChange = (name) => {

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -223,7 +223,7 @@ export class GcdsSelect {
       this._validator = getValidator(this.validator);
     }
 
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-describedby']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
   }
 
   componentWillUpdate() {

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -238,7 +238,7 @@ export class GcdsTextarea {
       this._validator = getValidator(this.validator);
     }
 
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['aria-describedby', 'placeholder']);
+    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement, ['placeholder']);
   }
 
   componentWillUpdate() {

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -5,7 +5,7 @@ export function format(label: string): string {
 export const inheritAttributes = (el: HTMLElement, shadowElement: HTMLElement, attributes: string[] = []) => {
   const attributeObject = {};
 
-  // Chech for any aria or data attributes
+  // Check for any aria or data attributes
   for (let i = 0; i < el.attributes.length; i++) {
     let attr = el.attributes[i];
     if (attr.name.includes("aria-") || attr.name.includes("data-")) {

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -5,6 +5,16 @@ export function format(label: string): string {
 export const inheritAttributes = (el: HTMLElement, shadowElement: HTMLElement, attributes: string[] = []) => {
   const attributeObject = {};
 
+  // Chech for any aria or data attributes
+  for (let i = 0; i < el.attributes.length; i++) {
+    let attr = el.attributes[i];
+    if (attr.name.includes("aria-") || attr.name.includes("data-")) {
+      attributeObject[attr.name] = attr.value;
+      el.removeAttribute(attr.name);
+    }
+  }
+
+  // Check for attributes defined by component
   attributes.forEach(attr => {
     if (el.hasAttribute(attr) || (shadowElement && shadowElement.hasAttribute(attr))) {
       const value = el.getAttribute(attr) || shadowElement.getAttribute(attr);


### PR DESCRIPTION
# Summary | Résumé

Update `inheritAttributes` function to look for aria and data attributes by default.

## Use

- `hostElement`: web component
- `targetElement`: html element in web component to inherit attributes
- `attributes`: Additional attributes, not aria or data, to inherit

``` js
this.inheritedAttributes =  inheritAttributes( hostElement, targetElement, [attributes] );
```
