### PR TITLE
V0.9.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "0.9.3"
+  "version": "0.9.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3648,9 +3648,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.3.tgz",
-      "integrity": "sha512-Tr0eMKYIOajtkEYntEQEXjTkmHuN91ByyotcguUUBmFbKbcJWP8XohExjy6iXi+EcHRNFq21GSqixfoS8a9z2Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.5.tgz",
+      "integrity": "sha512-ardl8/QcYLSYj6IH5G6MpRhSJ7AHS4Tiz9VIKg+syeKA/0P2TNnP+w4lwADw52CT5VasM1Owsf3Y8rH1KqH02Q==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -37682,7 +37682,7 @@
     },
     "packages/angular": {
       "name": "@cdssnc/gcds-components-angular",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -37690,15 +37690,15 @@
       "peerDependencies": {
         "@angular/common": "^14.2.0",
         "@angular/core": "^14.2.0",
-        "@cdssnc/gcds-components": "^0.9.2"
+        "@cdssnc/gcds-components": "^0.9.3"
       }
     },
     "packages/react": {
       "name": "@cdssnc/gcds-components-react",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
-        "@cdssnc/gcds-components": "^0.9.3"
+        "@cdssnc/gcds-components": "^0.9.4"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",
@@ -37723,7 +37723,7 @@
     },
     "packages/web": {
       "name": "@cdssnc/gcds-components",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.7.0",
@@ -37735,7 +37735,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
-        "@cdssnc/gcds-tokens": "^1.0.3",
+        "@cdssnc/gcds-tokens": "^1.0.5",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -40306,7 +40306,7 @@
       "requires": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
-        "@cdssnc/gcds-tokens": "^1.0.3",
+        "@cdssnc/gcds-tokens": "^1.0.5",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -40378,7 +40378,7 @@
     "@cdssnc/gcds-components-react": {
       "version": "file:packages/react",
       "requires": {
-        "@cdssnc/gcds-components": "^0.9.3",
+        "@cdssnc/gcds-components": "^0.9.4",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "react": "^18.2.0",
@@ -40395,9 +40395,9 @@
       }
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.3.tgz",
-      "integrity": "sha512-Tr0eMKYIOajtkEYntEQEXjTkmHuN91ByyotcguUUBmFbKbcJWP8XohExjy6iXi+EcHRNFq21GSqixfoS8a9z2Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.0.5.tgz",
+      "integrity": "sha512-ardl8/QcYLSYj6IH5G6MpRhSJ7AHS4Tiz9VIKg+syeKA/0P2TNnP+w4lwADw52CT5VasM1Owsf3Y8rH1KqH02Q==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,5 @@
     "typescript": "~4.7.2",
     "workbox-build": "^4.3.1"
   },
-  "license": "MIT",
-  "workspaces": [
-    "packages/web",
-    "packages/react",
-    "packages/angular"
-  ]
+  "license": "MIT"
 }

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-angular",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Angular wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "@angular/common": "^14.2.0",
     "@angular/core": "^14.2.0",
-    "@cdssnc/gcds-components": "^0.9.3"
+    "@cdssnc/gcds-components": "^0.9.4"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/angular/src/lib/gcds-components.module.ts
+++ b/packages/angular/src/lib/gcds-components.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 
 import { DIRECTIVES } from './stencil-generated';
 
-import { defineCustomElements } from 'gcds-components/loader';
+import { defineCustomElements } from '@cdssnc/gcds-components/loader';
 
 defineCustomElements(window);
 

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-react",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
-        "@cdssnc/gcds-components": "^0.9.3"
+        "@cdssnc/gcds-components": "^0.9.4"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "React wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -29,7 +29,7 @@
     "gcds.css"
   ],
   "dependencies": {
-    "@cdssnc/gcds-components": "^0.9.3"
+    "@cdssnc/gcds-components": "^0.9.4"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.7.0",
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
-        "@cdssnc/gcds-tokens": "^1.0.4",
+        "@cdssnc/gcds-tokens": "^1.0.5",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Web components for the GCDS",
   "homepage": "https://design-system.alpha.canada.ca/",


### PR DESCRIPTION
# Summary | Résumé

Update `@cdsnc/gcds-components`, `@cdsnc/gcds-components-react` amd `@cdsnc/gcds-components-angular` to `v0.9.4`.

## Changes

- [Breadcrumbs / Details style update](https://github.com/cds-snc/gcds-components/pull/137)
  - Update link styles in the `gcds-breadcrumbs` and `gcds-details` components
- [Modify form components aria-describedby for better a11y](https://github.com/cds-snc/gcds-components/pull/135)
  - Change the way `aria-describedby` is rendered to avoid instances like `aria-describedby=" error-message"`
- [Add button full-width sizing when on mobile](https://github.com/cds-snc/gcds-components/pull/134)
  - `gcds-button` will now go full width once under `480px/30rem` screen size.
  - Buttons with `button-style="text-only"` will not go full width
- [Fix mobile trigger in gcds-site-menu](https://github.com/cds-snc/gcds-components/pull/132)
  - Fix bug with data attributes on mobile trigger menu button in `gcds-site-menu`

**Note**: Already published package