### PR TITLE
remove icon from file uploader button

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -333,7 +333,6 @@ export class GcdsFileUploader {
           <div class={`file-uploader__input ${value.length > 0 ? "uploaded-files" : ''}`}>
             <button type="button" tabindex="-1" onClick={() => this.shadowElement.click()}>
               {i18n[lang].button.upload}
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input
               type="file"

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -14,7 +14,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -39,7 +38,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" disabled="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -65,7 +63,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="true" aria-describedby="error-message-file-uploader file-uploader__summary" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -91,7 +88,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" aria-describedby="hint-file-uploader file-uploader__summary" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -116,7 +112,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -141,7 +136,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -166,7 +160,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" required="" />
             <p id="file-uploader__summary">No file currently selected.</p>


### PR DESCRIPTION
# Summary | Résumé

Remove the icon from the file uploader button to match the new design.