### PR TITLE
Fix: Hide chevron on first breadcrumb item

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
-        "@cdssnc/gcds-tokens": "^1.1.0",
+        "@cdssnc/gcds-tokens": "^1.1.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -1923,9 +1923,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.1.0.tgz",
-      "integrity": "sha512-ZFsMqJSjnha7JDllLDC/RiFhCSBcQS9yxExNwSV5xnv9IFB42fdmRy6hEuVnuGw3cT0tti/GLhKDeGsXKuAuyQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.1.1.tgz",
+      "integrity": "sha512-hkryLHgV/s50uOdc846568OZ9yC45DqQRja5NGuIrfdnE4lnL7nZbhSjvhGYLRtYx3e6oicYYoXxCMjLTsTZGw==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -27832,9 +27832,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.1.0.tgz",
-      "integrity": "sha512-ZFsMqJSjnha7JDllLDC/RiFhCSBcQS9yxExNwSV5xnv9IFB42fdmRy6hEuVnuGw3cT0tti/GLhKDeGsXKuAuyQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.1.1.tgz",
+      "integrity": "sha512-hkryLHgV/s50uOdc846568OZ9yC45DqQRja5NGuIrfdnE4lnL7nZbhSjvhGYLRtYx3e6oicYYoXxCMjLTsTZGw==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.3.2",
     "@babel/core": "^7.20.12",
-    "@cdssnc/gcds-tokens": "^1.1.0",
+    "@cdssnc/gcds-tokens": "^1.1.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -8,7 +8,7 @@
       position: absolute;
       top: var(--gcds-breadcrumbs-item-arrow-top);
       left: var(--gcds-breadcrumbs-item-arrow-left);
-      content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='0.4rem' height='0.8rem' viewBox='0 0 8 14'><path fill='26374a' d='M7.7,6.3c0.4,0.4,0.4,1,0,1.4l-6,6c-0.4,0.4-1,0.4-1.4,0s-0.4-1,0-1.4L5.6,7L0.3,1.7c-0.4-0.4-0.4-1,0-1.4s1-0.4,1.4,0 L7.7,6.3L7.7,6.3z'/></svg>");
+      content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='12px' viewBox='0 0 8 14'><path fill='26374a' d='M7.7,6.3c0.4,0.4,0.4,1,0,1.4l-6,6c-0.4,0.4-1,0.4-1.4,0s-0.4-1,0-1.4L5.6,7L0.3,1.7c-0.4-0.4-0.4-1,0-1.4s1-0.4,1.4,0 L7.7,6.3L7.7,6.3z'/></svg>");
     }
 
     a {

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
@@ -2,8 +2,9 @@
   ol {
     font: var(--gcds-breadcrumbs-font);
     list-style: none;
-    margin: 0;
-    padding: 0;
+    overflow-x: hidden;
+    margin: var(--gcds-breadcrumbs-margin);
+    padding: var(--gcds-breadcrumbs-padding);
 
     &.has-canada-link gcds-breadcrumbs-item:first-child,
     &:not(.has-canada-link) ::slotted(:first-child) {


### PR DESCRIPTION
# Summary | Résumé

Add additional CSS and tokens to fix display issue when `gcds-breadcrumbs` is using `hide-canada-link`.

Fixes #152 

**Note: Relies on tokens from https://github.com/cds-snc/gcds-tokens/pull/114**
