### PR TITLE
Tokens review update

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.5.2",
+        "@cdssnc/gcds-tokens": "^1.5.3",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -2593,9 +2593,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.2.tgz",
-      "integrity": "sha512-EIhw9SDZtyEqqMM09Aqdu0bHPcaRDiVQgurJWidSMkJXP5ZAVe24sNsqfV8T9Y4MSv8HM2eBGv3RjfHe9wORag==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.4.tgz",
+      "integrity": "sha512-CR73Kgx7+qhCfjDDfCCR6wMAY0+OZyoByxPzr/SkH+B+sPXcvtvgaYEEWX10dHG4cezDXPUUkWqp281X4EaaNA==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -25936,9 +25936,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.2.tgz",
-      "integrity": "sha512-EIhw9SDZtyEqqMM09Aqdu0bHPcaRDiVQgurJWidSMkJXP5ZAVe24sNsqfV8T9Y4MSv8HM2eBGv3RjfHe9wORag==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.4.tgz",
+      "integrity": "sha512-CR73Kgx7+qhCfjDDfCCR6wMAY0+OZyoByxPzr/SkH+B+sPXcvtvgaYEEWX10dHG4cezDXPUUkWqp281X4EaaNA==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.5.3",
+        "@cdssnc/gcds-tokens": "^1.5.4",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.5.3",
+    "@cdssnc/gcds-tokens": "^1.5.4",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -848,24 +848,6 @@ export namespace Components {
          */
         "variant": 'colour' | 'white';
     }
-    interface GcdsSiteMenu {
-        /**
-          * Menu alignment
-         */
-        "alignment": 'left' | 'center' | 'right' | 'split';
-        /**
-          * Desktop layout
-         */
-        "desktopLayout": 'topbar' | 'sidebar';
-        /**
-          * Mobile layout
-         */
-        "mobileLayout": 'drawer';
-        /**
-          * Sticky navigation flag
-         */
-        "position": 'static' | 'sticky';
-    }
     interface GcdsStepper {
         /**
           * Defines the current step.
@@ -1203,12 +1185,6 @@ declare global {
         prototype: HTMLGcdsSignatureElement;
         new (): HTMLGcdsSignatureElement;
     };
-    interface HTMLGcdsSiteMenuElement extends Components.GcdsSiteMenu, HTMLStencilElement {
-    }
-    var HTMLGcdsSiteMenuElement: {
-        prototype: HTMLGcdsSiteMenuElement;
-        new (): HTMLGcdsSiteMenuElement;
-    };
     interface HTMLGcdsStepperElement extends Components.GcdsStepper, HTMLStencilElement {
     }
     var HTMLGcdsStepperElement: {
@@ -1264,7 +1240,6 @@ declare global {
         "gcds-select": HTMLGcdsSelectElement;
         "gcds-side-nav": HTMLGcdsSideNavElement;
         "gcds-signature": HTMLGcdsSignatureElement;
-        "gcds-site-menu": HTMLGcdsSiteMenuElement;
         "gcds-stepper": HTMLGcdsStepperElement;
         "gcds-textarea": HTMLGcdsTextareaElement;
         "gcds-top-nav": HTMLGcdsTopNavElement;
@@ -2234,24 +2209,6 @@ declare namespace LocalJSX {
          */
         "variant"?: 'colour' | 'white';
     }
