### PR TITLE
Update GitHub actions to use new develop branch name

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -106,6 +106,9 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install repo
+        run: npm install
+
       - name: Install gcds-components
         run: npm install
         working-directory: ./packages/web

--- a/.github/workflows/publish-storybook-staging.yml
+++ b/.github/workflows/publish-storybook-staging.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - staging
+      - develop
     paths:
       - 'packages/web/src/**'
       - 'packages/web/.storybook/**'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
       branches:
         - main
-        - staging
+        - develop
 
 jobs:
   build-deploy:

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,5 @@
       "before 6am on the first day of the month"
     ]
   },
-  "baseBranches": ["staging"]
+  "baseBranches": ["develop"]
 }


### PR DESCRIPTION
# Summary | Résumé

With switching of `staging` to `develop`, the GitHub actions need to be updated as well.
