### PR TITLE
Update publish github action to use jobs

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -16,8 +16,8 @@ env:
   CDN_REGION: ca-central-1
 
 jobs:
-  build-deploy:
-    name: Publish packages
+  publish-web:
+    name: Publish @cdssnc/gcds-components
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -27,6 +27,72 @@ jobs:
             package: "./packages/web"
             dist: "./packages/web"
 
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Setup Node
+        uses: actions/setup-node@a9893b0cfb0821c9c7b5fec28a6a2e6cdd5e20a4
+        with:
+          node-version: 16.13.0
+
+      - name: Install repo
+        run: npm install
+
+      - name: Install ${{ matrix.name }}
+        run: npm install
+        working-directory: ${{ matrix.package }}
+
+      - name: Build ${{ matrix.name }}
+        run: npm run build
+        working-directory: ${{ matrix.package }}
+
+      - name: Publish ${{ matrix.name }}
+        uses: JS-DevTools/npm-publish@be39bf074cd386f38a375dd3d35464bf56735502
+        id: publish
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ${{ matrix.dist }}
+
+      - name: Configure AWS credentials using OIDC
+        if: steps.publish.outputs.id != ''
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
+          role-session-name: CDNPublish
+          aws-region: ${{ env.CDN_REGION }}
+
+      - name: Update CDN ${{ matrix.name }}
+        if: steps.publish.outputs.id != ''
+        run: |
+          PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
+
+          mkdir -p ./tmp \
+            && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
+            && cd ./tmp/node_modules
+
+          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
+          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/${{ matrix.name }}@latest --delete
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ matrix.name }}@latest/package.json
+
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
+        working-directory: ${{ matrix.package }}
+
+      - name: Slack notify on failure
+        if: failure()
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Publish ${{ matrix.name }} failed: <https://github.com/cds-snc/gcds-components/actions/workflows/compile-and-publish.yml|Publish packages>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}
+
+  publish-react-angular:
+    name: Publish @cdssnc/gcds-components-react and @cdssnc/gcds-components-angular
+    needs: publish-web
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - name: "@cdssnc/gcds-components-react"
             package: "./packages/react"
             dist: "./packages/react"
@@ -90,4 +156,5 @@ jobs:
         if: failure()
         run: |
           json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Publish ${{ matrix.name }} failed: <https://github.com/cds-snc/gcds-components/actions/workflows/compile-and-publish.yml|Publish packages>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}        
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}
+


### PR DESCRIPTION
# Summary | Résumé

To fix build/publish errors when running the `compile-and-publish.yml` action, switch the action to run sequential jobs.

The first job, `publish-web` will publish the `@cdssnc/gcds-components` npm package and publish the the CDN files. The second job, `publish-react-angular`, will do the same with the React and Angular packages but only if the `publish-web` job completes.

This change was required since the React and Angular packages are dependant on the new published version of `@cdssnc/gcds-components` and would fail if the web package was not published first.
