### PR TITLE
gcds-search border-radius style fix

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.5.0",
+        "@cdssnc/gcds-tokens": "^1.5.2",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -2593,9 +2593,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.0.tgz",
-      "integrity": "sha512-7iE4Ym0WxqHDj41skZImar0yiN829ZFamIF0qPqlroHlJotWk4SP9kX+E2ndKMEzS7dlCWf54by8c069/xRQdw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.2.tgz",
+      "integrity": "sha512-EIhw9SDZtyEqqMM09Aqdu0bHPcaRDiVQgurJWidSMkJXP5ZAVe24sNsqfV8T9Y4MSv8HM2eBGv3RjfHe9wORag==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -25936,9 +25936,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.0.tgz",
-      "integrity": "sha512-7iE4Ym0WxqHDj41skZImar0yiN829ZFamIF0qPqlroHlJotWk4SP9kX+E2ndKMEzS7dlCWf54by8c069/xRQdw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.2.tgz",
+      "integrity": "sha512-EIhw9SDZtyEqqMM09Aqdu0bHPcaRDiVQgurJWidSMkJXP5ZAVe24sNsqfV8T9Y4MSv8HM2eBGv3RjfHe9wORag==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.5.0",
+    "@cdssnc/gcds-tokens": "^1.5.2",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/src/components/gcds-search/gcds-search.css
+++ b/packages/web/src/components/gcds-search/gcds-search.css
@@ -27,8 +27,6 @@
         color: var(--gcds-search-default-text);
         border: var(--gcds-search-border-width) solid currentColor;
         border-radius: var(--gcds-search-border-radius);
-        border-start-end-radius: 0;
-        border-end-end-radius: 0;
         box-sizing: border-box;
         transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
       }
@@ -55,14 +53,14 @@
         border-color: var(--gcds-search-focus-text);
         outline: var(--gcds-search-outline-width) solid var(--gcds-search-focus-text);
         outline-offset: var(--gcds-search-border-width);
-        border-radius: var(--gcds-search-border-radius);
+        border-radius: var(--gcds-search-focus-border-radius);
         box-shadow: var(--gcds-search-focus-box-shadow);
         z-index: 30;
       }
     }
 
     ::part(button):focus {
-      border-radius: var(--gcds-search-border-radius);
+      border-radius: var(--gcds-search-focus-border-radius);
       box-shadow:  var(--gcds-search-focus-box-shadow);
     }
   }

--- a/packages/web/src/components/gcds-search/stories/overview.mdx
+++ b/packages/web/src/components/gcds-search/stories/overview.mdx
@@ -5,9 +5,9 @@ import * as Search from './gcds-search.stories';
 
 # Search<br/>`<gcds-search>`
 
-_Also called: error, inline error._
+_Also called: search box._
 
-An error message is a description of a problem blocking a user goal.
+Search is a way to enter keywords to find relevant information.
 
 <Canvas
   of={Search.Default}


### PR DESCRIPTION
# Summary | Résumé

Use new tokens to fix the `border-radius` of the `gcds-search` component. The `border-end-end-radius` was overwritten by the `border-radius`.
