### PR TITLE
feat: publish new packages to CDN

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -69,22 +69,19 @@ jobs:
           role-session-name: CDNPublish
           aws-region: ${{ env.CDN_REGION }}
 
-      - name: Update CDN with published package
+      - name: Update CDN ${{ matrix.name }}
         if: steps.publish.outputs.id != ''
         run: |
           PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
 
-          mkdir -p ./published \
-            && cd ./published \
-            && npm install "$PUBLISHED_PACKAGE" \
-            && cd ./node_modules
+          mkdir -p ./tmp \
+            && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
+            && cd ./tmp/node_modules
 
           aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
           aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/${{ matrix.name }}@latest --delete
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ matrix.name }}@latest/package.json
+
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
         working-directory: ${{ matrix.package }}
-
-
-
-
-

--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -7,45 +7,84 @@ on:
     paths:
       - 'lerna.json'
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  CDN_BUCKET: gc-design-system-production-cdn
+  CDN_REGION: ca-central-1
+
 jobs:
   build-deploy:
     name: Publish packages
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "@cdssnc/gcds-components"
+            package: "./packages/web"
+            dist: "./packages/web"
+
+          - name: "@cdssnc/gcds-components-react"
+            package: "./packages/react"
+            dist: "./packages/react"
+
+          - name: "@cdssnc/gcds-components-angular"
+            package: "./packages/angular"
+            dist: "./packages/angular/dist"
     steps:
       - name: Git Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: actions/setup-node@5b32c9063c6eb277dacbf3e916a8bc5d2617c5b7
+
+      - name: Setup Node
+        uses: actions/setup-node@5b32c9063c6eb277dacbf3e916a8bc5d2617c5b7
         with:
           node-version: 16.13.0
+
       - name: Install repo
         run: npm install
-      - name: Install @cdssnc/gcds-components
+
+      - name: Install ${{ matrix.name }}
         run: npm install
-        working-directory: ./packages/web
-      - name: Build @cdssnc/gcds-components
+        working-directory: ${{ matrix.package }}
+
+      - name: Build ${{ matrix.name }}
         run: npm run build
-        working-directory: ./packages/web
-      - uses: JS-DevTools/npm-publish@c196e53609e852c243616a87994e8961a9903ba4
+        working-directory: ${{ matrix.package }}
+
+      - name: Publish ${{ matrix.name }}
+        uses: JS-DevTools/npm-publish@c196e53609e852c243616a87994e8961a9903ba4
+        id: publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
-          package: ./packages/web
-      - name: Install @cdssnc/gcds-components-react
-        run: npm install
-        working-directory: ./packages/react
-      - name: Build @cdssnc/gcds-components-react
-        run: npm run build
-        working-directory: ./packages/react
-      - uses: JS-DevTools/npm-publish@c196e53609e852c243616a87994e8961a9903ba4
+          package: ${{ matrix.dist }}
+
+      - name: Configure AWS credentials using OIDC
+        if: steps.publish.outputs.id != ''
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ./packages/react
-      - name: Install @cdssnc/gcds-components-angular
-        run: npm install
-        working-directory: ./packages/angular
-      - name: Build @cdssnc/gcds-components-angular
-        run: npm run build
-        working-directory: ./packages/angular
-      - uses: JS-DevTools/npm-publish@c196e53609e852c243616a87994e8961a9903ba4
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          package: ./packages/angular/dist
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
+          role-session-name: CDNPublish
+          aws-region: ${{ env.CDN_REGION }}
+
+      - name: Update CDN with published package
+        if: steps.publish.outputs.id != ''
+        run: |
+          PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
+
+          mkdir -p ./published \
+            && cd ./published \
+            && npm install "$PUBLISHED_PACKAGE" \
+            && cd ./node_modules
+
+          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
+          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/${{ matrix.name }}@latest --delete
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
+        working-directory: ${{ matrix.package }}
+
+
+
+
+


### PR DESCRIPTION
# Summary
Update the publish package workflow so that new packages are now also published to the CDN.

Each new package will be published to a versioned directory in the CDN and replace the files for its `@latest` version.  This will allow users to either link to versioned assets or the latest files.  

The flow for the publish step is as follows:

1. Use the `steps.publish.outputs.id` output to determine if a package was published.  The [JS-DevTools/npm-publish action](https://github.com/JS-DevTools/npm-publish#output) only provides this if there was a release in the format of `${name}@${version}`.
2. Sets up AWS credentials to publish to the CDN's S3 bucket.
3. Creates a `./tmp` directory and uses `npm install "$PUBLISHED_PACKAGE"` to download the package's assets.  This is done to make sure the npm package always matches the CDN assets.
4. Publishes the package assets to a `${name}@${version}` directory and `${name}@latest` directory on the CDN.

Part of this work for this change involved refactoring the workflow to use a matrix strategy so that the CDN publish logic did not have to be repeated for each package.

# Related
- cds-snc/platform-core-services#322