### PR TITLE
Extra config + checkbox fix

### DIFF
--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -278,7 +278,7 @@ export class GcdsCheckbox {
   private onChange = () => {
     this.checked = !this.checked;
 
-    this.gcdsChange.emit(this.value);
+    this.gcdsChange.emit(this.checked);
   };
 
   render() {

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -47,5 +47,8 @@ export const config: Config = {
     },
     setupFiles: ['./src/utils/test/setupMock.js']
   },
-  buildEs5: 'prod'
+  buildEs5: 'prod',
+  extras: {
+    experimentalImportInjection: true
+  }
 };


### PR DESCRIPTION
# Summary | Résumé

Small adjustments for better use.

- Add `extra` config option `experimentalImportInjection` to stencil to help using the GCDS components in bundlers such as Vite. Will update to `enableImportInjection` when using `v3` of Stencil. #174 

- As flagged in #204, switch `onChange` on the `gcds-checkbox` to emit the `checked` value instead of `value`.
