### PR TITLE
remove boxshadow from focus state to support a line break

### DIFF
--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
@@ -58,7 +58,7 @@
           background-color: var(--gcds-error-summary-focus-link-background-color);
           color: var(--gcds-error-summary-focus-link-text);
           text-decoration: none;
-          box-shadow: var(--gcds-error-summary-focus-link-box-shadow);
+          box-shadow: none;
           outline-offset: var(--gcds-error-summary-focus-link-outline-offset);
           outline: var(--gcds-error-summary-focus-link-outline);
         }


### PR DESCRIPTION
## This PR consists of the following

### Removing box-shadow on error links 
- Noticing that some error messages will probably be long enough in some cases to force a line break and looks bad with the box-shadow. 
- The box-shadow needs to be removed from the focus style to account for this (and the error summary should be used on a white background anyway so removing it won't really matter)

| Before | After |
|--------|-------|
|   <img width="726" alt="Screen Shot 2023-05-01 at 20 22 51" src="https://user-images.githubusercontent.com/30609058/235554366-a3b00025-2a32-4a33-bf77-f26f4d501215.png"> |  <img width="724" alt="Screen Shot 2023-05-01 at 20 23 10" src="https://user-images.githubusercontent.com/30609058/235554381-e876f215-d1a0-4b65-bb95-e4d8e9e8436f.png"> |


