### PR TITLE
Fix typo in French label/placeholder

### DIFF
--- a/packages/web/src/components/gcds-search/i18n/I18N.js
+++ b/packages/web/src/components/gcds-search/i18n/I18N.js
@@ -5,7 +5,7 @@ const I18N = {
   },
   "fr": {
     search: "Recherche",
-    searchLabel: "Recherche dans {$}",
+    searchLabel: "Rechercher dans {$}",
   }
 }
 

--- a/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
+++ b/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
@@ -36,8 +36,8 @@ describe('gcds-search', () => {
             Recherche
           </h2>
           <form action="https://www.canada.ca/fr/sr/srb.html" class="gcds-search__form" method="get" role="search">
-            <gcds-label hide-label="" label="Recherche dans Canada.ca" label-for="search"></gcds-label>
-            <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Recherche dans Canada.ca" size="34" type="search">
+            <gcds-label hide-label="" label="Rechercher dans Canada.ca" label-for="search"></gcds-label>
+            <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Rechercher dans Canada.ca" size="34" type="search">
             <gcds-button class="gcds-search__button" exportparts="button" type="submit">
               <gcds-icon fixed-width="" label="Recherche" name="search"></gcds-icon>
             </gcds-button>


### PR DESCRIPTION
# Summary | Résumé

French label/placeholder was incorrectly spelled "Recherche dans", fixed to now be "Rechercher dans".
