### PR TITLE
A11y fixes

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -331,7 +331,7 @@ export class GcdsFileUploader {
           : null}
 
           <div class={`file-uploader__input ${value.length > 0 ? "uploaded-files" : ''}`}>
-            <button tabindex="-1">
+            <button type="button" tabindex="-1" onClick={() => this.shadowElement.click()}>
               {i18n[lang].button.upload}
               <gcds-icon name="upload" margin-left="200" />
             </button>

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -12,7 +12,7 @@ describe('gcds-file-uploader', () => {
         <div class="gcds-file-uploader-wrapper">
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
-            <button tabindex="-1">
+            <button type="button" tabindex="-1">
               Upload a file
               <gcds-icon name="upload" margin-left="200" />
             </button>
@@ -37,7 +37,7 @@ describe('gcds-file-uploader', () => {
         <div class="gcds-file-uploader-wrapper gcds-disabled">
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
-            <button tabindex="-1">
+            <button type="button" tabindex="-1">
               Upload a file
               <gcds-icon name="upload" margin-left="200" />
             </button>
@@ -63,7 +63,7 @@ describe('gcds-file-uploader', () => {
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <gcds-error-message message="This is an error message." messageId="file-uploader"></gcds-error-message>
           <div class="file-uploader__input">
-            <button tabindex="-1">
+            <button type="button" tabindex="-1">
               Upload a file
               <gcds-icon name="upload" margin-left="200" />
             </button>
@@ -89,7 +89,7 @@ describe('gcds-file-uploader', () => {
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <gcds-hint hint="This is a hint." hint-id="file-uploader"></gcds-hint>
           <div class="file-uploader__input">
-            <button tabindex="-1">
+            <button type="button" tabindex="-1">
               Upload a file
               <gcds-icon name="upload" margin-left="200" />
             </button>
@@ -114,7 +114,7 @@ describe('gcds-file-uploader', () => {
         <div class="gcds-file-uploader-wrapper">
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
-            <button tabindex="-1">
+            <button type="button" tabindex="-1">
               Upload a file
               <gcds-icon name="upload" margin-left="200" />
             </button>
@@ -139,7 +139,7 @@ describe('gcds-file-uploader', () => {
         <div class="gcds-file-uploader-wrapper">
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
-            <button tabindex="-1">
+            <button type="button" tabindex="-1">
               Upload a file
               <gcds-icon name="upload" margin-left="200" />
             </button>
@@ -164,7 +164,7 @@ describe('gcds-file-uploader', () => {
         <div class="gcds-file-uploader-wrapper">
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en" required=""></gcds-label>
           <div class="file-uploader__input">
-            <button tabindex="-1">
+            <button type="button" tabindex="-1">
               Upload a file
               <gcds-icon name="upload" margin-left="200" />
             </button>

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -68,11 +68,6 @@ export class GcdsNavGroup {
         (this.el.children[i] as HTMLGcdsNavGroupElement).toggleNav();
       }
     }
-
-    // Focus trigger button if closing nav group
-    if (this.open == false) {
-      this.triggerElement.focus();
-    }
   }
 
   /*

--- a/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
+++ b/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
@@ -59,20 +59,13 @@ export class GcdsSideNav {
   @Listen("gcdsClick", { target: 'document' })
   async gcdsClickListener(e) {
     if (this.el.contains(e.target)) {
-      if (e.target.hasAttribute("open")) {
+      // Update tab queue when clicking mobile menu
+      if (e.target == this.el && this.navSize == "mobile") {
+        await this.updateNavItemQueue(e.target);
+
+      // Update tab queue when clicking dropdown
+      } else if (e.target.nodeName == "GCDS-NAV-GROUP" && !e.target.hasAttribute("open")) {
         await this.updateNavItemQueue(this.el);
-        (e.target as HTMLGcdsNavGroupElement).focusTrigger();
-      } else {
-        await this.updateNavItemQueue(this.el);
-        if (e.target.children[0].nodeName == "GCDS-NAV-GROUP") {
-          setTimeout(() => {
-            (e.target.children[0] as HTMLGcdsNavGroupElement).focusTrigger();
-          }, 10);
-        } else if (e.target.children[0].nodeName == "GCDS-NAV-LINK") {
-          setTimeout(() => {
-            (e.target.children[0] as HTMLGcdsNavLinkElement).focusLink();
-          }, 10);
-        }
       }
     }
   }

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
@@ -71,25 +71,14 @@ export class GcdsTopNav {
   @Listen("gcdsClick", { target: 'document' })
   async gcdsClickListener(e) {
     if (this.el.contains(e.target)) {
-      if (e.target.hasAttribute("open")) {
-        await this.updateNavItemQueue(this.el);
-        (e.target as HTMLGcdsNavGroupElement).focusTrigger();
-      } else {
-        if (e.target == this.el && this.navSize == "mobile") {
-          await this.updateNavItemQueue(e.target);
-        } else {
-          await this.updateNavItemQueue(e.target, true);
-        }
+      // Update tab queue when clicking mobile menu
+      if (e.target == this.el && this.navSize == "mobile") {
+        await this.updateNavItemQueue(e.target);
 
-        if (e.target.children[0].nodeName == "GCDS-NAV-GROUP") {
-          setTimeout(() => {
-            (e.target.children[0] as HTMLGcdsNavGroupElement).focusTrigger();
-          }, 10);
-        } else if (e.target.children[0].nodeName == "GCDS-NAV-LINK") {
-          setTimeout(() => {
-            (e.target.children[0] as HTMLGcdsNavLinkElement).focusLink();
-          }, 10);
-        }
+      // Update tab queue when clicking dropdown
+      } else if (e.target.nodeName == "GCDS-NAV-GROUP" && !e.target.hasAttribute("open")) {
+        await this.updateNavItemQueue(e.target, true);
+        (e.target as HTMLGcdsNavGroupElement).focusTrigger();
       }
     }
   }

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -343,7 +343,7 @@
 
         <gcds-file-uploader
           uploader-id="form-uploader"
-          label="Upload"
+          label="Upload file"
           hint="You can upload multiple files, but they have to be png's."
           accept="image/png"
           multiple


### PR DESCRIPTION
# Summary | Résumé

Couple accessibility fixes for `gcds-file-uploader` and navigation components.

## File uploader

- Modified the button in `gcds-file-uploader` to be a `type="button"` to avoid submitting the form when interacting with the component with Voice control.
- Add `onClick` to 'Upload a file' button to click file input. Voice control software would click the button before the file input

## Navigation components

- Removed focus logic to avoid navigation components from stealing focus
- The first item of a dropdown will no longer be focused when dropdowns open from click. Will still focus when using keyboard controls.
