### PR TITLE
Renovate base branch update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,6 @@
     "schedule": [
       "before 6am on the first day of the month"
     ]
-  }
+  },
+  "baseBranches": ["staging"]
 }


### PR DESCRIPTION
# Summary | Résumé

With the new `staging` branch, configure renovate to use the staging branch instead of main.
