### PR TITLE
Update requiredFileInput validator

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -12,7 +12,7 @@ import i18n from './i18n/i18n';
 export class GcdsFileUploader {
   @Element() el: HTMLElement;
 
-  private shadowElement?: HTMLElement;
+  private shadowElement?: HTMLInputElement;
 
   _validator: Validator<any> = defaultValidator;
 
@@ -220,7 +220,7 @@ export class GcdsFileUploader {
    */
   @Method()
   async validate() {
-    if (!this._validator.validate(this.value.length) && this._validator.errorMessage) {
+    if (!this._validator.validate(this.shadowElement.files) && this._validator.errorMessage) {
       this.errorMessage = this._validator.errorMessage[this.lang];
       this.gcdsError.emit({ id: `#${this.uploaderId}`, message: `${this.label} - ${this.errorMessage}` });
     } else {
@@ -344,6 +344,7 @@ export class GcdsFileUploader {
               onFocus={(e) => this.onFocus(e)}
               onChange={(e) => this.handleChange(e)}
               aria-invalid={hasError ? 'true' : 'false'}
+              ref={element => this.shadowElement = element as HTMLInputElement}
             />
             { value.length > 0 ?
               <p id="file-uploader__summary">

--- a/packages/web/src/validators/input-validators/input-validators.ts
+++ b/packages/web/src/validators/input-validators/input-validators.ts
@@ -18,8 +18,8 @@ export const requiredEmailField: Validator<string> = {
   }
 }
 
-export const requiredFileInput: Validator<number> = {
-  validate: (value: number) => value > 0,
+export const requiredFileInput: Validator<FileList> = {
+  validate: (value: FileList) => value.length > 0,
   errorMessage: {
     "en": "You must upload a file to continue.",
     "fr": "Vous devez téléverser un fichier pour continuer."

--- a/packages/web/src/validators/input-validators/test/input-validators.spec.tsx
+++ b/packages/web/src/validators/input-validators/test/input-validators.spec.tsx
@@ -1,26 +1,52 @@
 import { requiredField, requiredFileInput } from "../input-validators";
+import {Blob} from 'buffer';
+
+interface MockFile {
+  name: string;
+  body: string;
+  mimeType: string;
+}
+
+const createFileFromMockFile = (file: MockFile): File => {
+const blob = new Blob([file.body], { type: file.mimeType }) as any;
+blob['lastModifiedDate'] = new Date();
+blob['name'] = file.name;
+return blob as File;
+};
+
+const createMockFileList = (files: MockFile[]) => {
+const fileList: FileList = {
+  length: files.length,
+  item(index: number): File {
+    return fileList[index];
+  }
+};
+files.forEach((file, index) => fileList[index] = createFileFromMockFile(file));
+
+return fileList;
+};
 
 describe('Required input validator', () => {
-    let results: Array<{value: string, res: boolean}> = [
-        {value: "Text field value", res: true},
-        {value: "", res: false},
-        {value: " ", res: false},
-    ];
-    results.forEach(i => 
-        it(`Should return ${i.res} for ${i.value}`, () => {
-            expect(requiredField.validate(i.value)).toEqual(i.res);
-        })
-    );
+  let results: Array<{value: string, res: boolean}> = [
+    {value: "Text field value", res: true},
+    {value: "", res: false},
+    {value: " ", res: false},
+  ];
+  results.forEach(i => 
+    it(`Should return ${i.res} for ${i.value}`, () => {
+      expect(requiredField.validate(i.value)).toEqual(i.res);
+    })
+  );
 });
 describe('Required file input validator', () => {
-    let results: Array<{value: number, res: boolean}> = [
-        {value: 2, res: true},
-        {value: 1, res: true},
-        {value: 0, res: false},
-    ];
-    results.forEach(i => 
-        it(`Should return ${i.res} for ${i.value}`, () => {
-            expect(requiredFileInput.validate(i.value)).toEqual(i.res);
-        })
-    );
+  let results: Array<{value: FileList, res: boolean}> = [
+    {value: createMockFileList([{ body: 'test', mimeType: 'text/plain', name: 'test1.txt' }, { body: 'test', mimeType: 'text/plain', name: 'test2.txt' }]), res: true},
+    {value: createMockFileList([{ body: 'test', mimeType: 'text/plain', name: 'test1.txt' }]), res: true},
+    {value: createMockFileList([]), res: false},
+  ];
+  results.forEach(i => 
+    it(`Should return ${i.res} for ${i.value}`, () => {
+      expect(requiredFileInput.validate(i.value)).toEqual(i.res);
+    })
+  );
 });


### PR DESCRIPTION
# Summary | Résumé

Update `requiredFileInput` validator used in the `gcds-file-uploader` to read the file input's `FileList` instead of the component's `value, this makes it easier to develop custom file-uploader validators.
