### PR TITLE
signature storybook events and properties page

### DIFF
--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -13,6 +13,21 @@ export default {
         defaultValue: { summary: 'signature' }
       },
     },
+    hasLink: {
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false }
+      },
+    },
+    variant: {
+      control: 'radio',
+      options: ['colour', 'white'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'colour' }
+      },
+    },
     ...langProp
   },
 };
@@ -21,6 +36,8 @@ const Template = (args) => (`
 <!-- Web component code (Angular, Vue) -->
 <gcds-signature
   type="${args.type}"
+  has-link="${args.hasLink}"
+  variant="${args.variant}"
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
 </gcds-signature>
@@ -28,6 +45,8 @@ const Template = (args) => (`
 <!-- React code -->
 <GcdsSignature
   type="${args.type}"
+  hasLink="${args.hasLink}"
+  variant="${args.variant}"
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
 </GcdsSignature>
@@ -36,5 +55,7 @@ const Template = (args) => (`
 export const Default = Template.bind({});
 Default.args = {
   type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
   lang: 'en'
 };

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -59,3 +59,51 @@ Default.args = {
   variant: 'colour',
   lang: 'en'
 };
+
+export const Wordmark = Template.bind({});
+Wordmark.args = {
+  type: 'wordmark',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'en'
+};
+
+export const SignatureFrench = Template.bind({});
+SignatureFrench.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'fr'
+};
+
+export const WordmarkFrench = Template.bind({});
+WordmarkFrench.args = {
+  type: 'wordmark',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'fr'
+};
+
+export const HasLinkTrue = Template.bind({});
+HasLinkTrue.args = {
+  type: 'signature',
+  hasLink: 'true',
+  variant: 'colour',
+  lang: 'en'
+};
+
+export const SignatureWhite = Template.bind({});
+SignatureWhite.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'white',
+  lang: 'en'
+};
+
+export const WordmarkWhite = Template.bind({});
+WordmarkWhite.args = {
+  type: 'wordmark',
+  hasLink: 'false',
+  variant: 'white',
+  lang: 'en'
+};

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -1,0 +1,40 @@
+import { langProp } from '../../../utils/storybook/component-properties';
+
+export default {
+  title: 'Components/Signature',
+
+  argTypes: {
+    // Props
+    type: {
+      control: 'radio',
+      options: ['signature', 'wordmark'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'signature' }
+      },
+    },
+    ...langProp
+  },
+};
+
+const Template = (args) => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-signature
+  type="${args.type}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</gcds-signature>
+
+<!-- React code -->
+<GcdsSignature
+  type="${args.type}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</GcdsSignature>
+`).replace(/\s\snull\n/g, '');
+
+export const Default = Template.bind({});
+Default.args = {
+  type: 'signature',
+  lang: 'en'
+};

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -52,6 +52,16 @@ const Template = (args) => (`
 </GcdsSignature>
 `).replace(/\s\snull\n/g, '');
 
+const TemplatePlayground = (args) => (`
+<gcds-signature
+  type="${args.type}"
+  has-link="${args.hasLink}"
+  variant="${args.variant}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</gcds-signature>
+`);
+
 export const Default = Template.bind({});
 Default.args = {
   type: 'signature',
@@ -105,5 +115,13 @@ WordmarkWhite.args = {
   type: 'wordmark',
   hasLink: 'false',
   variant: 'white',
+  lang: 'en'
+};
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
   lang: 'en'
 };

--- a/packages/web/src/components/gcds-signature/stories/overview.mdx
+++ b/packages/web/src/components/gcds-signature/stories/overview.mdx
@@ -1,0 +1,111 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as Signature from './gcds-signature.stories';
+
+<Meta of={Signature} name="Overview" />
+
+# Signature<br/>`<gcds-signature>`
+
+_Also called: wordmark._
+
+The signature is the Government of Canada landmark identifier found in the header or footer.
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+## Examples
+<br/>
+
+### Type property
+
+#### Signature Type
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### Wordmark Type
+
+<Canvas
+  of={Signature.Wordmark}
+  story={{ inline: true }}
+/>
+
+### Language
+
+#### English Signature
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### French Signature
+
+<Canvas
+  of={Signature.SignatureFrench}
+  story={{ inline: true }}
+/>
+
+#### English Wordmark
+
+<Canvas
+  of={Signature.Wordmark}
+  story={{ inline: true }}
+/>
+
+#### French Wordmark
+
+<Canvas
+  of={Signature.WordmarkFrench}
+  story={{ inline: true }}
+/>
+
+
+### hasLink property
+
+#### hasLink = false
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### hasLink = true
+
+<Canvas
+  of={Signature.HasLinkTrue}
+  story={{ inline: true }}
+/>
+
+### Colour variants
+
+#### Signature variant = colour
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### Wordmark variant = colour
+
+<Canvas
+  of={Signature.Wordmark}
+  story={{ inline: true }}
+/>
+
+#### Signature variant = white
+
+<Canvas
+  of={Signature.SignatureWhite}
+  story={{ inline: true }}
+/>
+
+#### Wordmark variant = white
+
+<Canvas
+  of={Signature.WordmarkWhite}
+  story={{ inline: true }}
+/>

--- a/packages/web/src/components/gcds-signature/stories/properties.mdx
+++ b/packages/web/src/components/gcds-signature/stories/properties.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import * as Signature from './gcds-signature.stories';
+
+<Meta of={Signature} name="Events & properties" />
+
+# Events & properties
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+  sourceState="shown"
+  type="dynamic"
+/>
+
+<Controls of={Signature.Default} sort="requiredFirst" />


### PR DESCRIPTION
## This PR consists of the following work

### Creating storybook events and properties page for the signature component
- I'm working on the signature component pages for the doc site and the code tab needs to use the storybook component builder thingy
- Created a simple story in which you can toggle the language and type of the signature component

![signature storybook](https://github.com/cds-snc/gcds-components/assets/30609058/5e2c3245-34eb-434c-a1d1-fa602404574b)
