### PR TITLE
Update required label rendering

### DIFF
--- a/packages/web/src/components/gcds-label/gcds-label.tsx
+++ b/packages/web/src/components/gcds-label/gcds-label.tsx
@@ -92,7 +92,7 @@ export class GcdsLabel {
         >
           <span>{label}</span>
           {required ?
-            <span class="label--required">({i18n[lang].required})</span>
+            <span aria-hidden="true" class="label--required">({i18n[lang].required})</span>
           : null}
         </label>
       </Host>

--- a/packages/web/src/components/gcds-label/test/gcds-label.spec.ts
+++ b/packages/web/src/components/gcds-label/test/gcds-label.spec.ts
@@ -46,7 +46,7 @@ describe('gcds-label', () => {
       <gcds-label id="label-for-input-renders" label="Label" label-for="input-renders" required="">
         <label class="gcds-label" htmlFor="input-renders">
           <span>Label</span>
-          <span class="label--required">(required)</span>
+          <span aria-hidden="true" class="label--required">(required)</span>
         </label>
       </gcds-label>
     `);
@@ -61,7 +61,7 @@ describe('gcds-label', () => {
       <gcds-label id="label-for-input-renders" label="Label" label-for="input-renders" lang="fr" required="">
         <label class="gcds-label" htmlFor="input-renders">
           <span>Label</span>
-          <span class="label--required">(obligatoire)</span>
+          <span aria-hidden="true" class="label--required">(obligatoire)</span>
         </label>
       </gcds-label>
     `);


### PR DESCRIPTION
# Summary | Résumé

Change the way the "(required)" text renders in `gcds-label`. (required) will now have `aria-hidden="true"` so it is no longer included in the accessible names of form components.
