### PR TITLE
gcds-lang-toggle + gcds-pagination stories

### DIFF
--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -6,6 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Validator, ValidatorEntry } from "./validators";
+export { Validator, ValidatorEntry } from "./validators";
 export namespace Components {
     interface GcdsAlert {
         /**
@@ -593,7 +594,7 @@ export namespace Components {
         /**
           * List display - URL object to create query strings and fragment on links
          */
-        "url": Object;
+        "url": string | object;
     }
     interface GcdsPhaseBanner {
         /**
@@ -1746,7 +1747,7 @@ declare namespace LocalJSX {
         /**
           * List display - URL object to create query strings and fragment on links
          */
-        "url"?: Object;
+        "url"?: string | object;
     }
     interface GcdsPhaseBanner {
         /**

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.stories.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.stories.tsx
@@ -1,0 +1,43 @@
+import { langProp } from '../../utils/storybook/component-properties';
+
+export default {
+  title: 'Components/Language toggle',
+
+  argTypes: {
+    // Props
+    href: {
+      name: 'href',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+      type: {
+        required: true
+      }
+    },
+    ...langProp
+  },
+};
+
+const Template = (args) => (`
+// Web Component (Angular, Vue)
+<gcds-lang-toggle
+  href="${args.href}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</gcds-lang-toggle>
+
+// React code
+<GcdsLangToggle
+  href="${args.href}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</GcdsLangToggle>
+`).replace(/\s\snull\n/g, '');
+
+export const Default = Template.bind({});
+Default.args = {
+  href: '#',
+  lang: 'en'
+};

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.css
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.css
@@ -181,7 +181,7 @@
           }
         }
 
-        &:first-of-type {
+        &.gcds-pagination-simple-previous {
           a {
             grid-template-areas:
               "icon text"
@@ -189,7 +189,7 @@
             grid-template-columns: 0.25fr 1fr;
           }
         }
-        &:last-of-type {
+        &.gcds-pagination-simple-next {
           float: right;
 
           a {

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.stories.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.stories.tsx
@@ -1,0 +1,132 @@
+import { langProp } from '../../utils/storybook/component-properties';
+
+export default {
+  title: 'Components/Pagination',
+
+  argTypes: {
+    // Props
+    label: {
+      name: 'label',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+      type: {
+        required: true
+      }
+    },
+    display: {
+      control: 'radio',
+      options: ['list', 'simple'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'list' }
+      },
+    },
+    nextHref: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    nextLabel: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    previousHref: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    previousLabel: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    totalPages: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    currentPage: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    url: {
+      name: 'url',
+      control: 'text',
+      description: '{ "queryStrings": { "key": "value" }, "fragment": string }',
+      table: {
+        type: { summary: 'string/object' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    ...langProp,
+  },
+};
+
+const Template = (args) => (`
+// Web Component (Angular, Vue)
+<gcds-pagination
+  ${args.display != "list" ? `display="${args.display}"` : null}
+  label="${args.label}"
+  ${args.display == "list" ?
+  `${args.totalPages ? `total-pages="${args.totalPages}"` : null}
+  ${args.currentPage ? `current-page="${args.currentPage}"` : null}
+  ${args.url ? `url='${args.url}'` : null}`
+  :
+  `${args.previousHref ? `previous-href="${args.previousHref}"` : null}
+  ${args.previousLabel ? `previous-label="${args.previousLabel}"` : null}
+  ${args.nextHref ? `next-href="${args.nextHref}"` : null}
+  ${args.nextLabel ? `next-label="${args.nextLabel}"` : null}`
+  }
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</gcds-pagination>
+
+// React code
+<GcdsPagination
+  ${args.display != "list" ? `display="${args.display}"` : null}
+  label="${args.label}"
+  ${args.display == "list" ?
+  `${args.totalPages ? `totalPages="${args.totalPages}"` : null}
+  ${args.currentPage ? `currentPage="${args.currentPage}"` : null}
+  ${args.url ? `url='${args.url}'` : null}`
+  :
+  `${args.previousHref ? `previousHref="${args.previousHref}"` : null}
+  ${args.previousLabel ? `previousLabel="${args.previousLabel}"` : null}
+  ${args.nextHref ? `nextHref="${args.nextHref}"` : null}
+  ${args.nextLabel ? `nextLabel="${args.nextLabel}"` : null}`
+  }
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</GcdsPagination>
+`).replace(/\s\snull\n/g, '');
+
+export const Default = Template.bind({});
+Default.args = {
+  display: 'list',
+  label: 'Pagination',
+  currentPage: '5',
+  totalPages: '10',
+  url: '',
+  previousHref: '#previous',
+  previousLabel: '',
+  nextHref: '#next',
+  nextLabel: '',
+  lang: 'en'
+};

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
@@ -68,7 +68,21 @@ export class GcdsPagination {
   /**
    * List display - URL object to create query strings and fragment on links
    */
-   @Prop() url: Object;
+   @Prop() url: string | object;
+   urlObject: object;
+
+  /**
+   * Convert url prop to object
+   * (Object props get treated as string when using Stencil components without a framework)
+   */
+  @Watch('url')
+  urlChanged(newUrl: string | object) {
+    if (typeof newUrl == "string") {
+      this.urlObject = JSON.parse(newUrl);
+    } else if (typeof newUrl == "object") {
+      this.urlObject = newUrl;
+    }
+  }
 
   /**
    * Function to fire when pageChange event is called
@@ -112,7 +126,7 @@ export class GcdsPagination {
 
     let linkAttrs = {
       onClick: (e) => this.onPageChange(e),
-      href: this.url ? constructHref(this.el, page, end) : "javascript:void(0)",
+      href: this.urlObject ? constructHref(this.urlObject, page, end) : "javascript:void(0)",
       "aria-label": !end ?
         I18N[this.lang].pageNumberOf.replace('{#}', page).replace('{total}', this.totalPages).replace('{label}', this.label)
       :
@@ -290,6 +304,12 @@ export class GcdsPagination {
 
     this.updateLang();
 
+    if (this.url && typeof this.url == "string") {
+      this.urlObject = JSON.parse(this.url);
+    } else if (this.url && typeof this.url == "object") {
+      this.urlObject = this.url;
+    }
+
     if (this.display == "list") {
       this.configureListPagination();
     }
@@ -326,36 +346,40 @@ export class GcdsPagination {
           <ul
             class="gcds-pagination-simple"
           >
-            <li>
-              <a
-                href={previousHref}
-                aria-label={`${I18N[lang].previousPage}${previousLabel ? `: ${previousLabel}` : ""}`}
-                onClick={(e) => this.onPageChange(e)}
-              >
-                <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-                <div class="gcds-pagination-simple-text">
-                  {I18N[lang].previous}
-                </div>
-                <span>
-                  {previousLabel}
-                </span>
-              </a>
-            </li>
-            <li>
-              <a
-                href={nextHref}
-                aria-label={`${I18N[lang].nextPage}${nextLabel ? `: ${nextLabel}` : ""}`}
-                onClick={(e) => this.onPageChange(e)}
-              >
-                <div class="gcds-pagination-simple-text">
-                  {I18N[lang].next}
-                </div>
-                <span>
-                  {nextLabel}
-                </span>
-                <gcds-icon margin-left="200" name="arrow-right"></gcds-icon>
-              </a>
-            </li>
+            {previousHref &&
+              <li class="gcds-pagination-simple-previous">
+                <a
+                  href={previousHref}
+                  aria-label={`${I18N[lang].previousPage}${previousLabel ? `: ${previousLabel}` : ""}`}
+                  onClick={(e) => this.onPageChange(e)}
+                >
+                  <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
+                  <div class="gcds-pagination-simple-text">
+                    {I18N[lang].previous}
+                  </div>
+                  <span>
+                    {previousLabel}
+                  </span>
+                </a>
+              </li>
+            }
+            {nextHref && 
+              <li class="gcds-pagination-simple-next">
+                <a
+                  href={nextHref}
+                  aria-label={`${I18N[lang].nextPage}${nextLabel ? `: ${nextLabel}` : ""}`}
+                  onClick={(e) => this.onPageChange(e)}
+                >
+                  <div class="gcds-pagination-simple-text">
+                    {I18N[lang].next}
+                  </div>
+                  <span>
+                    {nextLabel}
+                  </span>
+                  <gcds-icon margin-left="200" name="arrow-right"></gcds-icon>
+                </a>
+              </li>
+            }
           </ul>
         }
       </Host>

--- a/packages/web/src/components/gcds-pagination/readme.md
+++ b/packages/web/src/components/gcds-pagination/readme.md
@@ -18,7 +18,7 @@
 | `previousHref`       | `previous-href`  | Simple display - href for previous link                                 | `string`             | `undefined` |
 | `previousLabel`      | `previous-label` | Simple display - label for previous link                                | `string`             | `undefined` |
 | `totalPages`         | `total-pages`    | List display - Total number of pages                                    | `number`             | `undefined` |
-| `url`                | --               | List display - URL object to create query strings and fragment on links | `Object`             | `undefined` |
+| `url`                | `url`            | List display - URL object to create query strings and fragment on links | `object \| string`   | `undefined` |
 
 
 ## Events

--- a/packages/web/src/components/gcds-pagination/test/gcds-pagination.spec.tsx
+++ b/packages/web/src/components/gcds-pagination/test/gcds-pagination.spec.tsx
@@ -18,7 +18,7 @@ describe('gcds-pagination', () => {
     expect(page.root).toEqualHtml(`
       <gcds-pagination display="simple" lang="en" next-href="#next" next-label="Next label" previous-href="#previous" previous-label="Previous label" role="navigation">
         <ul class="gcds-pagination-simple">
-          <li>
+          <li class="gcds-pagination-simple-previous">
             <a aria-label="Previous page: Previous label" href="#previous">
               <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
               <div class="gcds-pagination-simple-text">
@@ -29,7 +29,7 @@ describe('gcds-pagination', () => {
               </span>
             </a>
           </li>
-          <li>
+          <li class="gcds-pagination-simple-next">
             <a aria-label="Next page: Next label" href="#next">
               <div class="gcds-pagination-simple-text">
                 Next
@@ -58,7 +58,7 @@ describe('gcds-pagination', () => {
     expect(page.root).toEqualHtml(`
       <gcds-pagination display="simple" lang="en" next-href="#next" previous-href="#previous" role="navigation">
         <ul class="gcds-pagination-simple">
-          <li>
+          <li class="gcds-pagination-simple-previous">
             <a aria-label="Previous page" href="#previous">
               <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
               <div class="gcds-pagination-simple-text">
@@ -68,7 +68,7 @@ describe('gcds-pagination', () => {
               </span>
             </a>
           </li>
-          <li>
+          <li class="gcds-pagination-simple-next">
             <a aria-label="Next page" href="#next">
               <div class="gcds-pagination-simple-text">
                 Next
@@ -98,7 +98,7 @@ describe('gcds-pagination', () => {
     expect(page.root).toEqualHtml(`
       <gcds-pagination display="simple" lang="fr" next-href="#next" next-label="Next label" previous-href="#previous" previous-label="Previous label" role="navigation">
         <ul class="gcds-pagination-simple">
-          <li>
+          <li class="gcds-pagination-simple-previous">
             <a aria-label="Page précédente: Previous label" href="#previous">
               <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
               <div class="gcds-pagination-simple-text">
@@ -109,7 +109,7 @@ describe('gcds-pagination', () => {
               </span>
             </a>
           </li>
-          <li>
+          <li class="gcds-pagination-simple-next">
             <a aria-label="Page suivante: Next label" href="#next">
               <div class="gcds-pagination-simple-text">
                 Suivante
@@ -138,7 +138,7 @@ describe('gcds-pagination', () => {
     expect(page.root).toEqualHtml(`
       <gcds-pagination display="simple" lang="fr" next-href="#next" previous-href="#previous" role="navigation">
         <ul class="gcds-pagination-simple">
-          <li>
+          <li class="gcds-pagination-simple-previous">
             <a aria-label="Page précédente" href="#previous">
               <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
               <div class="gcds-pagination-simple-text">
@@ -148,7 +148,7 @@ describe('gcds-pagination', () => {
               </span>
             </a>
           </li>
-          <li>
+          <li class="gcds-pagination-simple-next">
             <a aria-label="Page suivante" href="#next">
               <div class="gcds-pagination-simple-text">
                 Suivante

--- a/packages/web/src/components/gcds-pagination/utils/render.tsx
+++ b/packages/web/src/components/gcds-pagination/utils/render.tsx
@@ -2,78 +2,76 @@
  * Function to constuct href attribute from url object
  * Also looks for ::offset and ::match to increment query string values
  */
-function constructHref(el, page: number, end?: "next" | "previous" | null) {
+function constructHref(url, page: number, end?: "next" | "previous" | null) {
   let fragment = "";
   let qs = "";
 
-  if (el.url) {
+  let count = 0;
 
-    let count = 0;
+  for (const key in url.queryStrings) {
 
-    for (const key in el.url.queryStrings) {
+    let queryKey = key;
+    let queryValue = url.queryStrings[key];
 
-      let queryKey = key;
-      let queryValue = el.url.queryStrings[key];
+    if (key.includes("::")) {
 
-      if (key.includes("::")) {
+      let incrementer = key.split("::")[1];
+      let regExp = /\{\{([^)]+)\}\}/;
+      let matches = regExp.exec(url.queryStrings[key]);
 
-        let incrementer = key.split("::")[1];
-        let regExp = /\{\{([^)]+)\}\}/;
-        let matches = regExp.exec(el.url.queryStrings[key]);
+      // Offeset numbers
+      if (incrementer == "offset") {
+        let pageNumber = page;
 
-        // Offeset numbers
-        if (incrementer == "offset") {
-          let pageNumber = page;
-
-          if (end == "next") {
-            ++pageNumber;
-          }
-          else if (end == "previous") {
-            --pageNumber;
-          }
-
-          queryValue = matches ?
-            el.url.queryStrings[key].replace(`{{${matches[1]}}}`, `${((pageNumber-1) * Number(matches[1]))}`)
-          :
-            ((pageNumber-1) * el.url.queryStrings[key]);
-
-          queryKey = queryKey.replace("::offset", "");
+        if (end == "next") {
+        ++pageNumber;
+        }
+        else if (end == "previous") {
+        --pageNumber;
         }
 
-        // Match page number
-        if (incrementer == "match") {
+        queryValue = matches ?
+        url.queryStrings[key].replace(`{{${matches[1]}}}`, `${((pageNumber-1) * Number(matches[1]))}`)
+        :
+        ((pageNumber-1) * url.queryStrings[key]);
+
+        queryKey = queryKey.replace("::offset", "");
+      }
+
+      // Match page number
+      if (incrementer == "match") {
 
           let pageNumber = page;
 
           if (end == "next") {
-            ++pageNumber;
+          ++pageNumber;
           }
           else if (end == "previous") {
-            --pageNumber;
+          --pageNumber;
           }
 
           queryValue = matches ?
-            el.url.queryStrings[key].replace(`{{${matches[1]}}}`, `${(pageNumber * Number(matches[1]))}`)
+          url.queryStrings[key].replace(`{{${matches[1]}}}`, `${(pageNumber * Number(matches[1]))}`)
           :
-            (pageNumber * el.url.queryStrings[key]);
+          (pageNumber * url.queryStrings[key]);
 
           queryKey = queryKey.replace("::match", "");
-        }
       }
-
-      if (count == 0) {
-        qs += `?${queryKey}=${queryValue}`
-      } else {
-        qs += `&${queryKey}=${queryValue}`
-      }
-      ++count;
     }
 
-    if (el.url.fragment) {
-      fragment = `#${el.url.fragment}`;
+    if (count == 0) {
+      qs += `?${queryKey}=${queryValue}`
+    } else {
+      qs += `&${queryKey}=${queryValue}`
     }
-
+    ++count;
   }
+
+  if (url.fragment) {
+      fragment = `#${url.fragment}`;
+  }
+
+  
 
   let href = `${qs}${fragment}`;
 

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -315,7 +315,7 @@
         type="list"
         total-pages="22"
         current-page="8"
-        url={}
+        url='{"queryStrings": { "querystring::offset": 10 }, "fragment": "main" }'
         pageChangeHandler={}
       ></gcds-pagination>
 


### PR DESCRIPTION
# Summary | Résumé

Add `gcds-lang-toggle` and `gcds-pagination` to storybook.

## Additional changes to gcds-pagination

### Simple pagination rendering

`gcds-pagination` will no longer render the previous or next button if no `previous-href` or `next-href` is passed.

### URL property

The `url` property has been modified to accept and `object` or `string` like the `subLinks` property on the `gcds-footer`.
