### PR TITLE
add value to error summary links in storybook story

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "packages": [
     "packages/web",
     "packages/react",

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-angular",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Angular wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@cdssnc/gcds-components": "^0.10.1"
+    "@cdssnc/gcds-components": "^0.10.2"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-react",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
-        "@cdssnc/gcds-components": "^0.10.1"
+        "@cdssnc/gcds-components": "^0.10.2"
       },
       "devDependencies": {
         "@types/react": "^18.0.28",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "React wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -29,7 +29,7 @@
     "gcds.css"
   ],
   "dependencies": {
-    "@cdssnc/gcds-components": "^0.10.1"
+    "@cdssnc/gcds-components": "^0.10.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.7.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Web components for the GCDS",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.stories.tsx
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.stories.tsx
@@ -62,7 +62,11 @@ const Template = (args) => (`
 export const Default = Template.bind({});
 Default.args = {
   listen: true,
-  errorLinks: '',
+  errorLinks: `{
+    "error-href-1": "Error message",
+    "error-href-2": "Error message",
+    "error-href-3": "Error message"
+  }`,
   heading: '',
   subHeading: '',
   lang: 'en'

--- a/packages/web/src/components/gcds-error-summary/i18n/i18n.js
+++ b/packages/web/src/components/gcds-error-summary/i18n/i18n.js
@@ -4,7 +4,7 @@ const I18N = {
     subheading: "Errors were found on this page:"
   },
   "fr": {
-    heading: "Il y avait un problème",
+    heading: "Un problème est survenu",
     subheading: "Des erreurs ont été trouvées sur cette page :"
   }
 }

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -6,7 +6,7 @@
     <title>Stencil Component Starter</title>
 
     <!-- Utility framework -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/cds-snc/gcds-utilities/dist/utilities.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/cds-snc/gcds-utilities/dist/gcds-utility.css" />
 
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -91,7 +91,7 @@
       </gcds-breadcrumbs> -->
     </gcds-header>
 
-    <section class="container-xl mx-auto py-600">
+    <gcds-container container="xl" centered tag="main">
       <h1 class="text-center mb-500">GC Design System</h1>
 
       <h2>Components</h2>
@@ -141,7 +141,7 @@
       <h3 class="mt-700 mb-400 bb-1">Form elements (including stepper and error summary)</h3>
       <gcds-stepper current-step="1" total-steps="3"></gcds-stepper>
       <form novalidate>
-            
+
         <gcds-error-summary
           listen
         ></gcds-error-summary>
@@ -152,7 +152,7 @@
           hint="Please enter your full name."
           required
         ></gcds-input>
-        
+
         <gcds-input
           input-id="form-email"
           label="Email"
@@ -323,7 +323,7 @@
       <!-- ------------- Date Modified ------------- -->
 
       <gcds-date-modified>2023-01-26</gcds-date-modified>
-    </section>
+    </gcds-container>
 
     <gcds-footer
       display="full"


### PR DESCRIPTION
# v0.10.2

## Patch
- https://github.com/cds-snc/gcds-components/pull/167/commits/fc5ee8e410d85542d25cd273d084a7defdb883ed - Add value to error summary links in storybook story to display error summary instead of blank screen
- https://github.com/cds-snc/gcds-components/pull/167/commits/597f22435ded6fa1804c2af6143fc2ee9a0085b4 - Update french text for error summary default heading
- https://github.com/cds-snc/gcds-components/pull/167/commits/4b0fe7fa7c25cbcf8c00f6b7ca50cd2259f793e5 - Update demo with new UF name + add gcds-container