### PR TITLE
V0.10.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,10 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
-  "useWorkspaces": true,
-  "version": "0.9.4"
+  "version": "0.9.4",
+  "packages": [
+    "packages/web",
+    "packages/react",
+    "packages/angular"
+  ]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
-  "version": "0.9.4",
+  "version": "0.10.0",
   "packages": [
     "packages/web",
     "packages/react",

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-angular",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Angular wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@cdssnc/gcds-components": "^0.9.4"
+    "@cdssnc/gcds-components": "^0.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-react",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@cdssnc/gcds-components": "^0.9.4"
+        "@cdssnc/gcds-components": "^0.10.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "React wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -29,7 +29,7 @@
     "gcds.css"
   ],
   "dependencies": {
-    "@cdssnc/gcds-components": "^0.9.4"
+    "@cdssnc/gcds-components": "^0.10.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,7 @@
   },
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "directories": {
     "lib": "lib"
   },

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.7.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Web components for the GCDS",
   "homepage": "https://design-system.alpha.canada.ca/",


### PR DESCRIPTION
# v0.10.0

## New features
- Error summary component
  - New `gcds-error-summary` component for form validation on submit.
- Angular v15 update
  - Update `@cdssnc/gcds-components-angular` to use Angular v15. Package will no longer work with Angular v14.
## Minor

  - [#144](https://github.com/cds-snc/gcds-components/pull/144) [`d88d5f2`](https://github.com/cds-snc/gcds-components/commit/d88d5f21e82dfb55b14aba6c0a98da03c17833e1) Add `gcds-error-summary` to component library
  - [#149](https://github.com/cds-snc/gcds-components/pull/149) [`a531b14`](https://github.com/cds-snc/gcds-components/commit/a531b14050a2cce28fa6300a0551e2335962fabc) Update `@cdssnc/gcds-components-angular` to use Angular v15
 
## Patch
  - [#145](https://github.com/cds-snc/gcds-components/pull/145) [`dde9f87`](https://github.com/cds-snc/gcds-components/commit/dde9f870c8afbdab2251162e4f9fd32a296ac1ef) Add missing "About this site" heading to gcds-footer
  - [#150](https://github.com/cds-snc/gcds-components/pull/150) [`6e828bc`](https://github.com/cds-snc/gcds-components/commit/6e828bc7f15db7117992d1f0a97e5aff74070447) States and styles of `gcds-lang-toggle` and `gcds-button` have been updated to be consistent with Figma library
  - [#153](https://github.com/cds-snc/gcds-components/pull/153) [`68aab03`](https://github.com/cds-snc/gcds-components/commit/68aab03311405d24e32e235eec4f548540e8250e) Fix display issue showing an extra chevron when using hide-canada-link attribute in gcds-breadcrumbs
  - [#154](https://github.com/cds-snc/gcds-components/pull/154) [`dcbd5ab`](https://github.com/cds-snc/gcds-components/commit/dcbd5aba8125003912f172c64af09cf3434f6779) Change gcds-fieldset to no longer use shadowDom to match other form components



