### PR TITLE
Fix compile-and-publish action angular publishing

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -106,6 +106,9 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install repo
+        run: npm install
+
       - name: Install gcds-components
         run: npm install
         working-directory: ./packages/web


### PR DESCRIPTION
# Summary | Résumé

Add instruction `install repo` back into the compile and publish action to support Angular package.
