### PR TITLE
Add button full-width sizing when on mobile

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
-        "@cdssnc/gcds-tokens": "^1.0.3",
+        "@cdssnc/gcds-tokens": "^1.0.4",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -2053,9 +2053,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.3.tgz",
-      "integrity": "sha512-Tr0eMKYIOajtkEYntEQEXjTkmHuN91ByyotcguUUBmFbKbcJWP8XohExjy6iXi+EcHRNFq21GSqixfoS8a9z2Q==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.4.tgz",
+      "integrity": "sha512-qshRALgxjoHxG8DQAMh03+EUFzuxWOJw1X2kxBK373vWwxfsyKDT61zGb7m85X2H+9hvsq8lzeq4ihcJkpU2xw==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -26350,9 +26350,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.3.tgz",
-      "integrity": "sha512-Tr0eMKYIOajtkEYntEQEXjTkmHuN91ByyotcguUUBmFbKbcJWP8XohExjy6iXi+EcHRNFq21GSqixfoS8a9z2Q==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.4.tgz",
+      "integrity": "sha512-qshRALgxjoHxG8DQAMh03+EUFzuxWOJw1X2kxBK373vWwxfsyKDT61zGb7m85X2H+9hvsq8lzeq4ihcJkpU2xw==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.3.2",
     "@babel/core": "^7.20.12",
-    "@cdssnc/gcds-tokens": "^1.0.3",
+    "@cdssnc/gcds-tokens": "^1.0.4",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/src/components/gcds-button/gcds-button.css
+++ b/packages/web/src/components/gcds-button/gcds-button.css
@@ -6,8 +6,9 @@
   border: var(--gcds-button-border-width) solid transparent;
   text-decoration: none;
   border-radius: var(--gcds-button-border-radius);
+  box-sizing: border-box;
   display: inline-block;
-  width: fit-content;
+  width: var(--gcds-button-width);
   text-align: center;
   transition: all .15s ease-in-out;
 
@@ -125,5 +126,13 @@
   &.button--small {
     font: var(--gcds-button-small-font);
     padding: var(--gcds-button-small-padding);
+  }
+}
+
+@media screen and (max-width: 30rem) {
+  :host button:not(.button--text-only),
+  :host a:not(.button--text-only) {
+    width: var(--gcds-button-mobile-width);
+    margin: var(--gcds-button-mobile-margin);
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Add new component tokens to support full-width sizing on mobile.

Uses tokens from https://github.com/cds-snc/gcds-tokens/pull/106. Token Pr will have to merged first, and new package version added to this PR. (Merged)