-    interface GcdsSiteMenu {
-        /**
-          * Menu alignment
-         */
-        "alignment"?: 'left' | 'center' | 'right' | 'split';
-        /**
-          * Desktop layout
-         */
-        "desktopLayout": 'topbar' | 'sidebar';
-        /**
-          * Mobile layout
-         */
-        "mobileLayout": 'drawer';
-        /**
-          * Sticky navigation flag
-         */
-        "position"?: 'static' | 'sticky';
-    }
     interface GcdsStepper {
         /**
           * Defines the current step.
@@ -2399,7 +2356,6 @@ declare namespace LocalJSX {
         "gcds-select": GcdsSelect;
         "gcds-side-nav": GcdsSideNav;
         "gcds-signature": GcdsSignature;
-        "gcds-site-menu": GcdsSiteMenu;
         "gcds-stepper": GcdsStepper;
         "gcds-textarea": GcdsTextarea;
         "gcds-top-nav": GcdsTopNav;
@@ -2440,7 +2396,6 @@ declare module "@stencil/core" {
             "gcds-select": LocalJSX.GcdsSelect & JSXBase.HTMLAttributes<HTMLGcdsSelectElement>;
             "gcds-side-nav": LocalJSX.GcdsSideNav & JSXBase.HTMLAttributes<HTMLGcdsSideNavElement>;
             "gcds-signature": LocalJSX.GcdsSignature & JSXBase.HTMLAttributes<HTMLGcdsSignatureElement>;
-            "gcds-site-menu": LocalJSX.GcdsSiteMenu & JSXBase.HTMLAttributes<HTMLGcdsSiteMenuElement>;
             "gcds-stepper": LocalJSX.GcdsStepper & JSXBase.HTMLAttributes<HTMLGcdsStepperElement>;
             "gcds-textarea": LocalJSX.GcdsTextarea & JSXBase.HTMLAttributes<HTMLGcdsTextareaElement>;
             "gcds-top-nav": LocalJSX.GcdsTopNav & JSXBase.HTMLAttributes<HTMLGcdsTopNavElement>;

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
@@ -8,7 +8,7 @@
   margin: 0;
   padding: 0;
   border: 0;
-  transition: color ease-in-out .15s;
+  transition: color ease-in-out 0.15s;
 
   &:focus-within {
     color: var(--gcds-file-uploader-focus-text);
@@ -46,6 +46,11 @@
   &.gcds-error .file-uploader__uploaded-file:not(:focus) {
     border-color: var(--gcds-file-uploader-file-danger-border-color);
   }
+
+  &.gcds-error .file-uploader__uploaded-file:focus-within,
+  .file-uploader__uploaded-file:focus-within {
+    border-color: var(--gcds-file-uploader-file-focus-border-color);
+  }
 }
 
 :host .file-uploader__input {
@@ -66,7 +71,7 @@
     color: var(--gcds-file-uploader-button-text);
     border: var(--gcds-file-uploader-button-border-width) solid var(--gcds-file-uploader-button-text);
     border-radius: var(--gcds-file-uploader-button-border-radius);
-    transition: all .15s ease-in-out;
+    transition: all 0.15s ease-in-out;
   }
 
   input {
@@ -86,11 +91,20 @@
     overflow: hidden;
   }
 
+  &:hover button {
+    background-color: var(--gcds-file-uploader-hover-button-background);
+  }
+
   &:focus-within button {
     background-color: var(--gcds-file-uploader-focus-button-background);
     color: var(--gcds-file-uploader-focus-button-text);
     outline: var(--gcds-file-uploader-button-outline-width) solid var(--gcds-file-uploader-focus-button-background);
     border-color: currentColor;
+  }
+
+  &:active button {
+    background-color: var(--gcds-file-uploader-active-button-background);
+    color: var(--gcds-file-uploader-active-button-text);
   }
 }
 
@@ -123,28 +137,36 @@
     align-items: center;
     font: inherit;
     background: transparent;
+    border-radius: var(--gcds-file-uploader-file-button-border-radius);
     color: var(--gcds-file-uploader-file-button-default-text);
     margin: var(--gcds-file-uploader-file-button-margin);
     padding: var(--gcds-file-uploader-file-button-padding);
     outline: 0;
-    transition: color .35s;
+    transition: color 0.35s;
 
     &:not(:focus) span {
-      border-block-end: var(--gcds-file-uploader-file-button-border-width) solid currentColor;
-      transition: box-shadow .35s;
+      transition: box-shadow 0.35s;
+      overflow: visible;
+      text-decoration: underline;
+      text-underline-offset: var(--gcds-file-uploader-file-button-underline-offset);
+      text-decoration-thickness: var(--gcds-file-uploader-file-button-default-decoration-thickness);
     }
 
     &:hover {
       color: var(--gcds-file-uploader-file-button-hover-text);
+    }
 
-      &:not(:focus) span {
-        box-shadow: inset 0 calc(-1 * var(--gcds-file-uploader-file-button-border-width)) 0 currentColor;
-      }
+    &:hover span {
+      text-decoration-thickness: var(--gcds-file-uploader-file-button-hover-decoration-thickness);
     }
 
     &:focus {
       background-color: var(--gcds-file-uploader-focus-button-background);
       color: var(--gcds-file-uploader-focus-button-text);
+      outline: var(--gcds-file-uploader-focus-button-outline-width) solid var(--gcds-file-uploader-focus-button-background);
+      outline-offset: var(--gcds-file-uploader-focus-button-outline-offset);
+      border-color: var(--gcds-file-uploader-focus-button-background);
+      text-decoration-color: transparent;
     }
   }
 }

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.css
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.css
@@ -23,10 +23,11 @@
           background-color: var(--gcds-pagination-focus-background);
           outline: var(--gcds-pagination-focus-outline-width) solid var(--gcds-pagination-focus-background);
           outline-offset: var(--gcds-pagination-border-width);
+          text-decoration: none;
         }
 
         &:active:not(:focus),
-        &[aria-current*=page]:not(:focus) {
+        &[aria-current*='page']:not(:focus) {
           color: var(--gcds-pagination-active-text);
           background: var(--gcds-pagination-active-background);
           border-color: var(--gcds-pagination-active-background);
@@ -173,21 +174,20 @@
 
           & > .gcds-pagination-simple-text {
             grid-area: text;
-            margin: var(--gcds-pagination-simple-listitem-text-margin)
+            margin: var(--gcds-pagination-simple-listitem-text-margin);
           }
 
           & > span {
             grid-area: label;
             font-weight: var(--gcds-pagination-simple-label-font-weight);
-            text-decoration: underline;
           }
         }
 
         &.gcds-pagination-simple-previous {
           a {
             grid-template-areas:
-              "icon text"
-              "icon label";
+              'icon text'
+              'icon label';
             grid-template-columns: 0.25fr 1fr;
           }
         }
@@ -196,9 +196,9 @@
 
           a {
             grid-template-areas:
-              "text icon"
-              "label icon";
-            grid-template-columns: 1fr 0.25fr ;
+              'text icon'
+              'label icon';
+            grid-template-columns: 1fr 0.25fr;
           }
         }
       }

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.css
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.css
@@ -31,6 +31,8 @@
           color: var(--gcds-pagination-active-text);
           background: var(--gcds-pagination-active-background);
           border-color: var(--gcds-pagination-active-background);
+          text-decoration: none;
+          pointer-events: none;
         }
       }
     }

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.css
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.css
@@ -15,6 +15,7 @@
 
         &:hover {
           background: var(--gcds-pagination-hover-background);
+          color: var(--gcds-pagination-hover-text);
         }
 
         &:focus {


### PR DESCRIPTION
## This PR contains the following updates

These are changes to align with the figma file more and to make state styles more consistent

## ** The tokens referenced in this PR are from [GCDS TOKENS PULL 144](https://github.com/cds-snc/gcds-tokens/pull/144) **

### File uploader updates
- Upload button had only default state when it should function like a secondary button
- Focus styles have been updated on the uploaded file and the remove button
- The remove button hover style was using `border-block-end` which was causing the uploaded file bucket to resize on state changes, it has been updated to use `text-decoration` instead.

| Before |  ![file-upload-before](https://github.com/cds-snc/gcds-components/assets/30609058/049f3338-bd37-4b52-b530-b48042337eb7) |
|--------|---|
| After  |  ![file-upload-after](https://github.com/cds-snc/gcds-components/assets/30609058/2945e96a-d508-4637-bcf3-05af4d5e3e7a) |

### Pagination updates
- hover text and border color has been applied to the hover state for pages
- `text-decoration` hidden on focus and active state to match some of our other states
- `pointer-events` removed from current page 
- Subheading on simple pagination was receiving different styling than the top line when they should be identical

| Before | ![pagination-before](https://github.com/cds-snc/gcds-components/assets/30609058/5964fea9-38cb-4ad3-80c8-51345c73e3da)|
|--------|---|
| After  | ![pagination-after](https://github.com/cds-snc/gcds-components/assets/30609058/4ef7890d-e112-4b54-938f-cd8e5a0df8c8) |
