### PR TITLE
Gcds-card component

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -113,14 +113,14 @@ export declare interface GcdsButton extends Components.GcdsButton {
 
 
 @ProxyCmp({
-  inputs: ['cardTitle', 'description', 'href', 'imgAlt', 'imgSrc', 'tag', 'type']
+  inputs: ['cardTitle', 'description', 'href', 'imgAlt', 'imgSrc', 'tag', 'titleElement', 'type']
 })
 @Component({
   selector: 'gcds-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['cardTitle', 'description', 'href', 'imgAlt', 'imgSrc', 'tag', 'type'],
+  inputs: ['cardTitle', 'description', 'href', 'imgAlt', 'imgSrc', 'tag', 'titleElement', 'type'],
 })
 export class GcdsCard {
   protected el: HTMLElement;

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -113,6 +113,28 @@ export declare interface GcdsButton extends Components.GcdsButton {
 
 
 @ProxyCmp({
+  inputs: ['cardTitle', 'description', 'href', 'imgAlt', 'imgSrc', 'tag', 'type']
+})
+@Component({
+  selector: 'gcds-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['cardTitle', 'description', 'href', 'imgAlt', 'imgSrc', 'tag', 'type'],
+})
+export class GcdsCard {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface GcdsCard extends Components.GcdsCard {}
+
+
+@ProxyCmp({
   inputs: ['blurHandler', 'checkboxId', 'checked', 'clickHandler', 'disabled', 'errorMessage', 'focusHandler', 'hint', 'label', 'name', 'required', 'validateOn', 'validator', 'value'],
   methods: ['validate']
 })

--- a/packages/angular/src/lib/stencil-generated/index.ts
+++ b/packages/angular/src/lib/stencil-generated/index.ts
@@ -6,6 +6,7 @@ export const DIRECTIVES = [
   d.GcdsBreadcrumbs,
   d.GcdsBreadcrumbsItem,
   d.GcdsButton,
+  d.GcdsCard,
   d.GcdsCheckbox,
   d.GcdsContainer,
   d.GcdsDateModified,

--- a/packages/react/src/components/stencil-generated/index.ts
+++ b/packages/react/src/components/stencil-generated/index.ts
@@ -12,6 +12,7 @@ export const GcdsAlert = /*@__PURE__*/createReactComponent<JSX.GcdsAlert, HTMLGc
 export const GcdsBreadcrumbs = /*@__PURE__*/createReactComponent<JSX.GcdsBreadcrumbs, HTMLGcdsBreadcrumbsElement>('gcds-breadcrumbs');
 export const GcdsBreadcrumbsItem = /*@__PURE__*/createReactComponent<JSX.GcdsBreadcrumbsItem, HTMLGcdsBreadcrumbsItemElement>('gcds-breadcrumbs-item');
 export const GcdsButton = /*@__PURE__*/createReactComponent<JSX.GcdsButton, HTMLGcdsButtonElement>('gcds-button');
+export const GcdsCard = /*@__PURE__*/createReactComponent<JSX.GcdsCard, HTMLGcdsCardElement>('gcds-card');
 export const GcdsCheckbox = /*@__PURE__*/createReactComponent<JSX.GcdsCheckbox, HTMLGcdsCheckboxElement>('gcds-checkbox');
 export const GcdsContainer = /*@__PURE__*/createReactComponent<JSX.GcdsContainer, HTMLGcdsContainerElement>('gcds-container');
 export const GcdsDateModified = /*@__PURE__*/createReactComponent<JSX.GcdsDateModified, HTMLGcdsDateModifiedElement>('gcds-date-modified');

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
-        "@cdssnc/gcds-tokens": "^1.1.1",
+        "@cdssnc/gcds-tokens": "^1.3.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -1923,9 +1923,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.1.1.tgz",
-      "integrity": "sha512-hkryLHgV/s50uOdc846568OZ9yC45DqQRja5NGuIrfdnE4lnL7nZbhSjvhGYLRtYx3e6oicYYoXxCMjLTsTZGw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.0.tgz",
+      "integrity": "sha512-QmQLJpU8ePgEHI51TxvBpDAIJxIz7uB5IMmw3pAdJQzSwlwBtwFu0JzKZ5PRT2NW7AvumpZ5l3MUiggtu4O/rQ==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -28130,9 +28130,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.1.1.tgz",
-      "integrity": "sha512-hkryLHgV/s50uOdc846568OZ9yC45DqQRja5NGuIrfdnE4lnL7nZbhSjvhGYLRtYx3e6oicYYoXxCMjLTsTZGw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.0.tgz",
+      "integrity": "sha512-QmQLJpU8ePgEHI51TxvBpDAIJxIz7uB5IMmw3pAdJQzSwlwBtwFu0JzKZ5PRT2NW7AvumpZ5l3MUiggtu4O/rQ==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.3.2",
         "@babel/core": "^7.20.12",
-        "@cdssnc/gcds-tokens": "^1.3.0",
+        "@cdssnc/gcds-tokens": "^1.3.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -1923,9 +1923,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.0.tgz",
-      "integrity": "sha512-QmQLJpU8ePgEHI51TxvBpDAIJxIz7uB5IMmw3pAdJQzSwlwBtwFu0JzKZ5PRT2NW7AvumpZ5l3MUiggtu4O/rQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.1.tgz",
+      "integrity": "sha512-BBOhGkBWEWTAkQUqLO4zGHDJc9Dcer1fDHi8b3Gz1UVub+f8mbGh3jRyVXpnmdunTmrkcyAbYFprTZE+afVbzQ==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -28130,9 +28130,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.0.tgz",
-      "integrity": "sha512-QmQLJpU8ePgEHI51TxvBpDAIJxIz7uB5IMmw3pAdJQzSwlwBtwFu0JzKZ5PRT2NW7AvumpZ5l3MUiggtu4O/rQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.1.tgz",
+      "integrity": "sha512-BBOhGkBWEWTAkQUqLO4zGHDJc9Dcer1fDHi8b3Gz1UVub+f8mbGh3jRyVXpnmdunTmrkcyAbYFprTZE+afVbzQ==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1923,15 +1923,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-<<<<<<< HEAD
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.0.tgz",
       "integrity": "sha512-QmQLJpU8ePgEHI51TxvBpDAIJxIz7uB5IMmw3pAdJQzSwlwBtwFu0JzKZ5PRT2NW7AvumpZ5l3MUiggtu4O/rQ==",
-=======
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.2.1.tgz",
-      "integrity": "sha512-EaFX5Rcn3iyBt8heszhi1oOvai/tXfGFawZ0PEui3b+IWjwwEgd+Ul4tMeSaCUytUWHzZCA6Ar7eUj2lTE7mfA==",
->>>>>>> staging
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -28136,15 +28130,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-<<<<<<< HEAD
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.3.0.tgz",
       "integrity": "sha512-QmQLJpU8ePgEHI51TxvBpDAIJxIz7uB5IMmw3pAdJQzSwlwBtwFu0JzKZ5PRT2NW7AvumpZ5l3MUiggtu4O/rQ==",
-=======
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.2.1.tgz",
-      "integrity": "sha512-EaFX5Rcn3iyBt8heszhi1oOvai/tXfGFawZ0PEui3b+IWjwwEgd+Ul4tMeSaCUytUWHzZCA6Ar7eUj2lTE7mfA==",
->>>>>>> staging
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.3.2",
     "@babel/core": "^7.20.12",
-    "@cdssnc/gcds-tokens": "^1.1.1",
+    "@cdssnc/gcds-tokens": "^1.3.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.3.2",
     "@babel/core": "^7.20.12",
-    "@cdssnc/gcds-tokens": "^1.3.0",
+    "@cdssnc/gcds-tokens": "^1.3.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -138,11 +138,11 @@ export namespace Components {
          */
         "tag": string;
         /**
-          * The card title element attribute specifies HTML element the title renders as
+          * The title element attribute specifies HTML element the title renders as
          */
         "titleElement": 'h3' | 'h4' | 'h5' | 'h6' | 'a';
         /**
-          * The type attribute specifies the how the card renders as a link
+          * The type attribute specifies how the card renders as a link
          */
         "type": 'link' | 'action';
     }
@@ -1264,11 +1264,11 @@ declare namespace LocalJSX {
          */
         "tag"?: string;
         /**
-          * The card title element attribute specifies HTML element the title renders as
+          * The title element attribute specifies HTML element the title renders as
          */
         "titleElement"?: 'h3' | 'h4' | 'h5' | 'h6' | 'a';
         /**
-          * The type attribute specifies the how the card renders as a link
+          * The type attribute specifies how the card renders as a link
          */
         "type"?: 'link' | 'action';
     }

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -6,6 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Validator, ValidatorEntry } from "./validators";
+export { Validator, ValidatorEntry } from "./validators";
 export namespace Components {
     interface GcdsAlert {
         /**
@@ -110,6 +111,28 @@ export namespace Components {
           * Set button types
          */
         "type": 'submit' | 'reset' | 'button' | 'link';
+    }
+    interface GcdsCard {
+        /**
+          * The card title attribute specifies the title that appears on the card
+         */
+        "cardTitle": string;
+        /**
+          * The description attribute specifies the body of text that appears on the card
+         */
+        "description": string;
+        /**
+          * The href attribute specifies the URL of the page the link goes to
+         */
+        "href": string;
+        /**
+          * The img alt attribute specifies the alt text for the image provided, if none, image will be decorative
+         */
+        "imgAlt": string;
+        /**
+          * The img src attribute specifies the path to the image
+         */
+        "imgSrc": string;
     }
     interface GcdsCheckbox {
         /**
@@ -901,6 +924,12 @@ declare global {
         prototype: HTMLGcdsButtonElement;
         new (): HTMLGcdsButtonElement;
     };
+    interface HTMLGcdsCardElement extends Components.GcdsCard, HTMLStencilElement {
+    }
+    var HTMLGcdsCardElement: {
+        prototype: HTMLGcdsCardElement;
+        new (): HTMLGcdsCardElement;
+    };
     interface HTMLGcdsCheckboxElement extends Components.GcdsCheckbox, HTMLStencilElement {
     }
     var HTMLGcdsCheckboxElement: {
@@ -1056,6 +1085,7 @@ declare global {
         "gcds-breadcrumbs": HTMLGcdsBreadcrumbsElement;
         "gcds-breadcrumbs-item": HTMLGcdsBreadcrumbsItemElement;
         "gcds-button": HTMLGcdsButtonElement;
+        "gcds-card": HTMLGcdsCardElement;
         "gcds-checkbox": HTMLGcdsCheckboxElement;
         "gcds-container": HTMLGcdsContainerElement;
         "gcds-date-modified": HTMLGcdsDateModifiedElement;
@@ -1195,6 +1225,28 @@ declare namespace LocalJSX {
           * Set button types
          */
         "type"?: 'submit' | 'reset' | 'button' | 'link';
+    }
+    interface GcdsCard {
+        /**
+          * The card title attribute specifies the title that appears on the card
+         */
+        "cardTitle": string;
+        /**
+          * The description attribute specifies the body of text that appears on the card
+         */
+        "description": string;
+        /**
+          * The href attribute specifies the URL of the page the link goes to
+         */
+        "href": string;
+        /**
+          * The img alt attribute specifies the alt text for the image provided, if none, image will be decorative
+         */
+        "imgAlt"?: string;
+        /**
+          * The img src attribute specifies the path to the image
+         */
+        "imgSrc"?: string;
     }
     interface GcdsCheckbox {
         /**
@@ -2037,6 +2089,7 @@ declare namespace LocalJSX {
         "gcds-breadcrumbs": GcdsBreadcrumbs;
         "gcds-breadcrumbs-item": GcdsBreadcrumbsItem;
         "gcds-button": GcdsButton;
+        "gcds-card": GcdsCard;
         "gcds-checkbox": GcdsCheckbox;
         "gcds-container": GcdsContainer;
         "gcds-date-modified": GcdsDateModified;
@@ -2072,6 +2125,7 @@ declare module "@stencil/core" {
             "gcds-breadcrumbs": LocalJSX.GcdsBreadcrumbs & JSXBase.HTMLAttributes<HTMLGcdsBreadcrumbsElement>;
             "gcds-breadcrumbs-item": LocalJSX.GcdsBreadcrumbsItem & JSXBase.HTMLAttributes<HTMLGcdsBreadcrumbsItemElement>;
             "gcds-button": LocalJSX.GcdsButton & JSXBase.HTMLAttributes<HTMLGcdsButtonElement>;
+            "gcds-card": LocalJSX.GcdsCard & JSXBase.HTMLAttributes<HTMLGcdsCardElement>;
             "gcds-checkbox": LocalJSX.GcdsCheckbox & JSXBase.HTMLAttributes<HTMLGcdsCheckboxElement>;
             "gcds-container": LocalJSX.GcdsContainer & JSXBase.HTMLAttributes<HTMLGcdsContainerElement>;
             "gcds-date-modified": LocalJSX.GcdsDateModified & JSXBase.HTMLAttributes<HTMLGcdsDateModifiedElement>;

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -137,6 +137,10 @@ export namespace Components {
           * The tag attribute specifies the tag text that appears above the card title
          */
         "tag": string;
+        /**
+          * The card title attribute specifies the title that appears on the card
+         */
+        "type": 'link' | 'action';
     }
     interface GcdsCheckbox {
         /**
@@ -1255,6 +1259,10 @@ declare namespace LocalJSX {
           * The tag attribute specifies the tag text that appears above the card title
          */
         "tag"?: string;
+        /**
+          * The card title attribute specifies the title that appears on the card
+         */
+        "type"?: 'link' | 'action';
     }
     interface GcdsCheckbox {
         /**

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -133,6 +133,10 @@ export namespace Components {
           * The img src attribute specifies the path to the image
          */
         "imgSrc": string;
+        /**
+          * The tag attribute specifies the tag text that appears above the card title
+         */
+        "tag": string;
     }
     interface GcdsCheckbox {
         /**
@@ -1234,7 +1238,7 @@ declare namespace LocalJSX {
         /**
           * The description attribute specifies the body of text that appears on the card
          */
-        "description": string;
+        "description"?: string;
         /**
           * The href attribute specifies the URL of the page the link goes to
          */
@@ -1247,6 +1251,10 @@ declare namespace LocalJSX {
           * The img src attribute specifies the path to the image
          */
         "imgSrc"?: string;
+        /**
+          * The tag attribute specifies the tag text that appears above the card title
+         */
+        "tag"?: string;
     }
     interface GcdsCheckbox {
         /**

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -140,6 +140,10 @@ export namespace Components {
         /**
           * The card title attribute specifies the title that appears on the card
          */
+        "titleElement": 'h3' | 'h4' | 'h5' | 'h6' | 'a';
+        /**
+          * The card title attribute specifies the title that appears on the card
+         */
         "type": 'link' | 'action';
     }
     interface GcdsCheckbox {
@@ -1259,6 +1263,10 @@ declare namespace LocalJSX {
           * The tag attribute specifies the tag text that appears above the card title
          */
         "tag"?: string;
+        /**
+          * The card title attribute specifies the title that appears on the card
+         */
+        "titleElement"?: 'h3' | 'h4' | 'h5' | 'h6' | 'a';
         /**
           * The card title attribute specifies the title that appears on the card
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -138,11 +138,11 @@ export namespace Components {
          */
         "tag": string;
         /**
-          * The card title attribute specifies the title that appears on the card
+          * The card title element attribute specifies HTML element the title renders as
          */
         "titleElement": 'h3' | 'h4' | 'h5' | 'h6' | 'a';
         /**
-          * The card title attribute specifies the title that appears on the card
+          * The type attribute specifies the how the card renders as a link
          */
         "type": 'link' | 'action';
     }
@@ -1264,11 +1264,11 @@ declare namespace LocalJSX {
          */
         "tag"?: string;
         /**
-          * The card title attribute specifies the title that appears on the card
+          * The card title element attribute specifies HTML element the title renders as
          */
         "titleElement"?: 'h3' | 'h4' | 'h5' | 'h6' | 'a';
         /**
-          * The card title attribute specifies the title that appears on the card
+          * The type attribute specifies the how the card renders as a link
          */
         "type"?: 'link' | 'action';
     }

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -1,29 +1,56 @@
-:host {
-  display: block;
+@layer reset, defaults, slot;
 
-  a {
-    border: 1px solid black;
+@layer reset {
+  :host * {
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+  }
+}
+
+@layer defaults {
+  :host {
     display: block;
-    height: 100%;
-    overflow: hidden;
-    text-decoration: none;
-
-    img {
-      width: 100%;
-    }
-
-    p {
-      padding: 0 1rem;
-      max-width: 65ch;
-    }
-
-    .gcds-card__title {
-      text-decoration: underline;
-      font: var(--gcds-font-h6);
-    }
-
-    .gcds-card__description {
+  
+    .gcds-card {
+      border: 1px solid var(--gcds-color-grayscale-100);
+      border-radius: var(--gcds-border-radius-md);
+      background-color: var(--gcds-color-grayscale-0);
+      display: block;
+      padding: var(--gcds-spacing-400);
+      height: 100%;
       color: #333;
+
+      *:not(slot):not(.gcds-card__spacer) {
+        display: block;
+        margin-bottom: var(--gcds-spacing-400);
+      }
+
+      .gcds-card__image {
+        width: 100%;
+      }
+  
+      .gcds-card__title {
+        text-decoration: underline;
+        font: var(--gcds-font-h6);
+      }
+  
+      .gcds-card__description {
+        max-width: 65ch;
+      }
+    }
+  }
+}
+
+@layer slot {
+  :host {
+    .gcds-card:has(slot) {
+      display: flex;
+      flex-direction: column;
+
+      .gcds-card__spacer {
+        flex: 1;
+      }
     }
   }
 }

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -47,7 +47,7 @@
       }
   
       .gcds-card__description {
-        max-width: 65ch;
+        max-width: var(--gcds-card-description-max-width);
       }
     }
   }

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -13,17 +13,18 @@
     display: block;
   
     .gcds-card {
-      border: 1px solid var(--gcds-color-grayscale-100); /* --gcds-card-border */
-      border-radius: var(--gcds-border-radius-md); /* --gcds-card-border-radius */
-      background-color: var(--gcds-color-grayscale-0); /* --gcds-card-background-color */
+      border: var(--gcds-card-border);
+      border-radius: var(--gcds-card-border-radius);
+      background-color: var(--gcds-card-background-color);
       display: block;
-      padding: var(--gcds-spacing-400); /* --gcds-card-padding */
+      padding: var(--gcds-card-padding);
       height: 100%;
-      color: var(--gcds-text-primary); /* --gcds-card-color */
+      color: var(--gcds-card-color);
+      position: relative;
 
-      *:not(slot):not(.gcds-card__spacer) {
+      > *:not(slot):not(.gcds-card__spacer) {
         display: block;
-        margin: 0 0 var(--gcds-spacing-400); /* --gcds-card-margin */
+        margin: var(--gcds-card-margin);
       }
 
       .gcds-card__image {
@@ -31,16 +32,17 @@
       }
 
       .gcds-card__tag {
-        font: var(--gcds-font-caption); /* --gcds-card-tag-font */
-        color: var(--gcds-text-secondary); /* --gcds-card-tag-color */
+        font: var(--gcds-card-tag-font);
+        color: var(--gcds-card-tag-color);
       }
   
-      .gcds-card__title {
-        color: var(--gcds-button-text-only-default-text); /* --gcds-card-title-color */
-        font: var(--gcds-font-h6); /* --gcds-card-title-font */
-        text-underline-offset: var(--gcds-border-width-md);
+      .gcds-card__title,
+      .gcds-card__title > a {
+        color: var(--gcds-card-title-color);
+        font: var(--gcds-card-title-font);
+        text-underline-offset: var(--gcds-card-title-text-underline-offset);
         text-decoration-color: currentColor;
-        text-decoration-thickness: var(--gcds-border-width-sm);  /* --gcds-card-decoration-thickness */
+        text-decoration-thickness: var(--gcds-card-title-text-decoration-thickness);
         width: fit-content;
       }
   
@@ -62,8 +64,8 @@
       }
 
       ::slotted(*) {
-        color: var(--gcds-text-secondary);  /* --gcds-card-slot-color */
-        font: var(--gcds-font-caption); /* --gcds-card-slot-font */
+        color: var(--gcds-card-slot-color);
+        font: var(--gcds-card-slot-font) !important;
         z-index: 2;
       }
     }
@@ -73,7 +75,8 @@
 @layer link {
   :host {
     .gcds-card--link {
-      .gcds-card__title::after {
+      .gcds-card__title > a::after,
+      a.gcds-card__title::after {
         position: absolute;
         top: 0;
         right: 0;
@@ -90,32 +93,35 @@
 @layer state.hover {
   :host {
     .gcds-card--link:hover {
-      background-color: var(--gcds-color-grayscale-50); /* --gcds-card-hover-background-color */
+      background-color: var(--gcds-card-hover-background-color);
       cursor: pointer;
-      box-shadow: 0 var(--gcds-spacing-50) var(--gcds-spacing-200) var(--gcds-spacing-50) var(--gcds-color-grayscale-100);  /* --gcds-card-hover-box-shadow */
+      box-shadow: var(--gcds-card-hover-box-shadow);
 
-      .gcds-card__title {
-        color: var(--gcds-link-hover);  /* --gcds-card-hover-title-color */
-        text-decoration-thickness: var(--gcds-border-width-md);  /* --gcds-card-hover-title-decoration-thickness */
+      .gcds-card__title > a,
+      a.gcds-card__title {
+        color: var(--gcds-card-hover-title-color);
+        text-decoration-thickness: var(--gcds-card-hover-title-text-decoration-thickness);
       }
     }
 
-    .gcds-card__title:hover {
-      color: var(--gcds-link-hover);  /* --gcds-card-hover-title-color */
-      text-decoration-thickness: var(--gcds-border-width-md);  /* --gcds-card-hover-title-decoration-thickness */
+    .gcds-card__title > a:hover,
+    a.gcds-card__title:hover {
+      color: var(--gcds-card-hover-title-color);
+      text-decoration-thickness: var(--gcds-card-hover-title-text-decoration-thickness);
     }
   }
 }
 
 @layer state.focus {
   :host {
-    .gcds-card__title:focus {
-      background-color: var(--gcds-focus-background); /* --gcds-card-focus-title-background-color */
-      border-radius: var(--gcds-border-radius-sm); /* --gcds-card-focus-title-border-radius */
-      box-shadow: 0var(--gcds-details-focus-box-shadow);  /* --gcds-card-focus-title-box-shadow */
-      color: var(--gcds-details-focus-text);  /* --gcds-card-focus-title-color */
-      outline: var(--gcds-details-focus-outline); /* --gcds-card-focus-title-outline */
-      outline-offset: var(--gcds-details-focus-outline-offset);  /* --gcds-card-focus-title-outline-offset */
+    .gcds-card__title > a:focus,
+    a.gcds-card__title:focus {
+      background-color: var(--gcds-card-focus-background);
+      border-radius: var(--gcds-card-focus-border-radius);
+      box-shadow: var(--gcds-card-focus-box-shadow);
+      color: var(--gcds-card-focus-color);
+      outline: var(--gcds-card-focus-outline);
+      outline-offset: var(--gcds-card-focus-outline-offset);
       text-decoration: none;
     }
   }

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -1,4 +1,4 @@
-@layer reset, defaults, slot;
+@layer reset, defaults, slot, state.hover, state.focus;
 
 @layer reset {
   :host * {
@@ -13,26 +13,35 @@
     display: block;
   
     .gcds-card {
-      border: 1px solid var(--gcds-color-grayscale-100);
-      border-radius: var(--gcds-border-radius-md);
-      background-color: var(--gcds-color-grayscale-0);
+      border: 1px solid var(--gcds-color-grayscale-100); /* --gcds-card-border */
+      border-radius: var(--gcds-border-radius-md); /* --gcds-card-border-radius */
+      background-color: var(--gcds-color-grayscale-0); /* --gcds-card-background-color */
       display: block;
-      padding: var(--gcds-spacing-400);
+      padding: var(--gcds-spacing-400); /* --gcds-card-padding */
       height: 100%;
-      color: #333;
+      color: var(--gcds-text-primary); /* --gcds-card-color */
 
       *:not(slot):not(.gcds-card__spacer) {
         display: block;
-        margin-bottom: var(--gcds-spacing-400);
+        margin: 0 0 var(--gcds-spacing-400); /* --gcds-card-margin */
       }
 
       .gcds-card__image {
         width: 100%;
       }
+
+      .gcds-card__tag {
+        font: var(--gcds-font-caption); /* --gcds-card-tag-font */
+        color: var(--gcds-text-secondary); /* --gcds-card-tag-color */
+      }
   
       .gcds-card__title {
-        text-decoration: underline;
-        font: var(--gcds-font-h6);
+        color: var(--gcds-button-text-only-default-text); /* --gcds-card-title-color */
+        font: var(--gcds-font-h6); /* --gcds-card-title-font */
+        text-underline-offset: var(--gcds-border-width-md);
+        text-decoration-color: currentColor;
+        text-decoration-thickness: var(--gcds-border-width-sm);  /* --gcds-card-decoration-thickness */
+        width: fit-content;
       }
   
       .gcds-card__description {
@@ -51,6 +60,44 @@
       .gcds-card__spacer {
         flex: 1;
       }
+
+      ::slotted(*) {
+        color: var(--gcds-text-secondary);  /* --gcds-card-slot-color */
+      }
+    }
+  }
+}
+
+@layer state.hover {
+  :host {
+    .gcds-card--link:hover {
+      background-color: var(--gcds-color-grayscale-50); /* --gcds-card-hover-background-color */
+      cursor: pointer;
+      box-shadow: 0 var(--gcds-spacing-50) var(--gcds-spacing-200) var(--gcds-spacing-50) var(--gcds-color-grayscale-100);  /* --gcds-card-hover-box-shadow */
+
+      .gcds-card__title {
+        color: var(--gcds-link-hover);  /* --gcds-card-hover-title-color */
+        text-decoration-thickness: var(--gcds-border-width-md);  /* --gcds-card-hover-title-decoration-thickness */
+      }
+    }
+
+    .gcds-card__title:hover {
+      color: var(--gcds-link-hover);  /* --gcds-card-hover-title-color */
+      text-decoration-thickness: var(--gcds-border-width-md);  /* --gcds-card-hover-title-decoration-thickness */
+    }
+  }
+}
+
+@layer state.focus {
+  :host {
+    .gcds-card__title:focus {
+      background-color: var(--gcds-focus-background); /* --gcds-card-focus-title-background-color */
+      border-radius: var(--gcds-border-radius-sm); /* --gcds-card-focus-title-border-radius */
+      box-shadow: 0var(--gcds-details-focus-box-shadow);  /* --gcds-card-focus-title-box-shadow */
+      color: var(--gcds-details-focus-text);  /* --gcds-card-focus-title-color */
+      outline: var(--gcds-details-focus-outline); /* --gcds-card-focus-title-outline */
+      outline-offset: var(--gcds-details-focus-outline-offset);  /* --gcds-card-focus-title-outline-offset */
+      text-decoration: none;
     }
   }
 }

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -1,0 +1,29 @@
+:host {
+  display: block;
+
+  a {
+    border: 1px solid black;
+    display: block;
+    height: 100%;
+    overflow: hidden;
+    text-decoration: none;
+
+    img {
+      width: 100%;
+    }
+
+    p {
+      padding: 0 1rem;
+      max-width: 65ch;
+    }
+
+    .gcds-card__title {
+      text-decoration: underline;
+      font: var(--gcds-font-h6);
+    }
+
+    .gcds-card__description {
+      color: #333;
+    }
+  }
+}

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -1,4 +1,4 @@
-@layer reset, defaults, slot, state.hover, state.focus;
+@layer reset, defaults, slot, link, state.hover, state.focus;
 
 @layer reset {
   :host * {
@@ -63,6 +63,25 @@
 
       ::slotted(*) {
         color: var(--gcds-text-secondary);  /* --gcds-card-slot-color */
+        font: var(--gcds-font-caption); /* --gcds-card-slot-font */
+        z-index: 2;
+      }
+    }
+  }
+}
+
+@layer link {
+  :host {
+    .gcds-card--link {
+      .gcds-card__title::after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 1;
+        pointer-events: auto;
+        content: "";
       }
     }
   }

--- a/packages/web/src/components/gcds-card/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.stories.tsx
@@ -1,0 +1,114 @@
+export default {
+  title: 'Components/Card',
+
+  argTypes: {
+    // Props
+    cardTitle: {
+      name: 'card-title',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+      type: {
+        required: true
+      }
+    },
+    href: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+      type: {
+        required: true
+      }
+    },
+    tag: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      }
+    },
+    description: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      }
+    },
+    imgSrc: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      }
+    },
+    imgAlt: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      }
+    },
+    type: {
+      control: 'radio',
+      options: ['link', 'action'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'link' }
+      },
+    },
+
+    // Slots
+    footer: {
+      control: {
+        type: 'text',
+      },
+      table: {
+        category: 'Slots | Fentes',
+      }
+    },
+  },
+};
+
+const Template = (args) => (`
+// Web Component (Angular, Vue)
+<gcds-card
+  card-title="${args.cardTitle}"
+  ${args.href ? `href="${args.href}"` : null}
+  ${args.type != 'link' ? `type="action"` : null}
+  ${args.tag ? `tag="${args.tag}"` : null}
+  ${args.description ? `description="${args.description}"` : null}
+  ${args.imgSrc ? `img-src="${args.imgSrc}"` : null}
+  ${args.imgAlt ? `img-alt="${args.imgAlt}"` : null}
+>
+  ${args.footer ? `<div slot="footer">${args.footer}</div>` : null}
+</gcds-card>
+
+// React code
+<GcdsCard
+  cardTitle="${args.cardTitle}"
+  ${args.href ? `href="${args.href}"` : null}
+  ${args.type != 'link' ? `type="action"` : null}
+  ${args.tag ? `tag="${args.tag}"` : null}
+  ${args.description ? `description="${args.description}"` : null}
+  ${args.imgSrc ? `imgSrc="${args.imgSrc}"` : null}
+  ${args.imgAlt ? `imgAlt="${args.imgAlt}"` : null}
+>
+  ${args.footer ? `<div slot="footer">${args.footer}</div>` : null}
+</GcdsCard>
+`).replace(/\s\snull\n/g, '');
+
+export const Default = Template.bind({});
+Default.args = {
+  cardTitle: 'Title of the article',
+  href: '#',
+  type: 'link',
+  tag: '',
+  description: '',
+  imgSrc: '',
+  imgAlt: '',
+  footer: '',
+};

--- a/packages/web/src/components/gcds-card/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.stories.tsx
@@ -60,6 +60,14 @@ export default {
         defaultValue: { summary: 'link' }
       },
     },
+    titleElement: {
+      control: 'radio',
+      options: ['h3', 'h4', 'h5', 'h6', 'a'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'a' }
+      },
+    },
 
     // Slots
     footer: {
@@ -79,6 +87,7 @@ const Template = (args) => (`
   card-title="${args.cardTitle}"
   ${args.href ? `href="${args.href}"` : null}
   ${args.type != 'link' ? `type="action"` : null}
+  ${args.titleElement != 'a' ? `title-element="${args.titleElement}"` : null}
   ${args.tag ? `tag="${args.tag}"` : null}
   ${args.description ? `description="${args.description}"` : null}
   ${args.imgSrc ? `img-src="${args.imgSrc}"` : null}
@@ -92,6 +101,7 @@ const Template = (args) => (`
   cardTitle="${args.cardTitle}"
   ${args.href ? `href="${args.href}"` : null}
   ${args.type != 'link' ? `type="action"` : null}
+  ${args.titleElement != 'a' ? `titleElement="${args.titleElement}"` : null}
   ${args.tag ? `tag="${args.tag}"` : null}
   ${args.description ? `description="${args.description}"` : null}
   ${args.imgSrc ? `imgSrc="${args.imgSrc}"` : null}
@@ -106,6 +116,7 @@ Default.args = {
   cardTitle: 'Title of the article',
   href: '#',
   type: 'link',
+  titleElement: 'a',
   tag: '',
   description: '',
   imgSrc: '',

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -11,6 +11,11 @@ export class GcdsCard {
   /**
    * The card title attribute specifies the title that appears on the card
    */
+  @Prop({ reflect: true }) type: 'link' | 'action' = 'link';
+
+  /**
+   * The card title attribute specifies the title that appears on the card
+   */
   @Prop({ reflect: true }) cardTitle!: string;
 
   /**
@@ -43,10 +48,15 @@ export class GcdsCard {
   }
 
   render() {
-    const { cardTitle, href, description, tag, imgSrc, imgAlt, hasCardFooter } = this;
+    const { type, cardTitle, href, description, tag, imgSrc, imgAlt, hasCardFooter } = this;
+
+
     return (
       <Host>
-        <div class="gcds-card">
+        <div 
+          class={`gcds-card gcds-card--${type}`}
+          onClick={() => type == 'link' && window.location.replace(href)}
+        >
           {imgSrc &&
             <img 
               src={imgSrc}

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -9,7 +9,7 @@ export class GcdsCard {
   @Element() el: HTMLElement;
 
   /**
-   * The card title attribute specifies the title that appears on the card
+   * The type attribute specifies the how the card renders as a link
    */
   @Prop({ reflect: true }) type: 'link' | 'action' = 'link';
 
@@ -19,7 +19,7 @@ export class GcdsCard {
   @Prop({ reflect: true }) cardTitle!: string;
 
   /**
-   * The card title attribute specifies the title that appears on the card
+   * The card title element attribute specifies HTML element the title renders as
    */
   @Prop() titleElement: 'h3' | 'h4' | 'h5' | 'h6' | 'a' = 'a';
 

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -1,0 +1,54 @@
+import { Component, Host, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'gcds-card',
+  styleUrl: 'gcds-card.css',
+  shadow: true,
+})
+export class GcdsCard {
+
+  /**
+   * The card title attribute specifies the title that appears on the card
+   */
+  @Prop({ reflect: true }) cardTitle!: string;
+
+  /**
+   * The href attribute specifies the URL of the page the link goes to
+   */
+  @Prop({ reflect: true }) href!: string;
+
+  /**
+   * The description attribute specifies the body of text that appears on the card
+   */
+  @Prop({ reflect: true }) description!: string;
+
+  /**
+   * The img src attribute specifies the path to the image
+   */
+  @Prop({ reflect: true }) imgSrc: string;
+
+  /**
+   * The img alt attribute specifies the alt text for the image provided, if none, image will be decorative
+   */
+  @Prop({ reflect: true }) imgAlt: string;
+
+  render() {
+    const { cardTitle, href, description, imgSrc, imgAlt } = this;
+    return (
+      <Host>
+        <a href={href}>
+          {imgSrc &&
+            <img src={imgSrc} alt={imgAlt ? imgAlt : ""} />
+          }
+          <p class="gcds-card__title">
+            {cardTitle}
+          </p>
+          <p class="gcds-card__description">
+            {description}
+          </p>
+        </a>
+      </Host>
+    );
+  }
+
+}

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -9,7 +9,7 @@ export class GcdsCard {
   @Element() el: HTMLElement;
 
   /**
-   * The type attribute specifies the how the card renders as a link
+   * The type attribute specifies how the card renders as a link
    */
   @Prop({ reflect: true }) type: 'link' | 'action' = 'link';
 

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, Prop, h } from '@stencil/core';
+import { Element, Component, Host, Prop, h, Fragment } from '@stencil/core';
 
 @Component({
   tag: 'gcds-card',
@@ -6,6 +6,7 @@ import { Component, Host, Prop, h } from '@stencil/core';
   shadow: true,
 })
 export class GcdsCard {
+  @Element() el: HTMLElement;
 
   /**
    * The card title attribute specifies the title that appears on the card
@@ -20,7 +21,12 @@ export class GcdsCard {
   /**
    * The description attribute specifies the body of text that appears on the card
    */
-  @Prop({ reflect: true }) description!: string;
+  @Prop({ reflect: true }) description: string;
+
+  /**
+   * The tag attribute specifies the tag text that appears above the card title
+   */
+  @Prop({ reflect: true }) tag: string;
 
   /**
    * The img src attribute specifies the path to the image
@@ -32,21 +38,45 @@ export class GcdsCard {
    */
   @Prop({ reflect: true }) imgAlt: string;
 
+  private get hasCardFooter() {
+    return !!this.el.querySelector('[slot="footer"]');
+  }
+
   render() {
-    const { cardTitle, href, description, imgSrc, imgAlt } = this;
+    const { cardTitle, href, description, tag, imgSrc, imgAlt, hasCardFooter } = this;
     return (
       <Host>
-        <a href={href}>
+        <div class="gcds-card">
           {imgSrc &&
-            <img src={imgSrc} alt={imgAlt ? imgAlt : ""} />
+            <img 
+              src={imgSrc}
+              alt={imgAlt ? imgAlt : ""}
+              class="gcds-card__image"
+            />
           }
-          <p class="gcds-card__title">
+          {tag &&
+            <span class="gcds-card__tag">
+              {tag}
+            </span>
+          }
+          <a
+            href={href}
+            class="gcds-card__title"
+          >
             {cardTitle}
-          </p>
-          <p class="gcds-card__description">
-            {description}
-          </p>
-        </a>
+          </a>
+          {description &&
+            <p class="gcds-card__description">
+              {description}
+            </p>
+          }
+          {hasCardFooter &&
+            <>
+              <div class="gcds-card__spacer"></div>
+              <slot name="footer"></slot>
+            </>
+          }
+        </div>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -50,12 +50,10 @@ export class GcdsCard {
   render() {
     const { type, cardTitle, href, description, tag, imgSrc, imgAlt, hasCardFooter } = this;
 
-
     return (
       <Host>
         <div 
           class={`gcds-card gcds-card--${type}`}
-          onClick={() => type == 'link' && window.location.replace(href)}
         >
           {imgSrc &&
             <img 

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -19,6 +19,11 @@ export class GcdsCard {
   @Prop({ reflect: true }) cardTitle!: string;
 
   /**
+   * The card title attribute specifies the title that appears on the card
+   */
+  @Prop() titleElement: 'h3' | 'h4' | 'h5' | 'h6' | 'a' = 'a';
+
+  /**
    * The href attribute specifies the URL of the page the link goes to
    */
   @Prop({ reflect: true }) href!: string;
@@ -48,7 +53,9 @@ export class GcdsCard {
   }
 
   render() {
-    const { type, cardTitle, href, description, tag, imgSrc, imgAlt, hasCardFooter } = this;
+    const { type, cardTitle, titleElement, href, description, tag, imgSrc, imgAlt, hasCardFooter } = this;
+
+    const Element = titleElement;
 
     return (
       <Host>
@@ -67,12 +74,21 @@ export class GcdsCard {
               {tag}
             </span>
           }
-          <a
-            href={href}
-            class="gcds-card__title"
-          >
-            {cardTitle}
-          </a>
+          {Element != 'a' ?
+           <Element class="gcds-card__title">
+              <a href={href}>
+                {cardTitle}
+              </a>
+            </Element>
+          :
+            <a
+              href={href}
+              class="gcds-card__title"
+            >
+              {cardTitle}
+            </a>
+          }
+
           {description &&
             <p class="gcds-card__description">
               {description}

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -19,7 +19,7 @@ export class GcdsCard {
   @Prop({ reflect: true }) cardTitle!: string;
 
   /**
-   * The card title element attribute specifies HTML element the title renders as
+   * The title element attribute specifies HTML element the title renders as
    */
   @Prop() titleElement: 'h3' | 'h4' | 'h5' | 'h6' | 'a' = 'a';
 

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -1,0 +1,23 @@
+# gcds-card
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property                 | Attribute     | Description                                                                                            | Type                 | Default     |
+| ------------------------ | ------------- | ------------------------------------------------------------------------------------------------------ | -------------------- | ----------- |
+| `cardTitle` _(required)_ | `card-title`  | The card title attribute specifies the title that appears on the card                                  | `string`             | `undefined` |
+| `description`            | `description` | The description attribute specifies the body of text that appears on the card                          | `string`             | `undefined` |
+| `href` _(required)_      | `href`        | The href attribute specifies the URL of the page the link goes to                                      | `string`             | `undefined` |
+| `imgAlt`                 | `img-alt`     | The img alt attribute specifies the alt text for the image provided, if none, image will be decorative | `string`             | `undefined` |
+| `imgSrc`                 | `img-src`     | The img src attribute specifies the path to the image                                                  | `string`             | `undefined` |
+| `tag`                    | `tag`         | The tag attribute specifies the tag text that appears above the card title                             | `string`             | `undefined` |
+| `type`                   | `type`        | The card title attribute specifies the title that appears on the card                                  | `"action" \| "link"` | `'link'`    |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -15,8 +15,8 @@
 | `imgAlt`                 | `img-alt`       | The img alt attribute specifies the alt text for the image provided, if none, image will be decorative | `string`                              | `undefined` |
 | `imgSrc`                 | `img-src`       | The img src attribute specifies the path to the image                                                  | `string`                              | `undefined` |
 | `tag`                    | `tag`           | The tag attribute specifies the tag text that appears above the card title                             | `string`                              | `undefined` |
-| `titleElement`           | `title-element` | The card title element attribute specifies HTML element the title renders as                           | `"a" \| "h3" \| "h4" \| "h5" \| "h6"` | `'a'`       |
-| `type`                   | `type`          | The type attribute specifies the how the card renders as a link                                        | `"action" \| "link"`                  | `'link'`    |
+| `titleElement`           | `title-element` | The title element attribute specifies HTML element the title renders as                                | `"a" \| "h3" \| "h4" \| "h5" \| "h6"` | `'a'`       |
+| `type`                   | `type`          | The type attribute specifies how the card renders as a link                                            | `"action" \| "link"`                  | `'link'`    |
 
 
 ----------------------------------------------

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -15,8 +15,8 @@
 | `imgAlt`                 | `img-alt`       | The img alt attribute specifies the alt text for the image provided, if none, image will be decorative | `string`                              | `undefined` |
 | `imgSrc`                 | `img-src`       | The img src attribute specifies the path to the image                                                  | `string`                              | `undefined` |
 | `tag`                    | `tag`           | The tag attribute specifies the tag text that appears above the card title                             | `string`                              | `undefined` |
-| `titleElement`           | `title-element` | The card title attribute specifies the title that appears on the card                                  | `"a" \| "h3" \| "h4" \| "h5" \| "h6"` | `'a'`       |
-| `type`                   | `type`          | The card title attribute specifies the title that appears on the card                                  | `"action" \| "link"`                  | `'link'`    |
+| `titleElement`           | `title-element` | The card title element attribute specifies HTML element the title renders as                           | `"a" \| "h3" \| "h4" \| "h5" \| "h6"` | `'a'`       |
+| `type`                   | `type`          | The type attribute specifies the how the card renders as a link                                        | `"action" \| "link"`                  | `'link'`    |
 
 
 ----------------------------------------------

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property                 | Attribute     | Description                                                                                            | Type                 | Default     |
-| ------------------------ | ------------- | ------------------------------------------------------------------------------------------------------ | -------------------- | ----------- |
-| `cardTitle` _(required)_ | `card-title`  | The card title attribute specifies the title that appears on the card                                  | `string`             | `undefined` |
-| `description`            | `description` | The description attribute specifies the body of text that appears on the card                          | `string`             | `undefined` |
-| `href` _(required)_      | `href`        | The href attribute specifies the URL of the page the link goes to                                      | `string`             | `undefined` |
-| `imgAlt`                 | `img-alt`     | The img alt attribute specifies the alt text for the image provided, if none, image will be decorative | `string`             | `undefined` |
-| `imgSrc`                 | `img-src`     | The img src attribute specifies the path to the image                                                  | `string`             | `undefined` |
-| `tag`                    | `tag`         | The tag attribute specifies the tag text that appears above the card title                             | `string`             | `undefined` |
-| `type`                   | `type`        | The card title attribute specifies the title that appears on the card                                  | `"action" \| "link"` | `'link'`    |
+| Property                 | Attribute       | Description                                                                                            | Type                                  | Default     |
+| ------------------------ | --------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------- | ----------- |
+| `cardTitle` _(required)_ | `card-title`    | The card title attribute specifies the title that appears on the card                                  | `string`                              | `undefined` |
+| `description`            | `description`   | The description attribute specifies the body of text that appears on the card                          | `string`                              | `undefined` |
+| `href` _(required)_      | `href`          | The href attribute specifies the URL of the page the link goes to                                      | `string`                              | `undefined` |
+| `imgAlt`                 | `img-alt`       | The img alt attribute specifies the alt text for the image provided, if none, image will be decorative | `string`                              | `undefined` |
+| `imgSrc`                 | `img-src`       | The img src attribute specifies the path to the image                                                  | `string`                              | `undefined` |
+| `tag`                    | `tag`           | The tag attribute specifies the tag text that appears above the card title                             | `string`                              | `undefined` |
+| `titleElement`           | `title-element` | The card title attribute specifies the title that appears on the card                                  | `"a" \| "h3" \| "h4" \| "h5" \| "h6"` | `'a'`       |
+| `type`                   | `type`          | The card title attribute specifies the title that appears on the card                                  | `"action" \| "link"`                  | `'link'`    |
 
 
 ----------------------------------------------

--- a/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
+++ b/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
@@ -21,9 +21,12 @@ describe('gcds-card a11y tests', () => {
     const page = await newE2EPage();
     await page.setContent(`<gcds-card
       card-title="Card"
+      tag="Tag"
       description="This is the card description"
       href="#card"
-    ></gcds-card>`);
+    >
+      <p slot="footer">Metadata</p>
+    </gcds-card>`);
 
     const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
     let results = await colorContrastTest;
@@ -53,11 +56,11 @@ describe('gcds-card a11y tests', () => {
       href="#card"
     ></gcds-card>`);
 
-    const linkText = await (await page.find('gcds-card >>> a')).innerText;
+    const linkText = await (await page.find('gcds-card >>> .gcds-card__title')).innerText;
 
     await page.keyboard.press("Tab");
 
-    expect(await page.evaluate(() => window.document.activeElement.shadowRoot.textContent)).toEqual(linkText);
+    expect(await page.evaluate(() => window.document.activeElement.shadowRoot.activeElement.textContent)).toEqual(linkText);
   });
 
   it('Alt text - no img-alt prop', async () => {
@@ -66,7 +69,7 @@ describe('gcds-card a11y tests', () => {
       card-title="Card"
       description="This is the card description"
       href="#card"
-      img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+      img-src="https://picsum.photos/480/270"
     ></gcds-card>`);
 
     const imgAltTest = new AxePuppeteer(page).withRules('image-alt').analyze();
@@ -81,7 +84,7 @@ describe('gcds-card a11y tests', () => {
       card-title="Card"
       description="This is the card description"
       href="#card"
-      img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+      img-src="https://picsum.photos/480/270"
       img-alt="Alt text for image test"
     ></gcds-card>`);
 

--- a/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
+++ b/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
@@ -1,0 +1,93 @@
+import { newE2EPage } from '@stencil/core/testing';
+const { AxePuppeteer } = require('@axe-core/puppeteer');
+
+describe('gcds-card', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<gcds-card></gcds-card>');
+
+    const element = await page.find('gcds-card');
+    expect(element).toHaveClass('hydrated');
+  });
+});
+
+/*
+ * Accessibility tests
+ * Axe-core rules: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-21-level-a--aa-rules
+ */
+
+describe('gcds-card a11y tests', () => {
+  it('Colour contrast: Primary button-role, button-styles', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<gcds-card
+      card-title="Card"
+      description="This is the card description"
+      href="#card"
+    ></gcds-card>`);
+
+    const colorContrastTest = new AxePuppeteer(page).withRules('color-contrast').analyze();
+    let results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('Link name', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<gcds-card
+      card-title="Card"
+      description="This is the card description"
+      href="#card"
+    ></gcds-card>`);
+
+    const linkNameTest = new AxePuppeteer(page).withRules('link-name').analyze();
+    let results = await linkNameTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('Keyboard focus', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<gcds-card
+      card-title="Card"
+      description="This is the card description"
+      href="#card"
+    ></gcds-card>`);
+
+    const linkText = await (await page.find('gcds-card >>> a')).innerText;
+
+    await page.keyboard.press("Tab");
+
+    expect(await page.evaluate(() => window.document.activeElement.shadowRoot.textContent)).toEqual(linkText);
+  });
+
+  it('Alt text - no img-alt prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<gcds-card
+      card-title="Card"
+      description="This is the card description"
+      href="#card"
+      img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+    ></gcds-card>`);
+
+    const imgAltTest = new AxePuppeteer(page).withRules('image-alt').analyze();
+    let results = await imgAltTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('Alt text w/ img-alt prop', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`<gcds-card
+      card-title="Card"
+      description="This is the card description"
+      href="#card"
+      img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+      img-alt="Alt text for image test"
+    ></gcds-card>`);
+
+    const imgAltTest = new AxePuppeteer(page).withRules('image-alt').analyze();
+    let results = await imgAltTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+});

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -1,0 +1,56 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GcdsCard } from '../gcds-card';
+
+describe('gcds-card', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        card-title="Card"
+        description="This is the card description"
+        href="#card"
+      ></gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-card card-title="Card" description="This is the card description" href="#card">
+        <mock:shadow-root>
+          <a href="#card">
+            <p class="gcds-card__title">
+              Card
+            </p>
+            <p class="gcds-card__description">
+              This is the card description
+            </p>
+          </a>
+        </mock:shadow-root>
+      </gcds-card>
+    `);
+  });
+
+  it('renders w/ img', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        card-title="Card"
+        description="This is the card description"
+        href="#card"
+        img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+      ></gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-card card-title="Card" description="This is the card description" href="#card"  img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg">
+        <mock:shadow-root>
+          <a href="#card">
+            <img alt="" src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg">
+            <p class="gcds-card__title">
+              Card
+            </p>
+            <p class="gcds-card__description">
+              This is the card description
+            </p>
+          </a>
+        </mock:shadow-root>
+      </gcds-card>
+    `);
+  });
+});

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -46,6 +46,31 @@ describe('gcds-card', () => {
     `);
   });
 
+  it('renders w/ h3 element', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        type="link"
+        card-title="Card"
+        href="#card"
+        title-element="h3"
+      ></gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+    <gcds-card card-title="Card" href="#card" title-element="h3" type="link">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--link">
+          <h3 class="gcds-card__title">
+            <a href="#card">
+                Card
+            </a>
+          </h3>
+        </div>
+      </mock:shadow-root>
+    </gcds-card
+    `);
+  });
+
   it('renders w/ tag', async () => {
     const page = await newSpecPage({
       components: [GcdsCard],

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -2,28 +2,97 @@ import { newSpecPage } from '@stencil/core/testing';
 import { GcdsCard } from '../gcds-card';
 
 describe('gcds-card', () => {
-  it('renders', async () => {
+  it('renders - type link', async () => {
     const page = await newSpecPage({
       components: [GcdsCard],
       html: `<gcds-card
+        type="link"
         card-title="Card"
-        description="This is the card description"
         href="#card"
       ></gcds-card>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-card card-title="Card" description="This is the card description" href="#card">
-        <mock:shadow-root>
-          <a href="#card">
-            <p class="gcds-card__title">
-              Card
-            </p>
-            <p class="gcds-card__description">
-              This is the card description
-            </p>
+    <gcds-card card-title="Card" href="#card" type="link">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--link">
+          <a class="gcds-card__title" href="#card">
+            Card
           </a>
-        </mock:shadow-root>
-      </gcds-card>
+        </div>
+      </mock:shadow-root>
+    </gcds-card
+    `);
+  });
+
+  it('renders - type action', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        type="action"
+        card-title="Card"
+        href="#card"
+      ></gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+    <gcds-card card-title="Card" href="#card" type="action">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--action">
+          <a class="gcds-card__title" href="#card">
+            Card
+          </a>
+        </div>
+      </mock:shadow-root>
+    </gcds-card
+    `);
+  });
+
+  it('renders w/ tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        type="link"
+        card-title="Card"
+        href="#card"
+        tag="Tag"
+      ></gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+    <gcds-card card-title="Card" href="#card" tag="Tag" type="link">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--link">
+          <span class="gcds-card__tag">Tag</span>
+          <a class="gcds-card__title" href="#card">
+            Card
+          </a>
+        </div>
+      </mock:shadow-root>
+    </gcds-card
+    `);
+  });
+
+  it('renders w/ description', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        type="link"
+        card-title="Card"
+        href="#card"
+        description="This is the card description"
+      ></gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+    <gcds-card card-title="Card" href="#card" description="This is the card description" type="link">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--link">
+          <a class="gcds-card__title" href="#card">
+            Card
+          </a>
+          <p class="gcds-card__description">
+            This is the card description
+          </p>
+        </div>
+      </mock:shadow-root>
+    </gcds-card
     `);
   });
 
@@ -32,25 +101,74 @@ describe('gcds-card', () => {
       components: [GcdsCard],
       html: `<gcds-card
         card-title="Card"
-        description="This is the card description"
         href="#card"
-        img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+        img-src="https://picsum.photos/480/270"
       ></gcds-card>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-card card-title="Card" description="This is the card description" href="#card"  img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg">
-        <mock:shadow-root>
-          <a href="#card">
-            <img alt="" src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg">
-            <p class="gcds-card__title">
-              Card
-            </p>
-            <p class="gcds-card__description">
-              This is the card description
-            </p>
+    <gcds-card card-title="Card" href="#card" img-src="https://picsum.photos/480/270" type="link">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--link">
+          <img alt="" class="gcds-card__image" src="https://picsum.photos/480/270">
+          <a class="gcds-card__title" href="#card">
+            Card
           </a>
-        </mock:shadow-root>
-      </gcds-card>
+        </div>
+      </mock:shadow-root>
+    </gcds-card>
+    `);
+  });
+
+  it('renders w/ img and alt', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        card-title="Card"
+        href="#card"
+        img-src="https://picsum.photos/480/270"
+        img-alt="Alt text for image from picsum"
+      ></gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+    <gcds-card card-title="Card" href="#card" img-src="https://picsum.photos/480/270" img-alt="Alt text for image from picsum" type="link">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--link">
+          <img alt="Alt text for image from picsum" class="gcds-card__image" src="https://picsum.photos/480/270">
+          <a class="gcds-card__title" href="#card">
+            Card
+          </a>
+        </div>
+      </mock:shadow-root>
+    </gcds-card>
+    `);
+  });
+
+  it('renders w/ footer slot', async () => {
+    const page = await newSpecPage({
+      components: [GcdsCard],
+      html: `<gcds-card
+        type="link"
+        card-title="Card"
+        href="#card"
+      >
+        <p slot="footer">Additional Metadata</p>
+      </gcds-card>`,
+    });
+    expect(page.root).toEqualHtml(`
+    <gcds-card card-title="Card" href="#card" type="link">
+      <mock:shadow-root>
+        <div class="gcds-card gcds-card--link">
+          <a class="gcds-card__title" href="#card">
+            Card
+          </a>
+          <div class="gcds-card__spacer"></div>
+          <slot name="footer"></slot>
+        </div>
+      </mock:shadow-root>
+      <p slot="footer">
+        Additional Metadata
+      </p>
+    </gcds-card
     `);
   });
 });

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -143,51 +143,40 @@
           card-title="Hello card number 1"
           href="#red"
           description="This is a card"
-          img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+          tag="Core"
+          img-src="https://picsum.photos/480/270"
         >
-            <div slot="footer">
-                Red
-            </div>
         </gcds-card>
 
         <gcds-card
           card-title="Hello card number 2 with a really long title for some reason"
           href="#red"
+          type="action"
           description="This is a card with an img and possibly more"
-          img-src="https://www.canada.ca/content/dam/ised-isde/images/features/CDAP_Generic_Banner_360x203.jpg"
+          img-src="https://picsum.photos/480/270"
         >
-                <gcds-button slot="footer">
-                Buttons
-                </gcds-button>
+            <gcds-button slot="footer">RED</gcds-button>
         </gcds-card>
 
         <gcds-card
           card-title="Hello card number 3"
           href="#red"
           description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque viverra ex at scelerisque vulputate. Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
-          img-src="https://www.canada.ca/content/dam/themes/business/features/OCT%20-%201058_09_20%20-%2050-30Challenge_WebButton_360x203_1.jpg"
+          img-src="https://picsum.photos/480/270"
         >
-                <gcds-button slot="footer">
-                Buttons
-                </gcds-button>
         </gcds-card>
         <gcds-card
           card-title="Hello card number 4"
           href="#red"
           description="Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
-          img-src="https://www.canada.ca/content/dam/themes/business/features/OCT%20-%201058_09_20%20-%2050-30Challenge_WebButton_360x203_1.jpg"
+          img-src="https://picsum.photos/480/270"
         >
-            <div slot="footer">
-                <gcds-button>
-                Buttons
-                </gcds-button>
-            </div>
         </gcds-card>
         <gcds-card
           card-title="Hello card number 5"
           href="#red"
           description="This is a card with an img and possibly more"
-          img-src="https://www.canada.ca/content/dam/ised-isde/images/features/CDAP_Generic_Banner_360x203.jpg"
+          img-src="https://picsum.photos/480/270"
         >
         </gcds-card>
       </gcds-grid>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -131,6 +131,62 @@
       </gcds-button>
 
       <!-- ------------- Containers ------------- -->
+      <h3 class="mt-700 mb-400 bb-sm">Cards</h3>
+      <gcds-grid
+        tag="div"
+        columns-desktop="1fr 1fr 1fr"
+        columns-tablet="1fr 1fr"
+        columns="1fr"
+        gap="250"
+      >
+        <gcds-card
+          card-title="Hello card number 1"
+          href="#red"
+          description="This is a card"
+          img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
+        >
+        </gcds-card>
+
+        <gcds-card
+          card-title="Hello card number 2"
+          href="#red"
+          description="This is a card with an img and possibly more"
+          img-src="https://www.canada.ca/content/dam/ised-isde/images/features/CDAP_Generic_Banner_360x203.jpg"
+        >
+        </gcds-card>
+
+        <gcds-card
+          card-title="Hello card number 3"
+          href="#red"
+          description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque viverra ex at scelerisque vulputate. Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
+          img-src="https://www.canada.ca/content/dam/themes/business/features/OCT%20-%201058_09_20%20-%2050-30Challenge_WebButton_360x203_1.jpg"
+        >
+        </gcds-card>
+        <gcds-card
+          card-title="Hello card number 4"
+          href="#red"
+          description="Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
+          img-src="https://www.canada.ca/content/dam/themes/business/features/OCT%20-%201058_09_20%20-%2050-30Challenge_WebButton_360x203_1.jpg"
+        >
+        </gcds-card>
+        <gcds-card
+          card-title="Hello card number 5"
+          href="#red"
+          description="This is a card with an img and possibly more"
+          img-src="https://www.canada.ca/content/dam/ised-isde/images/features/CDAP_Generic_Banner_360x203.jpg"
+        >
+        </gcds-card>
+      </gcds-grid>
+
+      <gcds-card
+        class="mt-400"
+        card-title="Card not in column"
+        href="#red"
+        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque viverra ex at scelerisque vulputate. Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
+      >
+      </gcds-card>
+
+      <!-- ------------- Containers ------------- -->
 
       <h3 class="mt-700 mb-400 bb-sm">Containers</h3>
       <gcds-container container="full">

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -145,14 +145,20 @@
           description="This is a card"
           img-src="https://www.canada.ca/content/dam/themes/business/features/1017_05_22_BBF_NL_Button_360x203.jpg"
         >
+            <div slot="footer">
+                Red
+            </div>
         </gcds-card>
 
         <gcds-card
-          card-title="Hello card number 2"
+          card-title="Hello card number 2 with a really long title for some reason"
           href="#red"
           description="This is a card with an img and possibly more"
           img-src="https://www.canada.ca/content/dam/ised-isde/images/features/CDAP_Generic_Banner_360x203.jpg"
         >
+                <gcds-button slot="footer">
+                Buttons
+                </gcds-button>
         </gcds-card>
 
         <gcds-card
@@ -161,6 +167,9 @@
           description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque viverra ex at scelerisque vulputate. Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
           img-src="https://www.canada.ca/content/dam/themes/business/features/OCT%20-%201058_09_20%20-%2050-30Challenge_WebButton_360x203_1.jpg"
         >
+                <gcds-button slot="footer">
+                Buttons
+                </gcds-button>
         </gcds-card>
         <gcds-card
           card-title="Hello card number 4"
@@ -168,6 +177,11 @@
           description="Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
           img-src="https://www.canada.ca/content/dam/themes/business/features/OCT%20-%201058_09_20%20-%2050-30Challenge_WebButton_360x203_1.jpg"
         >
+            <div slot="footer">
+                <gcds-button>
+                Buttons
+                </gcds-button>
+            </div>
         </gcds-card>
         <gcds-card
           card-title="Hello card number 5"

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -130,8 +130,10 @@
         External Link
       </gcds-button>
 
-      <!-- ------------- Containers ------------- -->
+      <!-- ------------- Cards ------------- -->
+
       <h3 class="mt-700 mb-400 bb-sm">Cards</h3>
+
       <gcds-grid
         tag="div"
         columns-desktop="1fr 1fr 1fr"
@@ -140,7 +142,8 @@
         gap="250"
       >
         <gcds-card
-          card-title="Hello card number 1"
+          card-title="Link card number 1"
+          title-element="h4"
           href="#red"
           description="This is a card"
           tag="Core"
@@ -149,35 +152,51 @@
         </gcds-card>
 
         <gcds-card
-          card-title="Hello card number 2 with a really long title for some reason"
+          card-title="Link card number 2 with a really long title for some reason"
+          title-element="h4"
           href="#red"
-          type="action"
           description="This is a card with an img and possibly more"
           img-src="https://picsum.photos/480/270"
         >
-            <gcds-button slot="footer">RED</gcds-button>
         </gcds-card>
 
         <gcds-card
-          card-title="Hello card number 3"
+          card-title="Link card number 3"
+          title-element="h4"
           href="#red"
           description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque viverra ex at scelerisque vulputate. Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
           img-src="https://picsum.photos/480/270"
         >
         </gcds-card>
+      </gcds-grid>
+
+      <gcds-grid
+        tag="div"
+        columns-desktop="1fr 1fr"
+        columns-tablet="1fr"
+        columns="1fr"
+        gap="250"
+        class="d-block mt-250"
+      >
         <gcds-card
-          card-title="Hello card number 4"
+          type="action"
+          card-title="Action card number 1"
+          title-element="h4"
           href="#red"
           description="Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
           img-src="https://picsum.photos/480/270"
         >
+          <gcds-button type="button" button-role="secondary" slot="footer">Action</gcds-button>
         </gcds-card>
         <gcds-card
-          card-title="Hello card number 5"
+          type="action"
+          card-title="Action card number 2"
+          title-element="h4"
           href="#red"
           description="This is a card with an img and possibly more"
           img-src="https://picsum.photos/480/270"
         >
+          <gcds-button type="button" button-role="secondary" slot="footer">Action</gcds-button>
         </gcds-card>
       </gcds-grid>
 

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -7,7 +7,7 @@ import { angularOutputTarget } from '@stencil/angular-output-target';
 
 export const config: Config = {
   namespace: 'gcds',
-  globalStyle: './node_modules/@cdssnc/gcds-tokens/build/web/variables.css',
+  globalStyle: './node_modules/@cdssnc/gcds-tokens/build/web/css/tokens.css',
   srcDir: './src',
   outputTargets: [
     react({

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -15,7 +15,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment"
   },
   "include": [
     "src"


### PR DESCRIPTION
# Summary | Résumé

Add new `gcds-card` to component library.

## Gcds-card

```
<gcds-card
  type="link"                // link | action
  card-title=""              // *required, string
  href=""                       // *required, string
  title-element="a"     // h3 | h4 | h5 | h6 | a


  description=""          // string
  tag=""                       // string


  img-src=""                 // string
  img-alt=""                 // string
>
 <slot name=”footer”></slot>
</gcds-card>
```

### Card types

#### Link card

The link card is used to display information and has no call to action. The card footer is optional to display metadata about the card contents. If the card links to additional information the entire card is interactive.

#### Action card

The action card is used to display information and it contains a call to action in the card footer. Unlike the default card, only the headline link and the call to action in the card footer are interactive. 

