### PR TITLE
Include i18n for all components

### DIFF
--- a/packages/web/src/components/gcds-alert/gcds-alert.tsx
+++ b/packages/web/src/components/gcds-alert/gcds-alert.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Event, EventEmitter, Host, Prop, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-alert',
@@ -109,19 +110,11 @@ export class GcdsAlert {
             class={`gcds-alert alert--role-${alertRole} ${isFixed ? 'alert--is-fixed' : ''}`}
             role="alert"
             aria-label={
-              lang == 'en' ?
-                `This is ${
-                  alertRole === 'danger' ? 'a critical'
-                  : alertRole === 'info' ? 'an info'
-                  : alertRole === 'success' ? 'a success'
-                  : alertRole === 'warning' ? 'a warning'
-                  : null } alert.`
-              : `Ceci est une alerte ${
-                  alertRole === 'danger' ? 'd\'effacement'
-                  : alertRole === 'info' ? 'd\'information'
-                  : alertRole === 'success' ? 'de succès'
-                  : alertRole === 'warning' ? 'd\'avertissement'
-                  : null }.`
+              alertRole === 'danger' ? i18n[lang].label.danger
+              : alertRole === 'info' ? i18n[lang].label.info
+              : alertRole === 'success' ? i18n[lang].label.success
+              : alertRole === 'warning' ? i18n[lang].label.warning
+              : null
             }
           >
             <gcds-container container={isFixed ? container : 'full'} centered>
@@ -145,7 +138,7 @@ export class GcdsAlert {
                   <button
                     class="alert__close-btn"
                     onClick={(e) => this.onDismiss(e)}
-                    aria-label={ lang == 'en' ? 'Close alert.' : 'Fermer l\'alerte.'}
+                    aria-label={ i18n[lang].closeBtn }
                   >
                     <gcds-icon aria-hidden="true" name="times" size="text" />
                   </button>

--- a/packages/web/src/components/gcds-alert/i18n/i18n.js
+++ b/packages/web/src/components/gcds-alert/i18n/i18n.js
@@ -1,0 +1,22 @@
+const I18N = {
+  "en": {
+    label: {
+      danger: "This is a critical alert.",
+      info: "This is an info alert.",
+      success: "This is a success alert.",
+      warning: "This is a warning alert.",
+    },
+    closeBtn: "Close alert.",
+  },
+  "fr": {
+    label: {
+      danger: "Ceci est une alerte d'effacement.",
+      info: "Ceci est une alerte d'information.",
+      success: "Ceci est une alerte de succès.",
+      warning: "Ceci est une alerte d'avertissement.",
+    },
+    closeBtn: "Fermer l'alerte.",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-breadcrumbs',
@@ -48,13 +49,13 @@ export class GcdsBreadcrumbs {
     return (
       <Host>
         <nav
-          aria-label={lang == 'en' ? 'Breadcrumb' : 'Chemin de navigation'}
+          aria-label={i18n[lang].label}
           class="gcds-breadcrumbs"
         >
           <ol class={hideCanadaLink ? '' : 'has-canada-link'}>
             { !hideCanadaLink ?
               <gcds-breadcrumbs-item
-                href={`https://www.canada.ca/${lang == 'en' ? 'en' : 'fr'}.html`}
+                href={`https://www.canada.ca/${lang == 'fr' ? 'fr' : 'en'}.html`}
               >
                 Canada.ca
               </gcds-breadcrumbs-item>

--- a/packages/web/src/components/gcds-breadcrumbs/i18n/i18n.js
+++ b/packages/web/src/components/gcds-breadcrumbs/i18n/i18n.js
@@ -1,0 +1,10 @@
+const I18N = {
+  "en": {
+    label: "Breadcrumb",
+  },
+  "fr": {
+    label: "Chemin de navigation",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-button/gcds-button.tsx
+++ b/packages/web/src/components/gcds-button/gcds-button.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, Method, Host, Watch, Prop, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
 import { inheritAttributes} from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-button',
@@ -266,7 +267,7 @@ export class GcdsButton {
           { type === 'link' && target === '_blank' ?
             <gcds-icon
               name="external-link"
-              label={ lang == 'en' ? 'Opens in a new tab.' : 'S\'ouvre dans un nouvel onglet.' }
+              label={i18n[lang].label}
               margin-left="200"
             />
           : <slot name="right"></slot> }

--- a/packages/web/src/components/gcds-button/i18n/i18n.js
+++ b/packages/web/src/components/gcds-button/i18n/i18n.js
@@ -1,0 +1,10 @@
+const I18N = {
+  "en": {
+    label: "Opens in a new tab.",
+  },
+  "fr": {
+    label: "S'ouvre dans un nouvel onglet.",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Host, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-date-modified',
@@ -35,16 +36,12 @@ export class GcdsDateModified {
   }
 
   render() {
+    const { lang } = this;
+
     return (
       <Host>
         <dl class="gcds-date-modified">
-          <dt>
-            {this.lang == "en" ? 
-              "Date modified:"
-            : 
-              "Date de modification :"
-            }
-            </dt>
+          <dt>{i18n[lang].term}</dt>
           <dd>
             <time>
               <slot></slot>

--- a/packages/web/src/components/gcds-date-modified/i18n/i18n.js
+++ b/packages/web/src/components/gcds-date-modified/i18n/i18n.js
@@ -1,0 +1,10 @@
+const I18N = {
+  "en": {
+    term: "Date modified:",
+  },
+  "fr": {
+    term: "Date de modification :",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -2,6 +2,7 @@ import { Component, Prop, Element, Method, Event, EventEmitter, Listen, State, H
 import { assignLanguage, observerConfig, inheritAttributes } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
 import { validateFieldsetElements } from '../../validators/fieldset-validators/fieldset-validators';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-fieldset',
@@ -192,7 +193,7 @@ export class GcdsFieldset {
       }
     }
   }
-  
+
   /*
   * Observe lang attribute change
   */
@@ -243,7 +244,6 @@ export class GcdsFieldset {
         fieldsetAttrs["aria-describedby"] = `error-message-${fieldsetId} ${fieldsetAttrs["aria-describedby"] ? ` ${fieldsetAttrs["aria-describedby"]}` : ""}`;
     }
 
-    const requiredText = lang == "en" ? "required" : "obligatoire";
     return (
       <Host>
         <fieldset
@@ -259,10 +259,8 @@ export class GcdsFieldset {
           >
             {legend}
             {required ?
-                <strong class="legend__required">({requiredText})</strong>
-              :
-                null
-            }
+              <strong class="legend__required">({i18n[lang].required})</strong>
+            : null }
           </legend>
 
           {hint ? <gcds-hint hint={hint} hint-id={fieldsetId} /> : null}

--- a/packages/web/src/components/gcds-fieldset/i18n/i18n.js
+++ b/packages/web/src/components/gcds-fieldset/i18n/i18n.js
@@ -1,0 +1,10 @@
+const I18N = {
+  "en": {
+    required: "required",
+  },
+  "fr": {
+    required: "obligatoire",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, Prop, Watch, State, Method, Host, h, Listen } from '@stencil/core';
 import { assignLanguage, inheritAttributes, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-file-uploader',
@@ -202,7 +203,7 @@ export class GcdsFileUploader {
   @Event() gcdsRemoveFile: EventEmitter;
   removeFile = (e) => {
     e.preventDefault();
-    
+
     let filesContainer = this.value;
     const file = filesContainer.indexOf(e.target.closest('.file-uploader__uploaded-file').childNodes[0].textContent);
 
@@ -250,7 +251,7 @@ export class GcdsFileUploader {
       }
     }
   }
-  
+
   /*
   * Observe lang attribute change
   */
@@ -331,7 +332,7 @@ export class GcdsFileUploader {
 
           <div class={`file-uploader__input ${value.length > 0 ? "uploaded-files" : ''}`}>
             <button tabindex="-1">
-              { lang == 'en' ? 'Upload a file' : 'Téléverser un fichier'}
+              {i18n[lang].button.upload}
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input
@@ -346,24 +347,22 @@ export class GcdsFileUploader {
             />
             { value.length > 0 ?
               <p id="file-uploader__summary">
-                <span>{ lang == 'en' ? 'Currently selected:' : 'Actuellement sélectionné:'} </span>
+                <span>{i18n[lang].summary.selected} </span>
                 { value.map(file => ( <span>{file} </span> )) }
               </p>
             :
-              <p id="file-uploader__summary">
-                { lang == 'en' ? 'No file currently selected' : 'Aucun fichier actuellement sélectionné' }
-              </p>
+              <p id="file-uploader__summary">{ i18n[lang].summary.unselected }</p>
             }
           </div>
 
           { value.length > 0 ? value.map(file => (
             <div
               class="file-uploader__uploaded-file"
-              aria-label={ lang == 'en' ? `Remove file ${file}` : `Supprimer le fichier ${file}` }
+              aria-label={`${i18n[lang].removeFile} ${file}.`}
             >
               <span>{file}</span>
               <button onClick={(e) => this.removeFile(e)}>
-                <span>{ lang == 'en' ? 'Remove' : 'Supprimer' }</span>
+                <span>{i18n[lang].button.remove}</span>
                 <gcds-icon name="times" size="text" margin-left="200" />
               </button>
             </div>

--- a/packages/web/src/components/gcds-file-uploader/i18n/i18n.js
+++ b/packages/web/src/components/gcds-file-uploader/i18n/i18n.js
@@ -1,0 +1,26 @@
+const I18N = {
+  "en": {
+    button: {
+      remove: "Remove",
+      upload: "Upload a file",
+    },
+    summary: {
+      selected: "Currently selected:",
+      unselected: "No file currently selected.",
+    },
+    removeFile: "Remove file",
+  },
+  "fr": {
+    button: {
+      remove: "Supprimer",
+      upload: "Téléverser un fichier",
+    },
+    summary: {
+      selected: "Actuellement sélectionné:",
+      unselected: "Aucun fichier actuellement sélectionné.",
+    },
+    removeFile: "Supprimer le fichier",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -17,7 +17,7 @@ describe('gcds-file-uploader', () => {
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected</p>
+            <p id="file-uploader__summary">No file currently selected.</p>
           </div>
         </div>
       </gcds-file-uploader>
@@ -42,7 +42,7 @@ describe('gcds-file-uploader', () => {
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" disabled="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected</p>
+            <p id="file-uploader__summary">No file currently selected.</p>
           </div>
         </div>
       </gcds-file-uploader>
@@ -68,7 +68,7 @@ describe('gcds-file-uploader', () => {
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="true" aria-describedby="error-message-file-uploader file-uploader__summary" />
-            <p id="file-uploader__summary">No file currently selected</p>
+            <p id="file-uploader__summary">No file currently selected.</p>
           </div>
         </div>
       </gcds-file-uploader>
@@ -94,7 +94,7 @@ describe('gcds-file-uploader', () => {
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" aria-describedby="hint-file-uploader file-uploader__summary" />
-            <p id="file-uploader__summary">No file currently selected</p>
+            <p id="file-uploader__summary">No file currently selected.</p>
           </div>
         </div>
       </gcds-file-uploader>
@@ -119,7 +119,7 @@ describe('gcds-file-uploader', () => {
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected</p>
+            <p id="file-uploader__summary">No file currently selected.</p>
           </div>
         </div>
       </gcds-file-uploader>
@@ -144,7 +144,7 @@ describe('gcds-file-uploader', () => {
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected</p>
+            <p id="file-uploader__summary">No file currently selected.</p>
           </div>
         </div>
       </gcds-file-uploader>
@@ -169,7 +169,7 @@ describe('gcds-file-uploader', () => {
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" required="" />
-            <p id="file-uploader__summary">No file currently selected</p>
+            <p id="file-uploader__summary">No file currently selected.</p>
           </div>
         </div>
       </gcds-file-uploader>

--- a/packages/web/src/components/gcds-label/gcds-label.tsx
+++ b/packages/web/src/components/gcds-label/gcds-label.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-label',
@@ -78,7 +79,6 @@ export class GcdsLabel {
 
   render() {
     const { hideLabel, labelFor, label, required, lang } = this;
-    const requiredText = lang == "en" ? "required" : "obligatoire";
 
     return (
       <Host
@@ -92,7 +92,7 @@ export class GcdsLabel {
         >
           <span>{label}</span>
           {required ?
-            <span class="label--required">({requiredText})</span>
+            <span class="label--required">({i18n[lang].required})</span>
           : null}
         </label>
       </Host>

--- a/packages/web/src/components/gcds-label/i18n/i18n.js
+++ b/packages/web/src/components/gcds-label/i18n/i18n.js
@@ -1,0 +1,10 @@
+const I18N = {
+  "en": {
+    required: "required",
+  },
+  "fr": {
+    required: "obligatoire",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-lang-toggle',
@@ -47,23 +48,13 @@ export class GcdsLangToggle {
 
     return (
       <Host>
-        {lang === "fr" ? (
-          <div>
-            <h2>Sélection de la langue</h2>
-            <a href={href} lang="en">
-              <span>English</span>
-              <abbr title="English">en</abbr>
-            </a>
-          </div>
-        ) : (
-          <div>
-            <h2>Language Selection</h2>
-            <a href={href} lang="fr">
-              <span>Français</span>
-              <abbr title="Français">fr</abbr>
-            </a>
-          </div>
-        )}
+        <div>
+          <h2>{i18n[lang].heading}</h2>
+          <a href={href} lang={i18n[lang].abbreviation}>
+            <span>{i18n[lang].language}</span>
+            <abbr title={i18n[lang].language}>{i18n[lang].abbreviation}</abbr>
+          </a>
+        </div>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-lang-toggle/i18n/i18n.js
+++ b/packages/web/src/components/gcds-lang-toggle/i18n/i18n.js
@@ -1,0 +1,14 @@
+const I18N = {
+  "en": {
+    abbreviation: "fr",
+    heading: "Language Selection",
+    language: "Français",
+  },
+  "fr": {
+    abbreviation: "en",
+    heading: "Sélection de la langue",
+    language: "English",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-phase-banner/gcds-phase-banner.tsx
+++ b/packages/web/src/components/gcds-phase-banner/gcds-phase-banner.tsx
@@ -1,4 +1,6 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
+import { Component, Element, Host, Prop, State, h } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-phase-banner',
@@ -7,7 +9,6 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 })
 export class GcdsPhaseBanner {
   @Element() el: HTMLElement;
-
 
   /**
    * Props
@@ -28,15 +29,45 @@ export class GcdsPhaseBanner {
    */
   @Prop() isFixed?: boolean;
 
+
+  /**
+  * Language of rendered component
+  */
+  @State() lang: string;
+
+
+  /**
+   * Events
+   */
+
+  /*
+  * Observe lang attribute change
+  */
+  updateLang() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
+  async componentWillLoad() {
+    // Define lang attribute
+    this.lang = assignLanguage(this.el);
+
+    this.updateLang();
+  }
+
   render() {
-    const { bannerRole, container, isFixed } = this;
+    const { bannerRole, container, isFixed, lang } = this;
 
     return (
       <Host>
         <div
           class={`gcds-phase-banner banner--role-${bannerRole} ${isFixed ? 'banner--is-fixed' : ''}`}
           role="status"
-          aria-label="Banner"
+          aria-label={i18n[lang].label}
         >
           <gcds-container container={container} centered>
             <div class="banner__content">

--- a/packages/web/src/components/gcds-phase-banner/i18n/i18n.js
+++ b/packages/web/src/components/gcds-phase-banner/i18n/i18n.js
@@ -1,0 +1,10 @@
+const I18N = {
+  "en": {
+    label: "Banner",
+  },
+  "fr": {
+    label: "Bannière",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-stepper/gcds-stepper.tsx
+++ b/packages/web/src/components/gcds-stepper/gcds-stepper.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-stepper',
@@ -54,11 +55,7 @@ export class GcdsStepper {
     return (
       <Host>
         <h6 class="gcds-stepper">
-          { lang == 'en' ?
-            `Step ${currentStep} of ${totalSteps}`
-          :
-            `Étape ${currentStep} sur ${totalSteps}`
-          }
+          {`${i18n[lang].step} ${currentStep} ${i18n[lang].of} ${totalSteps}`}
         </h6>
       </Host>
     );

--- a/packages/web/src/components/gcds-stepper/i18n/i18n.js
+++ b/packages/web/src/components/gcds-stepper/i18n/i18n.js
@@ -1,0 +1,12 @@
+const I18N = {
+  "en": {
+    step: "Step",
+    of: "of",
+  },
+  "fr": {
+    step: "Étape",
+    of: "sur",
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, Method, Watch, EventEmitter, Host, State, Prop, h, Listen } from '@stencil/core';
 import { assignLanguage, inheritAttributes, observerConfig } from '../../utils/utils';
 import { Validator, defaultValidator, ValidatorEntry, getValidator, requiredValidator } from '../../validators';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-textarea',
@@ -231,7 +232,7 @@ export class GcdsTextarea {
       }
     }
   }
-  
+
   /*
   * Observe lang attribute change
   */
@@ -332,12 +333,10 @@ export class GcdsTextarea {
 
           {characterCount ?
             <p id={`textarea__count-${textareaId}`} aria-live="polite">
-              {this.lang == 'en'?
-                value  == undefined ? `${characterCount} characters allowed`
-                : `${characterCount - value.length} characters left`
+              {
+                value  == undefined ? `${characterCount} ${i18n[lang].characters.allowed}`
               :
-                value  == undefined ? `${characterCount} caractères maximum`
-                : `${characterCount - value.length} caractères restants`
+                `${characterCount - value.length} ${i18n[lang].characters.left}`
               }
             </p>
           : null}

--- a/packages/web/src/components/gcds-textarea/i18n/i18n.js
+++ b/packages/web/src/components/gcds-textarea/i18n/i18n.js
@@ -1,0 +1,16 @@
+const I18N = {
+  "en": {
+    characters: {
+      allowed: "characters allowed",
+      left: "characters left",
+    },
+  },
+  "fr": {
+    characters: {
+      allowed: "caractères maximum",
+      left: "caractères restants",
+    },
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-verify-banner/gcds-verify-banner.tsx
+++ b/packages/web/src/components/gcds-verify-banner/gcds-verify-banner.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 import CanadaFlag from './assets/canada-flag.svg';
 import ContentToggleArrow from './assets/content-toggle-arrow.svg';
@@ -65,55 +66,34 @@ export class GcdsVerifyBanner {
           >
             <span class='svg-container' innerHTML={CanadaFlag} />
             <p>
-              <small>{lang === 'en' ? 'An official website of the Government of Canada.' : 'Les sites Web officiels du gouvernement du Canada.'}</small>
+              <small>{i18n[lang].summary.text}</small>
               <a class="verify-banner__toggle">
-                <small>{lang === 'en' ? 'Learn to recognize one' : 'Comment les reconnaître'}</small>
+                <small>{i18n[lang].summary.link}</small>
                 <span class='svg-container' innerHTML={ContentToggleArrow} />
               </a>
             </p>
           </summary>
           <div class={`verify-banner__content ${container ? `container-${container}` : ''}`}>
-            <p><small>{lang === 'en' ? 'It can be hard to know what sites to trust. Here\'s how to identify a Government of Canada website before you share any info:' : 'Il peut être difficile de savoir quels sites sont fiables. Avant de partager des renseignements, vérifiez les points suivant pour déterminer s\'il s\'agit bien d\'un site du gouvernement du Canada:'}</small></p>
+            <p><small>{i18n[lang].content.description}</small></p>
             <br/>
-            {lang === 'en' ?
-              <gcds-grid tag="ul" container="lg" columns="1fr" columns-tablet={container === 'xs' || container === 'sm' ? '1fr' : '1fr 1fr'}>
-                <li>
-                  <h4>Canada.ca or gc.ca</h4>
-                  <p><small>Government of Canada website's normally use Canada.ca or gc.ca in the URL.</small></p>
-                </li>
-                <li>
-                  <h4>Available in both of Canada's Official Languages</h4>
-                  <p><small>Information will be available in both English and French.</small></p>
-                </li>
-                <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container' innerHTML={Lock} /> in the address bar.</small></p>
-                </li>
-                <li>
-                  <h4>A point of contact</h4>
-                  <p><small>Contact information will have Canada.ca, gc.ca, or the department name in the email address.</small></p>
-                </li>
-              </gcds-grid>
-            :
-              <gcds-grid tag="ul" container="lg" columns="1fr" columns-tablet={container === 'xs' || container === 'sm' ? '1fr' : '1fr 1fr'}>
-                <li>
-                  <h4>Canada.ca ou gc.ca</h4>
-                  <p><small>On retrouve normalement Canada.ca ou gc.ca dans l'adresse URL d'un site Web du gouvernement du Canada.</small></p>
-                </li>
-                <li>
-                  <h4>Offert dans les deux langues officielles</h4>
-                  <p><small>Vérifiez que les renseignements sont accessibles en français et en anglais.</small></p>
-                </li>
-                <li>
-                  <h4>Une icône de cadenas et HTTPS</h4>
-                  <p><small>Lorsqu'un navigateur affiche les sites Web sécuritaires du gouvernement du Canada, on retrouve <strong>https://</strong> et <span class='svg-container' innerHTML={Lock} /> dans la barre URL.</small></p>
-                </li>
-                <li>
-                  <h4>Un point de communication</h4>
-                  <p><small>On retrouve Canada.ca, gc.ca ou le nom du ministère dans l'URL de toute adresse courriel du gouvernement du Canada.</small></p>
-                </li>
-              </gcds-grid>
-            }
+            <gcds-grid tag="ul" container="lg" columns="1fr" columns-tablet={container === 'xs' || container === 'sm' ? '1fr' : '1fr 1fr'}>
+              <li>
+                <h4>{i18n[lang].content.url.heading}</h4>
+                <p><small>{i18n[lang].content.url.text}</small></p>
+              </li>
+              <li>
+                <h4>{i18n[lang].content.languages.heading}</h4>
+                <p><small>{i18n[lang].content.languages.text}</small></p>
+              </li>
+              <li>
+                <h4>{i18n[lang].content.https.heading}</h4>
+                <p><small>{i18n[lang].content.https.text} <strong>https://</strong>.</small></p>
+              </li>
+              <li>
+                <h4>{i18n[lang].content.contact.heading}</h4>
+                <p><small>{i18n[lang].content.contact.text}</small></p>
+              </li>
+            </gcds-grid>
           </div>
         </details>
       </Host>

--- a/packages/web/src/components/gcds-verify-banner/i18n/i18n.js
+++ b/packages/web/src/components/gcds-verify-banner/i18n/i18n.js
@@ -1,0 +1,54 @@
+const I18N = {
+  "en": {
+    summary: {
+      text: "An official website of the Government of Canada.",
+      link: "Learn to recognize one",
+    },
+    content: {
+      description: "It can be hard to know what sites to trust. Here's how to identify a Government of Canada website before you share any info:",
+      url: {
+        heading: "Canada.ca or gc.ca",
+        text: "Government of Canada website's normally use Canada.ca or gc.ca in the URL.",
+      },
+      languages: {
+        heading: "Available in both of Canada's Official Languages",
+        text: "Information will be available in both English and French.",
+      },
+      https: {
+        heading: "HTTPS",
+        text: "Secure Government of Canada websites use",
+      },
+      contact: {
+        heading: "A point of contact",
+        text: "Contact information will have Canada.ca, gc.ca, or the department name in the email address.",
+      },
+    }
+  },
+  "fr": {
+    summary: {
+      text: "Les sites Web officiels du gouvernement du Canada.",
+      link: "Comment les reconnaître",
+    },
+    content: {
+      description: "Il peut être difficile de savoir quels sites sont fiables. Avant de partager des renseignements, vérifiez les points suivant pour déterminer s'il s'agit bien d'un site du gouvernement du Canada:",
+      url: {
+        heading: "Canada.ca ou gc.ca",
+        text: "On retrouve normalement Canada.ca ou gc.ca dans l'adresse URL d'un site Web du gouvernement du Canada.",
+      },
+      languages: {
+        heading: "Offert dans les deux langues officielles",
+        text: "Vérifiez que les renseignements sont accessibles en français et en anglais.",
+      },
+      https: {
+        heading: "HTTPS",
+        text: "Lorsqu'un navigateur affiche les sites Web sécuritaires du gouvernement du Canada, on retrouve",
+      },
+      contact: {
+        heading: "Un point de communication",
+        text: "On retrouve Canada.ca, gc.ca ou le nom du ministère dans l'URL de toute adresse courriel du gouvernement du Canada.",
+      },
+    }
+  }
+}
+
+export default I18N;

--- a/packages/web/src/components/gcds-verify-banner/test/gcds-verify-banner.spec.tsx
+++ b/packages/web/src/components/gcds-verify-banner/test/gcds-verify-banner.spec.tsx
@@ -40,8 +40,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -87,8 +87,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Vérifiez que les renseignements sont accessibles en français et en anglais.</small></p>
                 </li>
                 <li>
-                  <h4>Une icône de cadenas et HTTPS</h4>
-                  <p><small>Lorsqu'un navigateur affiche les sites Web sécuritaires du gouvernement du Canada, on retrouve <strong>https://</strong> et <span class='svg-container'>Lock</span> dans la barre URL.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Lorsqu'un navigateur affiche les sites Web sécuritaires du gouvernement du Canada, on retrouve <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>Un point de communication</h4>
@@ -138,8 +138,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -185,8 +185,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -236,8 +236,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -283,8 +283,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -330,8 +330,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -377,8 +377,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -424,8 +424,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>
@@ -471,8 +471,8 @@ describe('gcds-verify-banner', () => {
                   <p><small>Information will be available in both English and French.</small></p>
                 </li>
                 <li>
-                  <h4>A padlock icon and HTTPS</h4>
-                  <p><small>Secure Government of Canada websites use <strong>https://</strong> and <span class='svg-container'>Lock</span> in the address bar.</small></p>
+                  <h4>HTTPS</h4>
+                  <p><small>Secure Government of Canada websites use <strong>https://</strong>.</small></p>
                 </li>
                 <li>
                   <h4>A point of contact</h4>


### PR DESCRIPTION
# Summary | Résumé

- Added localization files to all components with localization
- Removed padlock text from gcds-verify-banner

Note: While I was adding the localization file for the verify banner, I decided to remove the text referring to the padlock since browsers are removing the padlock soon.