### PR TITLE
Update storybook version to fix GitHub actions

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -75,7 +75,7 @@
     "react-syntax-highlighter": "^15.5.0",
     "sass": "^1.43.5",
     "stencil-inline-svg": "^1.1.0",
-    "storybook": "^7.0.22",
+    "storybook": "^v7.1.0-rc.2",
     "workbox-build": "^4.3.1"
   },
   "license": "MIT"


### PR DESCRIPTION
# Summary | Résumé

To solve GitHub actions falling to install `@cdssnc/gcds-components` update storybook to use `v7.1.0-rc2`. 

Versions `7.0.*` were all causing a installation failure with `esbuild`.
