### PR TITLE
v0.13.0

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -106,6 +106,9 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install repo
+        run: npm install
+
       - name: Install gcds-components
         run: npm install
         working-directory: ./packages/web

--- a/.github/workflows/publish-storybook-staging.yml
+++ b/.github/workflows/publish-storybook-staging.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - staging
+      - develop
     paths:
       - 'packages/web/src/**'
       - 'packages/web/.storybook/**'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
       branches:
         - main
-        - staging
+        - develop
 
 jobs:
   build-deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.13.0
+
+### New features
+
+- Search component (`gcds-search`)
+  - New `gcds-search` component for canada.ca compliance
+
+### Breaking changes
+
+- Header component (`gcds-header`)
+  - `topnav` slot in the `gcds-header` has been renamed to `skip-to-nav`
+
+### Minor
+
+- https://github.com/cds-snc/gcds-components/pull/212 - [c8f0aa1](https://github.com/cds-snc/gcds-components/commit/c8f0aa1107404b5093731548f072d22e8bb699a3) - Add `gcds-search` to component library
+- https://github.com/cds-snc/gcds-components/pull/225 - [2bc48f9](https://github.com/cds-snc/gcds-components/commit/2bc48f9f51e967c0d12b20b191fbfe2ff54790e1) - Rename `topnav` slot in `gcds-header` to `skip-to-nav`
+
+### Patch
+
+- https://github.com/cds-snc/gcds-components/pull/219 - [bfb7a58](https://github.com/cds-snc/gcds-components/commit/bfb7a58925b5a474e5885d02e6405faf18fe2d1f) - Update `gcds-top-nav` component style to match design files
+- https://github.com/cds-snc/gcds-components/pull/221 - [fd82057](https://github.com/cds-snc/gcds-components/commit/fd8205708aac28da71d18d794db8f4af9fa2455a) - Update hover styles for `gcds-file-uploader` and `gcds-pagination`
+- https://github.com/cds-snc/gcds-components/pull/225 - [2bc48f9](https://github.com/cds-snc/gcds-components/commit/2bc48f9f51e967c0d12b20b191fbfe2ff54790e1) - Update text in `gcds-file-uploader` button to `Choose file`
+- https://github.com/cds-snc/gcds-components/pull/227 - [0effdc8](https://github.com/cds-snc/gcds-components/commit/0effdc89e8c4866e023853e38c57c7e7d13c47aa) - Remove icon from `gcds-file-uploader` button label
+
 ## v0.12.1
 
 ### Patch

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
-  "version": "0.12.1",
+  "version": "0.13.0",
   "packages": [
     "packages/web",
     "packages/react",

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-angular",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-angular",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Angular wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
-    "@cdssnc/gcds-components": "^0.12.1"
+    "@cdssnc/gcds-components": "^0.13.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components-react",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.0.28",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components-react",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "React wrapper for gcds-components",
   "homepage": "https://design-system.alpha.canada.ca/",
@@ -29,7 +29,7 @@
     "gcds.css"
   ],
   "dependencies": {
-    "@cdssnc/gcds-components": "^0.12.1"
+    "@cdssnc/gcds-components": "^0.13.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -230,6 +230,13 @@
     border: var(--gcds-border-width-sm) solid var(--gcds-border-default);
   }
 
+  /* gcds-signature */
+  .sbdocs-preview .docs-story #story--components-signature--signature-white,
+  .sbdocs-preview .docs-story #story--components-signature--wordmark-white {
+    background: var(--gcds-color-grayscale-900);
+    padding: var(--gcds-spacing-450);
+  }
+
   /* gcds-top-nav */
   #story--components-top-navigation--default {
     height: 300px;

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -208,6 +208,29 @@
     margin: var(--gcds-spacing-0);
   }
 
+  /* gcds-icon */
+  .sbdocs-preview .docs-story #story--components-icon--name gcds-icon,
+  .sbdocs-preview .docs-story #story--components-icon--sizes gcds-icon {
+    margin: 0 var(--gcds-spacing-150) 0 0;
+  }
+
+  .sbdocs-preview .docs-story #story--components-icon--margin-left gcds-icon,
+  .sbdocs-preview .docs-story #story--components-icon--margin-right gcds-icon {
+    display: block;
+  }
+
+  .sbdocs-preview .docs-story #story--components-icon--margin-right-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .sbdocs-preview .docs-story #story--components-icon--width gcds-icon {
+    margin: 0 var(--gcds-spacing-150) 0 0;
+    border: var(--gcds-border-width-sm) solid var(--gcds-border-default);
+  }
+
+  /* gcds-top-nav */
   #story--components-top-navigation--default {
     height: 300px;
   }

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cdssnc/gcds-components",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.7.0",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.5.2",
+        "@cdssnc/gcds-tokens": "^1.5.4",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -2593,9 +2593,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.2.tgz",
-      "integrity": "sha512-EIhw9SDZtyEqqMM09Aqdu0bHPcaRDiVQgurJWidSMkJXP5ZAVe24sNsqfV8T9Y4MSv8HM2eBGv3RjfHe9wORag==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.4.tgz",
+      "integrity": "sha512-CR73Kgx7+qhCfjDDfCCR6wMAY0+OZyoByxPzr/SkH+B+sPXcvtvgaYEEWX10dHG4cezDXPUUkWqp281X4EaaNA==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -25936,9 +25936,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.2.tgz",
-      "integrity": "sha512-EIhw9SDZtyEqqMM09Aqdu0bHPcaRDiVQgurJWidSMkJXP5ZAVe24sNsqfV8T9Y4MSv8HM2eBGv3RjfHe9wORag==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.4.tgz",
+      "integrity": "sha512-CR73Kgx7+qhCfjDDfCCR6wMAY0+OZyoByxPzr/SkH+B+sPXcvtvgaYEEWX10dHG4cezDXPUUkWqp281X4EaaNA==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.5.4",
+        "@cdssnc/gcds-tokens": "^1.6.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -2593,9 +2593,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.4.tgz",
-      "integrity": "sha512-CR73Kgx7+qhCfjDDfCCR6wMAY0+OZyoByxPzr/SkH+B+sPXcvtvgaYEEWX10dHG4cezDXPUUkWqp281X4EaaNA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.6.0.tgz",
+      "integrity": "sha512-hpQRDb2ov175d3v35GwPolD9mbU/oXsLHlfrl3+HW8ERyH4E8QQZhlr0yVMfT/pjaOk9OEusZbRYpDneuO+1sw==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -25936,9 +25936,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.5.4.tgz",
-      "integrity": "sha512-CR73Kgx7+qhCfjDDfCCR6wMAY0+OZyoByxPzr/SkH+B+sPXcvtvgaYEEWX10dHG4cezDXPUUkWqp281X4EaaNA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.6.0.tgz",
+      "integrity": "sha512-hpQRDb2ov175d3v35GwPolD9mbU/oXsLHlfrl3+HW8ERyH4E8QQZhlr0yVMfT/pjaOk9OEusZbRYpDneuO+1sw==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-components",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Web components for the GCDS",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.5.4",
+    "@cdssnc/gcds-tokens": "^1.6.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.5.3",
+    "@cdssnc/gcds-tokens": "^1.5.4",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -848,24 +848,6 @@ export namespace Components {
          */
         "variant": 'colour' | 'white';
     }
-    interface GcdsSiteMenu {
-        /**
-          * Menu alignment
-         */
-        "alignment": 'left' | 'center' | 'right' | 'split';
-        /**
-          * Desktop layout
-         */
-        "desktopLayout": 'topbar' | 'sidebar';
-        /**
-          * Mobile layout
-         */
-        "mobileLayout": 'drawer';
-        /**
-          * Sticky navigation flag
-         */
-        "position": 'static' | 'sticky';
-    }
     interface GcdsStepper {
         /**
           * Defines the current step.
@@ -1203,12 +1185,6 @@ declare global {
         prototype: HTMLGcdsSignatureElement;
         new (): HTMLGcdsSignatureElement;
     };
-    interface HTMLGcdsSiteMenuElement extends Components.GcdsSiteMenu, HTMLStencilElement {
-    }
-    var HTMLGcdsSiteMenuElement: {
-        prototype: HTMLGcdsSiteMenuElement;
-        new (): HTMLGcdsSiteMenuElement;
-    };
     interface HTMLGcdsStepperElement extends Components.GcdsStepper, HTMLStencilElement {
     }
     var HTMLGcdsStepperElement: {
@@ -1264,7 +1240,6 @@ declare global {
         "gcds-select": HTMLGcdsSelectElement;
         "gcds-side-nav": HTMLGcdsSideNavElement;
         "gcds-signature": HTMLGcdsSignatureElement;
-        "gcds-site-menu": HTMLGcdsSiteMenuElement;
         "gcds-stepper": HTMLGcdsStepperElement;
         "gcds-textarea": HTMLGcdsTextareaElement;
         "gcds-top-nav": HTMLGcdsTopNavElement;
@@ -2234,24 +2209,6 @@ declare namespace LocalJSX {
          */
         "variant"?: 'colour' | 'white';
     }
-    interface GcdsSiteMenu {
-        /**
-          * Menu alignment
-         */
-        "alignment"?: 'left' | 'center' | 'right' | 'split';
-        /**
-          * Desktop layout
-         */
-        "desktopLayout": 'topbar' | 'sidebar';
-        /**
-          * Mobile layout
-         */
-        "mobileLayout": 'drawer';
-        /**
-          * Sticky navigation flag
-         */
-        "position"?: 'static' | 'sticky';
-    }
     interface GcdsStepper {
         /**
           * Defines the current step.
@@ -2399,7 +2356,6 @@ declare namespace LocalJSX {
         "gcds-select": GcdsSelect;
         "gcds-side-nav": GcdsSideNav;
         "gcds-signature": GcdsSignature;
-        "gcds-site-menu": GcdsSiteMenu;
         "gcds-stepper": GcdsStepper;
         "gcds-textarea": GcdsTextarea;
         "gcds-top-nav": GcdsTopNav;
@@ -2440,7 +2396,6 @@ declare module "@stencil/core" {
             "gcds-select": LocalJSX.GcdsSelect & JSXBase.HTMLAttributes<HTMLGcdsSelectElement>;
             "gcds-side-nav": LocalJSX.GcdsSideNav & JSXBase.HTMLAttributes<HTMLGcdsSideNavElement>;
             "gcds-signature": LocalJSX.GcdsSignature & JSXBase.HTMLAttributes<HTMLGcdsSignatureElement>;
-            "gcds-site-menu": LocalJSX.GcdsSiteMenu & JSXBase.HTMLAttributes<HTMLGcdsSiteMenuElement>;
             "gcds-stepper": LocalJSX.GcdsStepper & JSXBase.HTMLAttributes<HTMLGcdsStepperElement>;
             "gcds-textarea": LocalJSX.GcdsTextarea & JSXBase.HTMLAttributes<HTMLGcdsTextareaElement>;
             "gcds-top-nav": LocalJSX.GcdsTopNav & JSXBase.HTMLAttributes<HTMLGcdsTopNavElement>;

--- a/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
@@ -40,14 +40,14 @@ export default {
 const Template = (args) => (`
 <!-- Web component code (Angular, Vue) -->
 <gcds-breadcrumbs ${args.hideCanadaLink ? `hide-canada-link` : null } ${args.lang != "en" ? `lang="${args.lang}"` : null}>
-  <gcds-breadcrumbs-item href="${args.href}">Travel and tourism</gcds-breadcrumbs-item>
-  <gcds-breadcrumbs-item href="${args.href}">Immigration and citizenship</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="${args.href}">Home page</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="${args.href}">Parent page link</gcds-breadcrumbs-item>
 </gcds-breadcrumbs>
 
 <!-- React code -->
 <GcdsBreadcrumbs ${args.hideCanadaLink ? `hideCanadaLink` : null} ${args.lang != "en" ? `lang="${args.lang}"` : null}>
-  <GcdsBreadcrumbsItem href="${args.href}">Travel and tourism</GcdsBreadcrumbsItem>
-  <GcdsBreadcrumbsItem href="${args.href}">Immigration and citizenship</GcdsBreadcrumbsItem>
+  <GcdsBreadcrumbsItem href="${args.href}">Home page</GcdsBreadcrumbsItem>
+  <GcdsBreadcrumbsItem href="${args.href}">Parent page link</GcdsBreadcrumbsItem>
 </GcdsBreadcrumbs>
 `).replace(/ null/g, '');
 
@@ -56,8 +56,8 @@ const TemplatePlayground = (args) => (`
   ${args.hideCanadaLink ? `hide-canada-link` : null }
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  <gcds-breadcrumbs-item href="${args.href}">Travel and tourism</gcds-breadcrumbs-item>
-  <gcds-breadcrumbs-item href="${args.href}">Immigration and citizenship</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="${args.href}">Home page</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="${args.href}">Parent page link</gcds-breadcrumbs-item>
 </gcds-breadcrumbs>
 `);
 

--- a/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
@@ -113,12 +113,12 @@ const Template = (args) => (`
 
 export const Default = Template.bind({});
 Default.args = {
-  cardTitle: 'Title of the article',
+  cardTitle: 'Card title link',
   href: '#',
   type: 'link',
   titleElement: 'a',
-  tag: '',
-  description: '',
+  tag: 'Tag',
+  description: 'Description or supporting text relating to the headline. Longer text will be truncated with ...',
   imgSrc: '',
   imgAlt: '',
   footer: '',

--- a/packages/web/src/components/gcds-checkbox/stories/gcds-checkbox.stories.tsx
+++ b/packages/web/src/components/gcds-checkbox/stories/gcds-checkbox.stories.tsx
@@ -148,9 +148,9 @@ const Template = (args) => (`
 export const Default = Template.bind({});
 Default.args = {
   checkboxId: 'checkbox',
-  label: 'Checkbox label',
+  label: 'Label',
   name: 'checkbox',
-  hint: '',
+  hint: 'Description or example to make the option clearer.',
   errorMessage: '',
   required: false,
   disabled: false,

--- a/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
+++ b/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
@@ -73,6 +73,82 @@ const Template = (args) => (`
 </GcdsContainer>
 `).replace(/ null/g, '');
 
+const TemplateMargin = () => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-container size="md" border margin="0">Margin 0</gcds-container>
+<gcds-container size="md" border margin="50">Margin 50</gcds-container>
+<gcds-container size="md" border margin="100">Margin 100</gcds-container>
+<gcds-container size="md" border margin="150">Margin 150</gcds-container>
+<gcds-container size="md" border margin="200">Margin 200</gcds-container>
+<gcds-container size="md" border margin="250">Margin 250</gcds-container>
+<gcds-container size="md" border margin="300">Margin 300</gcds-container>
+<gcds-container size="md" border margin="400">Margin 400</gcds-container>
+<gcds-container size="md" border margin="450">Margin 450</gcds-container>
+<gcds-container size="md" border margin="500">Margin 500</gcds-container>
+<gcds-container size="md" border margin="550">Margin 550</gcds-container>
+<gcds-container size="md" border margin="600">Margin 600</gcds-container>
+<gcds-container size="md" border margin="700">Margin 700</gcds-container>
+<gcds-container size="md" border margin="800">Margin 800</gcds-container>
+<gcds-container size="md" border margin="900">Margin 900</gcds-container>
+<gcds-container size="md" border margin="1000">Margin 1000</gcds-container>
+
+<!-- React code -->
+<GcdsContainer size="md" border margin="0">Margin 0</GcdsContainer>
+<GcdsContainer size="md" border margin="50">Margin 50</GcdsContainer>
+<GcdsContainer size="md" border margin="100">Margin 100</GcdsContainer>
+<GcdsContainer size="md" border margin="150">Margin 150</GcdsContainer>
+<GcdsContainer size="md" border margin="200">Margin 200</GcdsContainer>
+<GcdsContainer size="md" border margin="250">Margin 250</GcdsContainer>
+<GcdsContainer size="md" border margin="300">Margin 300</GcdsContainer>
+<GcdsContainer size="md" border margin="400">Margin 400</GcdsContainer>
+<GcdsContainer size="md" border margin="450">Margin 450</GcdsContainer>
+<GcdsContainer size="md" border margin="500">Margin 500</GcdsContainer>
+<GcdsContainer size="md" border margin="550">Margin 550</GcdsContainer>
+<GcdsContainer size="md" border margin="600">Margin 600</GcdsContainer>
+<GcdsContainer size="md" border margin="700">Margin 700</GcdsContainer>
+<GcdsContainer size="md" border margin="800">Margin 800</GcdsContainer>
+<GcdsContainer size="md" border margin="900">Margin 900</GcdsContainer>
+<GcdsContainer size="md" border margin="1000">Margin 1000</GcdsContainer>
+`).replace(/ null/g, '');
+
+const TemplatePadding = () => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-container size="md" border padding="0">Padding 0</gcds-container>
+<gcds-container size="md" border padding="50">Padding 50</gcds-container>
+<gcds-container size="md" border padding="100">Padding 100</gcds-container>
+<gcds-container size="md" border padding="150">Padding 150</gcds-container>
+<gcds-container size="md" border padding="200">Padding 200</gcds-container>
+<gcds-container size="md" border padding="250">Padding 250</gcds-container>
+<gcds-container size="md" border padding="300">Padding 300</gcds-container>
+<gcds-container size="md" border padding="400">Padding 400</gcds-container>
+<gcds-container size="md" border padding="450">Padding 450</gcds-container>
+<gcds-container size="md" border padding="500">Padding 500</gcds-container>
+<gcds-container size="md" border padding="550">Padding 550</gcds-container>
+<gcds-container size="md" border padding="600">Padding 600</gcds-container>
+<gcds-container size="md" border padding="700">Padding 700</gcds-container>
+<gcds-container size="md" border padding="800">Padding 800</gcds-container>
+<gcds-container size="md" border padding="900">Padding 900</gcds-container>
+<gcds-container size="md" border padding="1000">Padding 1000</gcds-container>
+
+<!-- React code -->
+<GcdsContainer size="md" border padding="0">Padding 0</GcdsContainer>
+<GcdsContainer size="md" border padding="50">Padding 50</GcdsContainer>
+<GcdsContainer size="md" border padding="100">Padding 100</GcdsContainer>
+<GcdsContainer size="md" border padding="150">Padding 150</GcdsContainer>
+<GcdsContainer size="md" border padding="200">Padding 200</GcdsContainer>
+<GcdsContainer size="md" border padding="250">Padding 250</GcdsContainer>
+<GcdsContainer size="md" border padding="300">Padding 300</GcdsContainer>
+<GcdsContainer size="md" border padding="400">Padding 400</GcdsContainer>
+<GcdsContainer size="md" border padding="450">Padding 450</GcdsContainer>
+<GcdsContainer size="md" border padding="500">Padding 500</GcdsContainer>
+<GcdsContainer size="md" border padding="550">Padding 550</GcdsContainer>
+<GcdsContainer size="md" border padding="600">Padding 600</GcdsContainer>
+<GcdsContainer size="md" border padding="700">Padding 700</GcdsContainer>
+<GcdsContainer size="md" border padding="800">Padding 800</GcdsContainer>
+<GcdsContainer size="md" border padding="900">Padding 900</GcdsContainer>
+<GcdsContainer size="md" border padding="1000">Padding 1000</GcdsContainer>
+`).replace(/ null/g, '');
+
 const TemplatePlayground = (args) => (`
 <gcds-container
   ${args.size != "full" ? `size="${args.size}"`: null}
@@ -92,6 +168,7 @@ export const Default = Template.bind({});
 Default.args = {
   size: 'md',
   border: true,
+  centered: false,
   tag: 'div',
   padding: '400',
   default: '<p>This is a responsive container, you can replace this text with any content or other components.</p>',
@@ -165,6 +242,18 @@ Centered.args = {
   default: '<p>This container is centered.</p>',
 };
 
+// ------ Container margin ------
+
+export const Margin = TemplateMargin.bind({});
+Margin.args = {
+};
+
+// ------ Container padding ------
+
+export const Padding = TemplatePadding.bind({});
+Padding.args = {
+};
+
 // ------ Container events & props ------
 
 export const Props = Template.bind({});
@@ -172,8 +261,8 @@ Props.args = {
   size: 'md',
   tag: 'div',
   padding: '400',
-  border: true,
   centered: false,
+  border: true,
   default: '<p>This is a responsive container, you can replace this text with any content or other components.</p>',
 };
 

--- a/packages/web/src/components/gcds-container/stories/overview.mdx
+++ b/packages/web/src/components/gcds-container/stories/overview.mdx
@@ -68,16 +68,30 @@ A box to group content by limiting the width.
   story={{ inline: true }}
 />
 
+### Margin
+
+<Canvas
+  of={Container.Margin}
+  story={{ inline: true }}
+/>
+
+### Padding
+
+<Canvas
+  of={Container.Padding}
+  story={{ inline: true }}
+/>
+
 ## Resources
 
 <ul>
   <li>
-    <gcds-button type="link" button-style="text-only" href="" target="_blank">Guidance</gcds-button>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/container/" target="_blank">Guidance</gcds-button>
   </li>
   <li>
-    <gcds-button type="link" button-style="text-only" href="" target="_blank">Github</gcds-button>
+    <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/develop/packages/web/src/components/gcds-container" target="_blank">Github</gcds-button>
   </li>
   <li>
-    <gcds-button type="link" button-style="text-only" href="" target="_blank">Figma</gcds-button>
+    <gcds-button type="link" button-style="text-only" href="https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=6660-15761&mode=design&t=LvA5Ee7oJjZ49rKT-0" target="_blank">Figma</gcds-button>
   </li>
 </ul>

--- a/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
+++ b/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
@@ -56,7 +56,7 @@ const TemplatePlayground = (args) => (`
 export const Default = Template.bind({});
 Default.args = {
   messageId: 'message-id',
-  message: 'This is an error message.',
+  message: 'Error message or validation message.',
 };
 
 // ------ Error message events & props ------
@@ -64,7 +64,7 @@ Default.args = {
 export const Props = Template.bind({});
 Props.args = {
   messageId: 'message-id',
-  message: 'This is an error message.',
+  message: 'Error message or validation message.',
 };
 
 // ------ Error message playground ------
@@ -72,5 +72,5 @@ Props.args = {
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   messageId: '',
-  message: 'This is an error message.',
+  message: 'Error message or validation message.',
 };

--- a/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
+++ b/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
@@ -50,14 +50,54 @@ const Template = (args) => (`
 </GcdsErrorSummary>
 `).replace(/\s\snull\n/g, '');
 
+const TemplatePlayground = (args) => (`
+<gcds-error-summary
+  ${args.listen && !args.errorLinks ? `listen` : null}
+  ${args.errorLinks ? `error-links='${args.errorLinks}'` : null}
+  ${args.heading ? `heading="${args.heading}"` : null}
+>
+</gcds-error-summary>
+`);
+
+// ------ Error summary default ------
+
 export const Default = Template.bind({});
 Default.args = {
   listen: true,
   errorLinks: `{
-    "error-href-1": "Error message",
-    "error-href-2": "Error message",
-    "error-href-3": "Error message"
+    "error-href-1": "Error summary item.",
+    "error-href-2": "Error summary item.",
+    "error-href-3": "Error summary item."
   }`,
   heading: '',
   lang: 'en'
 };
+
+// ------ Error summary events & props ------
+
+export const Props = Template.bind({});
+Props.args = {
+  listen: true,
+  errorLinks: `{
+    "error-href-1": "Error summary item.",
+    "error-href-2": "Error summary item.",
+    "error-href-3": "Error summary item."
+  }`,
+  heading: '',
+  lang: 'en'
+};
+
+// ------ Error summary playground ------
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
+  listen: true,
+  errorLinks: `{
+    "error-href-1": "Error summary item.",
+    "error-href-2": "Error summary item.",
+    "error-href-3": "Error summary item."
+  }`,
+  heading: '',
+  lang: 'en'
+};
+

--- a/packages/web/src/components/gcds-error-summary/stories/overview.mdx
+++ b/packages/web/src/components/gcds-error-summary/stories/overview.mdx
@@ -1,0 +1,39 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as ErrorSummary from './gcds-error-summary.stories';
+
+<Meta of={ErrorSummary} name="Overview" />
+
+# Error summary<br/>`<gcds-error-summary>`
+
+_Also called: error list._
+
+An error summary is a list of user errors in a form.
+
+<Canvas
+  of={ErrorSummary.Default}
+  story={{ inline: true }}
+/>
+
+## Examples
+<br/>
+
+### Default
+
+<Canvas
+  of={ErrorSummary.Default}
+  story={{ inline: true }}
+/>
+
+## Resources
+
+<ul>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/error-summary/" target="_blank">Guidance</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-error-summary" target="_blank">Github</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=1579-4801&mode=design&t=2zIFVk9gcrqwM0Qj-0" target="_blank">Figma</gcds-button>
+  </li>
+</ul>

--- a/packages/web/src/components/gcds-error-summary/stories/properties.mdx
+++ b/packages/web/src/components/gcds-error-summary/stories/properties.mdx
@@ -6,10 +6,10 @@ import * as ErrorSummary from './gcds-error-summary.stories';
 # Events & properties
 
 <Canvas
-  of={ErrorSummary.Default}
+  of={ErrorSummary.Props}
   story={{ inline: true }}
   sourceState="shown"
   type="dynamic"
 />
 
-<Controls of={ErrorSummary.Default} sort="requiredFirst" />
+<Controls of={ErrorSummary.Props} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
+++ b/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
@@ -93,8 +93,17 @@ const Template = (args) => (`
   ${args.validateOn != "blur" ? `validate-on="${args.validateOn}"` : null}
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  <gcds-radio radio-id="r1" name="radio" label="Radio button 1"></gcds-radio>
-  <gcds-radio radio-id="r2" name="radio" label="Radio button 2"></gcds-radio>
+  <gcds-input input-id="form-input" label="Input label" hint="Hint / Example message." size="6"></gcds-input>
+  <gcds-select select-id="form-select" label="Select label" hint="Hint / Example message." default-value="Select option.">
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+    <option value="5">Option 5</option>
+    <option value="6">Option 6</option>
+    <option value="7">Option 7</option>
+    <option value="8">Option 8</option>
+  </gcds-select>
 </gcds-fieldset>
 
 <!-- React code -->
@@ -108,16 +117,25 @@ const Template = (args) => (`
   ${args.validateOn != "blur" ? `validateOn="${args.validateOn}"` : null}
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  <GcdsRadio radioId="r1" name="radio" label="Radio button 1"></GcdsRadio>
-  <GcdsRadio radioId="r2" name="radio" label="Radio button 2"></GcdsRadio>
+  <GcdsInput inputId="form-input" label="Input label" hint="Hint / Example message." size="6"></GcdsInput>
+  <GcdsSelect selectId="form-select" label="Select label" hint="Hint / Example message." defaultValue="Select option.">
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+    <option value="5">Option 5</option>
+    <option value="6">Option 6</option>
+    <option value="7">Option 7</option>
+    <option value="8">Option 8</option>
+  </GcdsSelect>
 </GcdsFieldset>
 `).replace(/\s\snull\n/g, '');
 
 export const Default = Template.bind({});
 Default.args = {
   fieldsetId: 'fieldset',
-  legend: 'Fieldset legend',
-  hint: '',
+  legend: 'Legend',
+  hint: 'Hint / Example message.',
   errorMessage: '',
   required: false,
   disabled: false,

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
@@ -8,7 +8,7 @@
   margin: 0;
   padding: 0;
   border: 0;
-  transition: color ease-in-out .15s;
+  transition: color ease-in-out 0.15s;
 
   &:focus-within {
     color: var(--gcds-file-uploader-focus-text);
@@ -46,6 +46,11 @@
   &.gcds-error .file-uploader__uploaded-file:not(:focus) {
     border-color: var(--gcds-file-uploader-file-danger-border-color);
   }
+
+  &.gcds-error .file-uploader__uploaded-file:focus-within,
+  .file-uploader__uploaded-file:focus-within {
+    border-color: var(--gcds-file-uploader-file-focus-border-color);
+  }
 }
 
 :host .file-uploader__input {
@@ -66,7 +71,7 @@
     color: var(--gcds-file-uploader-button-text);
     border: var(--gcds-file-uploader-button-border-width) solid var(--gcds-file-uploader-button-text);
     border-radius: var(--gcds-file-uploader-button-border-radius);
-    transition: all .15s ease-in-out;
+    transition: all 0.15s ease-in-out;
   }
 
   input {
@@ -86,11 +91,20 @@
     overflow: hidden;
   }
 
+  &:hover button {
+    background-color: var(--gcds-file-uploader-hover-button-background);
+  }
+
   &:focus-within button {
     background-color: var(--gcds-file-uploader-focus-button-background);
     color: var(--gcds-file-uploader-focus-button-text);
     outline: var(--gcds-file-uploader-button-outline-width) solid var(--gcds-file-uploader-focus-button-background);
     border-color: currentColor;
+  }
+
+  &:active button {
+    background-color: var(--gcds-file-uploader-active-button-background);
+    color: var(--gcds-file-uploader-active-button-text);
   }
 }
 
@@ -123,28 +137,36 @@
     align-items: center;
     font: inherit;
     background: transparent;
+    border-radius: var(--gcds-file-uploader-file-button-border-radius);
     color: var(--gcds-file-uploader-file-button-default-text);
     margin: var(--gcds-file-uploader-file-button-margin);
     padding: var(--gcds-file-uploader-file-button-padding);
     outline: 0;
-    transition: color .35s;
+    transition: color 0.35s;
 
     &:not(:focus) span {
-      border-block-end: var(--gcds-file-uploader-file-button-border-width) solid currentColor;
-      transition: box-shadow .35s;
+      transition: box-shadow 0.35s;
+      overflow: visible;
+      text-decoration: underline;
+      text-underline-offset: var(--gcds-file-uploader-file-button-underline-offset);
+      text-decoration-thickness: var(--gcds-file-uploader-file-button-default-decoration-thickness);
     }
 
     &:hover {
       color: var(--gcds-file-uploader-file-button-hover-text);
+    }
 
-      &:not(:focus) span {
-        box-shadow: inset 0 calc(-1 * var(--gcds-file-uploader-file-button-border-width)) 0 currentColor;
-      }
+    &:hover span {
+      text-decoration-thickness: var(--gcds-file-uploader-file-button-hover-decoration-thickness);
     }
 
     &:focus {
       background-color: var(--gcds-file-uploader-focus-button-background);
       color: var(--gcds-file-uploader-focus-button-text);
+      outline: var(--gcds-file-uploader-focus-button-outline-width) solid var(--gcds-file-uploader-focus-button-background);
+      outline-offset: var(--gcds-file-uploader-focus-button-outline-offset);
+      border-color: var(--gcds-file-uploader-focus-button-background);
+      text-decoration-color: transparent;
     }
   }
 }

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -333,7 +333,6 @@ export class GcdsFileUploader {
           <div class={`file-uploader__input ${value.length > 0 ? "uploaded-files" : ''}`}>
             <button type="button" tabindex="-1" onClick={() => this.shadowElement.click()}>
               {i18n[lang].button.upload}
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input
               type="file"

--- a/packages/web/src/components/gcds-file-uploader/i18n/i18n.js
+++ b/packages/web/src/components/gcds-file-uploader/i18n/i18n.js
@@ -2,7 +2,7 @@ const I18N = {
   "en": {
     button: {
       remove: "Remove",
-      upload: "Upload a file",
+      upload: "Choose file",
     },
     summary: {
       selected: "Currently selected:",
@@ -13,7 +13,7 @@ const I18N = {
   "fr": {
     button: {
       remove: "Supprimer",
-      upload: "Téléverser un fichier",
+      upload: "Choisir un fichier",
     },
     summary: {
       selected: "Actuellement sélectionné:",

--- a/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
+++ b/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
@@ -142,11 +142,175 @@ const Template = (args) => (`
 </GcdsFileUploader>
 `).replace(/\s\snull\n/g, '');
 
+const TemplatePlayground = (args) => (`
+<gcds-file-uploader
+  uploader-id="${args.uploaderId}"
+  label="${args.label}"
+  hint="${args.hint}"
+  error-message="${args.errorMessage}"
+  ${args.required ? `required` : null}
+  ${args.disabled ? `disabled` : null}
+  value="${args.value}"
+  ${args.accept ? `accept="${args.accept}"` : null}
+  ${args.multiple ? `multiple` : null}
+  validate-on="${args.validateOn}"
+  lang="${args.lang}"
+>
+</gcds-file-uploader>
+`);
+
+// ------ File uploader default ------
+
 export const Default = Template.bind({});
 Default.args = {
   uploaderId: 'uploader',
-  label: 'File uploader label',
-  hint: '',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+// ------ File uploader states ------
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  disabled: true,
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  errorMessage: 'Error message or validation message.',
+  required: true,
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  required: true,
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+// ------ File uploader multiple ------
+
+export const Multiple = Template.bind({});
+Multiple.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  multiple: true,
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+// ------ File uploader accept ------
+
+export const AcceptAudio = Template.bind({});
+AcceptAudio.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  accept: 'audio/*',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const AcceptImages = Template.bind({});
+AcceptImages.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  accept: 'image/*',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const AcceptJpg = Template.bind({});
+AcceptJpg.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  accept: 'image/jpeg',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const AcceptPdf = Template.bind({});
+AcceptPdf.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  accept: 'application/pdf',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const AcceptPng = Template.bind({});
+AcceptPng.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  accept: 'image/png',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const AcceptSvg = Template.bind({});
+AcceptSvg.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  accept: 'image/svg+xml',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+export const AcceptVideos = Template.bind({});
+AcceptVideos.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  accept: 'video/*',
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+// ------ File uploader events & properties ------
+
+export const Props = Template.bind({});
+Props.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
+  errorMessage: '',
+  required: false,
+  disabled: false,
+  value: '',
+  accept: '',
+  multiple: false,
+  validateOn: 'blur',
+  lang: 'en',
+};
+
+// ------ File uploader playground ------
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
+  uploaderId: 'uploader',
+  label: 'Label',
+  hint: 'Hint / Example message.',
   errorMessage: '',
   required: false,
   disabled: false,

--- a/packages/web/src/components/gcds-file-uploader/stories/overview.mdx
+++ b/packages/web/src/components/gcds-file-uploader/stories/overview.mdx
@@ -1,0 +1,143 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as FileUploader from './gcds-file-uploader.stories';
+
+<Meta of={FileUploader} name="Overview" />
+
+# File uploader<br/>`<gcds-file-uploader>`
+
+_Also called: file upload, file input, dropzone._
+
+A file uploader is a space to select and add supporting documentation.
+
+<Canvas
+  of={FileUploader.Default}
+  story={{ inline: true }}
+/>
+
+## Examples
+<br/>
+
+### State
+
+#### Default
+
+<Canvas
+  of={FileUploader.Default}
+  story={{ inline: true }}
+/>
+
+#### Required
+
+<Canvas
+  of={FileUploader.Required}
+  story={{ inline: true }}
+/>
+
+
+#### Error
+
+<Canvas
+  of={FileUploader.Error}
+  story={{ inline: true }}
+/>
+
+#### Disabled
+
+<Canvas
+  of={FileUploader.Disabled}
+  story={{ inline: true }}
+/>
+
+### Multiple files
+
+#### Default
+
+By default the user can only choose one file.
+
+<Canvas
+  of={FileUploader.Default}
+  story={{ inline: true }}
+/>
+
+#### Multiple files
+
+Setting `multiple` to `true` allows the user to choose multiple files.
+
+<Canvas
+  of={FileUploader.Multiple}
+  story={{ inline: true }}
+/>
+
+### Accepted file formats
+
+#### Default
+
+By default all file formats are allowed.
+
+<Canvas
+  of={FileUploader.Default}
+  story={{ inline: true }}
+/>
+
+#### Images only
+
+<Canvas
+  of={FileUploader.AcceptImages}
+  story={{ inline: true }}
+/>
+
+#### JPG only
+
+<Canvas
+  of={FileUploader.AcceptJpg}
+  story={{ inline: true }}
+/>
+
+#### PNG only
+
+<Canvas
+  of={FileUploader.AcceptPng}
+  story={{ inline: true }}
+/>
+
+#### SVG only
+
+<Canvas
+  of={FileUploader.AcceptSvg}
+  story={{ inline: true }}
+/>
+
+#### PDF only
+
+<Canvas
+  of={FileUploader.AcceptPdf}
+  story={{ inline: true }}
+/>
+
+#### Audio only
+
+<Canvas
+  of={FileUploader.AcceptAudio}
+  story={{ inline: true }}
+/>
+
+#### Videos only
+
+<Canvas
+  of={FileUploader.AcceptVideos}
+  story={{ inline: true }}
+/>
+
+## Resources
+
+<ul>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/select/" target="_blank">Guidance</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-select" target="_blank">Github</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=856-2826&mode=design&t=S19QCPw1uQKzztyY-0" target="_blank">Figma</gcds-button>
+  </li>
+</ul>

--- a/packages/web/src/components/gcds-file-uploader/stories/properties.mdx
+++ b/packages/web/src/components/gcds-file-uploader/stories/properties.mdx
@@ -6,10 +6,10 @@ import * as FileUploader from './gcds-file-uploader.stories';
 # Events & properties
 
 <Canvas
-  of={FileUploader.Default}
+  of={FileUploader.Props}
   story={{ inline: true }}
   sourceState="shown"
   type="dynamic"
 />
 
-<Controls of={FileUploader.Default} sort="requiredFirst" />
+<Controls of={FileUploader.Props} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -13,7 +13,7 @@ describe('gcds-file-uploader', () => {
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
-              Upload a file
+              Choose file
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
@@ -38,7 +38,7 @@ describe('gcds-file-uploader', () => {
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
-              Upload a file
+              Choose file
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" disabled="" aria-invalid="false" />
@@ -64,7 +64,7 @@ describe('gcds-file-uploader', () => {
           <gcds-error-message message="This is an error message." messageId="file-uploader"></gcds-error-message>
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
-              Upload a file
+              Choose file
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="true" aria-describedby="error-message-file-uploader file-uploader__summary" />
@@ -90,7 +90,7 @@ describe('gcds-file-uploader', () => {
           <gcds-hint hint="This is a hint." hint-id="file-uploader"></gcds-hint>
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
-              Upload a file
+              Choose file
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" aria-describedby="hint-file-uploader file-uploader__summary" />
@@ -115,7 +115,7 @@ describe('gcds-file-uploader', () => {
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
-              Upload a file
+              Choose file
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
@@ -140,7 +140,7 @@ describe('gcds-file-uploader', () => {
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
-              Upload a file
+              Choose file
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
@@ -165,7 +165,7 @@ describe('gcds-file-uploader', () => {
           <gcds-label label="file-uploader" label-for="file-uploader" lang="en" required=""></gcds-label>
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
-              Upload a file
+              Choose file
               <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" required="" />

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -14,7 +14,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -39,7 +38,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" disabled="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -65,7 +63,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="true" aria-describedby="error-message-file-uploader file-uploader__summary" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -91,7 +88,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" aria-describedby="hint-file-uploader file-uploader__summary" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -116,7 +112,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -141,7 +136,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
             <p id="file-uploader__summary">No file currently selected.</p>
@@ -166,7 +160,6 @@ describe('gcds-file-uploader', () => {
           <div class="file-uploader__input">
             <button type="button" tabindex="-1">
               Choose file
-              <gcds-icon name="upload" margin-left="200" />
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" required="" />
             <p id="file-uploader__summary">No file currently selected.</p>

--- a/packages/web/src/components/gcds-footer/stories/gcds-footer.stories.tsx
+++ b/packages/web/src/components/gcds-footer/stories/gcds-footer.stories.tsx
@@ -67,9 +67,9 @@ const Template = (args) => (`
 
 export const Default = Template.bind({});
 Default.args = {
-  display: 'compact',
-  contextualHeading: '',
-  contextualLinks: '',
+  display: 'full',
+  contextualHeading: 'Contextual navigation',
+  contextualLinks: '{ "Why GC Notify": "#", "Features": "#", "Activity on GC Notify": "#" }',
   subLinks: '',
   lang: 'en'
 };

--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -39,6 +39,10 @@
       .brand__signature,
       slot[name="signature"] {
         grid-area: signature;
+
+        gcds-signature {
+          margin: var( --gcds-header-brand-signature-margin);
+        }
       }
 
       .brand__search {
@@ -65,11 +69,11 @@
     }
   }
 
-  .gcds-header__topnav {
+  .gcds-header__skip-to-nav {
     text-align: center;
     position: absolute;
     width: 100%;
     margin-inline: auto;
-    top: var(--gcds-header-topnav-top);
+    top: var(--gcds-header-skiptonav-top);
   }
 }

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -65,14 +65,14 @@ export class GcdsHeader {
     this.updateLang();
   }
 
-  private get renderTopNav() {
-    if (!!this.el.querySelector('[slot="topnav"]')) {
-      return <slot name="topnav"></slot>;
+  private get renderSkipToNav() {
+    if (!!this.el.querySelector('[slot="skip-to-nav"]')) {
+      return <slot name="skip-to-nav"></slot>;
     } else if(this.skipToHref) {
       return (
       <nav
         aria-label={i18n[this.lang].skip}
-        class="gcds-header__topnav"
+        class="gcds-header__skip-to-nav"
       >
         <gcds-button
           type="link"
@@ -142,12 +142,12 @@ export class GcdsHeader {
   }
 
   render() {
-    const { renderTopNav, renderToggle, renderSignature, renderSearch, hasSearch, hasBanner, hasBreadcrumb } = this;
+    const { renderSkipToNav, renderToggle, renderSignature, renderSearch, hasSearch, hasBanner, hasBreadcrumb } = this;
     return (
       <Host
         role="banner"
       >
-        {renderTopNav}
+        {renderSkipToNav}
         {hasBanner ?
           <slot name="banner"></slot>
         :

--- a/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
+++ b/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
@@ -31,7 +31,7 @@ describe('gcds-header', () => {
     expect(page.root).toEqualHtml(`
       <gcds-header lang-href="/fr/" role="banner" signature-has-link="true" signature-variant="colour" skip-to-href="#main">
         <mock:shadow-root>
-          <nav aria-label="Skip to main content" class="gcds-header__topnav">
+          <nav aria-label="Skip to main content" class="gcds-header__skip-to-nav">
             <gcds-button button-role="skip-to-content" type="link" href="#main">
               Skip to main content
             </gcds-button>
@@ -92,7 +92,7 @@ describe('gcds-header', () => {
       components: [GcdsHeader],
       html: `
       <gcds-header>
-        <ul slot="topnav"></ul>
+        <ul slot="skip-to-nav"></ul>
         <div slot="banner"></div>
         <img slot="signature"/>
         <a href="/fr/" slot="toggle">Toggle</a>
@@ -104,7 +104,7 @@ describe('gcds-header', () => {
     expect(page.root).toEqualHtml(`
       <gcds-header role="banner">
         <mock:shadow-root>
-          <slot name="topnav"></slot>
+          <slot name="skip-to-nav"></slot>
           <slot name="banner"></slot>
           <div class="gcds-header__brand">
             <div class="brand__container">
@@ -117,7 +117,7 @@ describe('gcds-header', () => {
           </div>
           <slot name="menu"></slot>
         </mock:shadow-root>
-        <ul slot="topnav"></ul>
+        <ul slot="skip-to-nav"></ul>
         <div slot="banner"></div>
         <img slot="signature"/>
         <a href="/fr/" slot="toggle">

--- a/packages/web/src/components/gcds-icon/stories/gcds-icon.stories.tsx
+++ b/packages/web/src/components/gcds-icon/stories/gcds-icon.stories.tsx
@@ -1,0 +1,310 @@
+export default {
+  title: 'Components/Icon',
+
+  argTypes: {
+    // Props
+    iconStyle: {
+      name: 'icon-style',
+      control: { type: 'select' },
+      options: ['regular', 'solid'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'solid' }
+      },
+    },
+    label: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    marginLeft: {
+      name: 'margin-left',
+      control: { type: 'select' },
+      options: ['0', '50', '100', '150', '200', '250', '300', '400', '450', '500', '550', '600', '700', '800', '900', '1000'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    marginRight: {
+      name: 'margin-right',
+      control: { type: 'select' },
+      options: ['0', '50', '100', '150', '200', '250', '300', '400', '450', '500', '550', '600', '700', '800', '900', '1000'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+    },
+    name: {
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' }
+      },
+      type: {
+        required: true
+      }
+    },
+    fixedWidth: {
+      name: 'fixed-width',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false }
+      }
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['inherit', 'caption', 'text', 'h6', 'h5', 'h4', 'h3', 'h2', 'h1'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'text' }
+      },
+    },
+  },
+};
+
+const Template = (args) => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-icon ${args.label ? `label="${args.label}"` : null} name="${args.name}" ${args.iconStyle != 'solid' ? `icon-style="${args.iconStyle}"` : null} ${args.marginLeft ? `margin-left="${args.marginLeft}"` : null} ${args.marginRight ? `margin-right="${args.marginRight}"` : null} ${args.size != "text" ? `size="${args.size}"`: null} ${args.fixedWidth ? `fixed-width="${args.fixedWidth}"` : null}>
+</gcds-icon>
+
+<!-- React code -->
+<GcdsIcon ${args.label ? `label="${args.label}"` : null} name="${args.name}" ${args.iconStyle != 'solid' ? `iconStyle="${args.iconStyle}"` : null} ${args.marginLeft ? `marginLeft="${args.marginLeft}"` : null} ${args.marginRight ? `marginRight="${args.marginRight}"` : null} ${args.size != "text" ? `size="${args.size}"`: null} ${args.fixedWidth ? `fixedWidth="${args.fixedWidth}"` : null}>
+</GcdsIcon>
+`).replace(/ null/g, '');
+
+const TemplateMargin = (args) => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-icon name="${args.name}" ${args.marginLeft0 ? `margin-left="${args.marginLeft0}"` : null} ${args.marginRight0 ? `margin-right="${args.marginRight0}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft50 ? `margin-left="${args.marginLeft50}"` : null} ${args.marginRight50 ? `margin-right="${args.marginRight50}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft100 ? `margin-left="${args.marginLeft100}"` : null} ${args.marginRight100 ? `margin-right="${args.marginRight100}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft150 ? `margin-left="${args.marginLeft150}"` : null} ${args.marginRight150 ? `margin-right="${args.marginRight150}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft200 ? `margin-left="${args.marginLeft200}"` : null} ${args.marginRight200 ? `margin-right="${args.marginRight200}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft250 ? `margin-left="${args.marginLeft250}"` : null} ${args.marginRight250 ? `margin-right="${args.marginRight250}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft300 ? `margin-left="${args.marginLeft300}"` : null} ${args.marginRight300 ? `margin-right="${args.marginRight300}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft400 ? `margin-left="${args.marginLeft400}"` : null} ${args.marginRight400 ? `margin-right="${args.marginRight400}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft450 ? `margin-left="${args.marginLeft450}"` : null} ${args.marginRight450 ? `margin-right="${args.marginRight450}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft500 ? `margin-left="${args.marginLeft500}"` : null} ${args.marginRight500 ? `margin-right="${args.marginRight500}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft550 ? `margin-left="${args.marginLeft550}"` : null} ${args.marginRight550 ? `margin-right="${args.marginRight550}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft600 ? `margin-left="${args.marginLeft600}"` : null} ${args.marginRight600 ? `margin-right="${args.marginRight600}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft700 ? `margin-left="${args.marginLeft700}"` : null} ${args.marginRight700 ? `margin-right="${args.marginRight700}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft800 ? `margin-left="${args.marginLeft800}"` : null} ${args.marginRight800 ? `margin-right="${args.marginRight800}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft900 ? `margin-left="${args.marginLeft900}"` : null} ${args.marginRight900 ? `margin-right="${args.marginRight900}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.marginLeft1000 ? `margin-left="${args.marginLeft1000}"` : null} ${args.marginRight1000 ? `margin-right="${args.marginRight1000}"` : null}></gcds-icon>
+
+<!-- React code -->
+<GcdsIcon name="${args.name}" margin-left="0"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="50"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="100"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="150"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="200"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="250"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="300"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="400"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="500"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="550"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="600"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="700"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="800"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="900"></GcdsIcon>
+<GcdsIcon name="${args.name}" margin-left="1000"></GcdsIcon>
+`).replace(/ null/g, '');
+
+const TemplateMultiple = (args) => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-icon name="${args.name1}" ${args.size1 != "text" ? `size="${args.size1}"`: null}></gcds-icon>
+<gcds-icon name="${args.name2}" ${args.size2 != "text" ? `size="${args.size2}"`: null}></gcds-icon>
+<gcds-icon name="${args.name3}" ${args.size3 != "text" ? `size="${args.size3}"`: null}></gcds-icon>
+<gcds-icon name="${args.name4}" ${args.size4 != "text" ? `size="${args.size4}"`: null}></gcds-icon>
+<gcds-icon name="${args.name5}" ${args.size5 != "text" ? `size="${args.size5}"`: null}></gcds-icon>
+<gcds-icon name="${args.name6}" ${args.size6 != "text" ? `size="${args.size6}"`: null}></gcds-icon>
+<gcds-icon name="${args.name7}" ${args.size7 != "text" ? `size="${args.size7}"`: null}></gcds-icon>
+<gcds-icon name="${args.name8}" ${args.size8 != "text" ? `size="${args.size8}"`: null}></gcds-icon>
+<gcds-icon name="${args.name9}" ${args.size9 != "text" ? `size="${args.size9}"`: null}></gcds-icon>
+
+<!-- React code -->
+<GcdsIcon name="${args.name1}" ${args.size1 != "text" ? `size="${args.size1}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name2}" ${args.size2 != "text" ? `size="${args.size2}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name3}" ${args.size3 != "text" ? `size="${args.size3}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name4}" ${args.size4 != "text" ? `size="${args.size4}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name5}" ${args.size5 != "text" ? `size="${args.size5}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name6}" ${args.size6 != "text" ? `size="${args.size6}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name7}" ${args.size7 != "text" ? `size="${args.size7}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name8}" ${args.size8 != "text" ? `size="${args.size8}"`: null}></GcdsIcon>
+<GcdsIcon name="${args.name9}" ${args.size9 != "text" ? `size="${args.size9}"`: null}></GcdsIcon>
+`).replace(/ null/g, '');
+
+const TemplateTwo = (args) => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-icon name="${args.name}" ${args.size != "text" ? `size="${args.size}"`: null} ${args.fixedWidth1 ? `fixed-width="${args.fixedWidth1}"` : null}></gcds-icon>
+<gcds-icon name="${args.name}" ${args.size != "text" ? `size="${args.size}"`: null} ${args.fixedWidth2 ? `fixed-width="${args.fixedWidth2}"` : null}></gcds-icon>
+
+<!-- React code -->
+<GcdsIcon name="${args.name}" ${args.size != "text" ? `size="${args.size}"`: null} ${args.fixedWidth1 ? `fixedWidth="${args.fixedWidth1}"` : null}></GcdsIcon>
+<GcdsIcon name="${args.name}" ${args.size != "text" ? `size="${args.size}"`: null} ${args.fixedWidth2 ? `fixedWidth="${args.fixedWidth2}"` : null}></GcdsIcon>
+`).replace(/ null/g, '');
+
+const TemplatePlayground = (args) => (`
+<gcds-icon
+  ${args.label ? `label="${args.label}"` : null}
+  name="${args.name}"
+  ${args.marginLeft ? `margin-left="${args.marginLeft}"` : null}
+  ${args.marginRight ? `margin-right="${args.marginRight}"` : null}
+  ${args.size != "text" ? `size="${args.size}"`: null}
+  ${args.fixedWidth ? `fixed-width="${args.fixedWidth}"` : null}
+  ${args.iconStyle != 'solid' ? `iconStyle="${args.iconStyle}"` : null}
+>
+</gcds-icon>
+`);
+
+// ------ Icon default ------
+
+export const Default = Template.bind({});
+Default.args = {
+  name: 'tree',
+  size: 'text',
+  iconStyle: 'solid',
+};
+
+// ------ Icon name ------
+
+export const Name = TemplateMultiple.bind({});
+Name.args = {
+  name1: 'times',
+  name2: 'external-link',
+  name3: 'caret-up',
+  name4: 'caret-down',
+  name5: 'exclamation-circle',
+  name6: 'sync',
+  name7: 'download',
+  name8: 'check',
+  name9: 'paperclip',
+  size1: 'text',
+  size2: 'text',
+  size3: 'text',
+  size4: 'text',
+  size5: 'text',
+  size6: 'text',
+  size7: 'text',
+  size8: 'text',
+  size9: 'text',
+};
+
+// ------ Icon sizes ------
+
+export const Sizes = TemplateMultiple.bind({});
+Sizes.args = {
+  name1: 'tree',
+  name2: 'tree',
+  name3: 'tree',
+  name4: 'tree',
+  name5: 'tree',
+  name6: 'tree',
+  name7: 'tree',
+  name8: 'tree',
+  name9: 'tree',
+  size1: 'inherit',
+  size2: 'caption',
+  size3: 'text',
+  size4: 'h6',
+  size5: 'h5',
+  size6: 'h4',
+  size7: 'h3',
+  size8: 'h2',
+  size9: 'h1',
+};
+
+// ------ Icon margin ------
+
+export const MarginLeft = TemplateMargin.bind({});
+MarginLeft.args = {
+  name: 'tree',
+  marginLeft0: '0',
+  marginLeft50: '50',
+  marginLeft100: '100',
+  marginLeft150: '150',
+  marginLeft200: '200',
+  marginLeft250: '250',
+  marginLeft300: '300',
+  marginLeft400: '400',
+  marginLeft450: '450',
+  marginLeft500: '500',
+  marginLeft550: '550',
+  marginLeft600: '600',
+  marginLeft650: '650',
+  marginLeft700: '700',
+  marginLeft800: '800',
+  marginLeft900: '900',
+  marginLeft1000: '1000',
+  size: 'caption',
+};
+
+export const MarginRight = TemplateMargin.bind({});
+MarginRight.args = {
+  name: 'tree',
+  marginRight0: '0',
+  marginRight50: '50',
+  marginRight100: '100',
+  marginRight150: '150',
+  marginRight200: '200',
+  marginRight250: '250',
+  marginRight300: '300',
+  marginRight400: '400',
+  marginRight450: '450',
+  marginRight500: '500',
+  marginRight550: '550',
+  marginRight600: '600',
+  marginRight650: '650',
+  marginRight700: '700',
+  marginRight800: '800',
+  marginRight900: '900',
+  marginRight1000: '1000',
+  size: 'caption',
+};
+
+// ------ Icon width ------
+
+export const Width = TemplateTwo.bind({});
+Width.args = {
+  name: 'close',
+  size: 'text',
+  fixedWidth1: true,
+  fixedWidth2: false,
+};
+
+// ------ Icon label ------
+
+export const Label = Template.bind({});
+Label.args = {
+  name: 'close',
+  size: 'text',
+  iconStyle: 'solid',
+  label: 'Clicking this icon will close the element.',
+};
+
+// ------ Icon events & props ------
+
+export const Props = Template.bind({});
+Props.args = {
+  fixedWidth: false,
+  iconStyle: 'solid',
+  label: '',
+  name: 'tree',
+  size: 'text',
+};
+
+// ------ Icon playground ------
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
+  fixedWidth: false,
+  iconStyle: 'solid',
+  label: '',
+  marginLeft: '0',
+  marginRight: '0',
+  name: 'tree',
+  size: 'text',
+};

--- a/packages/web/src/components/gcds-icon/stories/overview.mdx
+++ b/packages/web/src/components/gcds-icon/stories/overview.mdx
@@ -1,0 +1,80 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as Icon from './gcds-icon.stories';
+
+<Meta of={Icon} name="Overview" />
+
+# Icon<br/>`<gcds-icon>`
+
+_Also called: glyphs, graphic, symbol._
+
+Icons are a visual cue to help users understand the context.
+
+<Canvas
+  of={Icon.Default}
+  story={{ inline: true }}
+/>
+
+## Examples
+<br/>
+
+### Name
+
+Our icon component uses Font Awesome icons. You can find an overview of all available icons on <gcds-button type="link" button-style="text-only" href="https://fontawesome.com/v5/search?p=6&o=r&m=free" target="_blank">fontawesome.com</gcds-button>.
+
+<Canvas
+  of={Icon.Name}
+  story={{ inline: true }}
+/>
+
+### Size
+
+<Canvas
+  of={Icon.Sizes}
+  story={{ inline: true }}
+/>
+
+### Margin
+
+#### Margin left
+
+<Canvas
+  of={Icon.MarginLeft}
+  story={{ inline: true }}
+/>
+
+#### Margin right
+
+<Canvas
+  of={Icon.MarginRight}
+  story={{ inline: true }}
+/>
+
+### Fixed width vs variable width
+
+<Canvas
+  of={Icon.Width}
+  story={{ inline: true }}
+/>
+
+### Label
+
+If you are using an icon by itself, use the `label` to ensure that it has the proper screen reader text attached to it in these cases.
+
+<Canvas
+  of={Icon.Label}
+  story={{ inline: true }}
+/>
+
+## Resources
+
+<ul>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/icon/" target="_blank">Guidance</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-icon" target="_blank">Github</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=1847-5001&mode=design&t=ViXMx7R6TcIiueUf-0" target="_blank">Figma</gcds-button>
+  </li>
+</ul>

--- a/packages/web/src/components/gcds-icon/stories/properties.mdx
+++ b/packages/web/src/components/gcds-icon/stories/properties.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import * as Icon from './gcds-icon.stories';
+
+<Meta of={Icon} name="Events & properties" />
+
+# Events & properties
+
+<Canvas
+  of={Icon.Props}
+  story={{ inline: true }}
+  sourceState="shown"
+  type="dynamic"
+/>
+
+<Controls of={Icon.Props} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
+++ b/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
@@ -221,6 +221,7 @@ Error.args = {
   type: 'text',
   label: 'Label',
   hint: 'Hint / example message.',
+  required: true,
   errorMessage: 'Error message or validation message.',
   lang: 'en',
   autocomplete: 'off',

--- a/packages/web/src/components/gcds-lang-toggle/stories/gcds-lang-toggle.stories.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/stories/gcds-lang-toggle.stories.tsx
@@ -22,22 +22,50 @@ export default {
 
 const Template = (args) => (`
 <!-- Web component code (Angular, Vue) -->
-<gcds-lang-toggle
-  href="${args.href}"
-  ${args.lang != "en" ? `lang="${args.lang}"` : null}
->
+<gcds-lang-toggle href="${args.href}" ${args.lang != "en" ? `lang="${args.lang}"` : null}>
 </gcds-lang-toggle>
 
 <!-- React code -->
-<GcdsLangToggle
-  href="${args.href}"
-  ${args.lang != "en" ? `lang="${args.lang}"` : null}
->
+<GcdsLangToggle href="${args.href}" ${args.lang != "en" ? `lang="${args.lang}"` : null}>
 </GcdsLangToggle>
-`).replace(/\s\snull\n/g, '');
+`).replace(/ null/g, '');
+
+const TemplatePlayground = (args) => (`
+<gcds-lang-toggle
+  href="${args.href}"
+  lang="${args.lang}"
+>
+</gcds-lang-toggle>
+`);
+
+// ------ Language toggle default ------
 
 export const Default = Template.bind({});
 Default.args = {
+  href: '#',
+  lang: 'en'
+};
+
+// ------ Language toggle french ------
+
+export const French = Template.bind({});
+French.args = {
+  href: '#',
+  lang: 'fr'
+};
+
+// ------ Language toggle events & props ------
+
+export const Props = Template.bind({});
+Props.args = {
+  href: '#',
+  lang: 'en'
+};
+
+// ------ Language toggle playground ------
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
   href: '#',
   lang: 'en'
 };

--- a/packages/web/src/components/gcds-lang-toggle/stories/overview.mdx
+++ b/packages/web/src/components/gcds-lang-toggle/stories/overview.mdx
@@ -1,0 +1,48 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as LangToggle from './gcds-lang-toggle.stories';
+
+<Meta of={LangToggle} name="Overview" />
+
+# Language toggle<br/>`<gcds-lang-toggle>`
+
+_Also called: language switch, language selector._
+
+The language toggle is a link to the same content in the other Official Language.
+
+<Canvas
+  of={LangToggle.Default}
+  story={{ inline: true }}
+/>
+
+## Examples
+<br/>
+
+### Language
+
+#### English
+
+<Canvas
+  of={LangToggle.Default}
+  story={{ inline: true }}
+/>
+
+#### French
+
+<Canvas
+  of={LangToggle.French}
+  story={{ inline: true }}
+/>
+
+## Resources
+
+<ul>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/language-toggle/" target="_blank">Guidance</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-lang-toggle" target="_blank">Github</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=1780-5094&mode=design&t=0xvOOptEga94UT0o-0" target="_blank">Figma</gcds-button>
+  </li>
+</ul>

--- a/packages/web/src/components/gcds-lang-toggle/stories/properties.mdx
+++ b/packages/web/src/components/gcds-lang-toggle/stories/properties.mdx
@@ -6,10 +6,10 @@ import * as LangToggle from './gcds-lang-toggle.stories';
 # Events & properties
 
 <Canvas
-  of={LangToggle.Default}
+  of={LangToggle.Props}
   story={{ inline: true }}
   sourceState="shown"
   type="dynamic"
 />
 
-<Controls of={LangToggle.Default} sort="requiredFirst" />
+<Controls of={LangToggle.Props} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
+++ b/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
@@ -56,9 +56,9 @@ const Template = (args) => (`
   ${args.open ? `open` : null}
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  <gcds-nav-link href="#">Form</gcds-nav-link>
-  <gcds-nav-link href="#">GitHub</gcds-nav-link>
-  <gcds-nav-link href="#">Slack</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
 </gcds-nav-group>
 
 <!-- React code -->
@@ -69,9 +69,9 @@ const Template = (args) => (`
   ${args.open ? `open` : null}
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  <GcdsNavLink href="#">Form</GcdsNavLink>
-  <GcdsNavLink href="#">GitHub</GcdsNavLink>
-  <GcdsNavLink href="#">Slack</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
 </GcdsNavGroup>
 `).replace(/\s\snull\n/g, '');
 

--- a/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
+++ b/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
@@ -58,5 +58,5 @@ export const Default = Template.bind({});
 Default.args = {
   href: '#link',
   current: false,
-  default: "Link"
+  default: "Nav link"
 };

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.css
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.css
@@ -15,6 +15,7 @@
 
         &:hover {
           background: var(--gcds-pagination-hover-background);
+          color: var(--gcds-pagination-hover-text);
         }
 
         &:focus {
@@ -22,13 +23,16 @@
           background-color: var(--gcds-pagination-focus-background);
           outline: var(--gcds-pagination-focus-outline-width) solid var(--gcds-pagination-focus-background);
           outline-offset: var(--gcds-pagination-border-width);
+          text-decoration: none;
         }
 
         &:active:not(:focus),
-        &[aria-current*=page]:not(:focus) {
+        &[aria-current*='page']:not(:focus) {
           color: var(--gcds-pagination-active-text);
           background: var(--gcds-pagination-active-background);
           border-color: var(--gcds-pagination-active-background);
+          text-decoration: none;
+          pointer-events: none;
         }
       }
     }
@@ -172,21 +176,20 @@
 
           & > .gcds-pagination-simple-text {
             grid-area: text;
-            margin: var(--gcds-pagination-simple-listitem-text-margin)
+            margin: var(--gcds-pagination-simple-listitem-text-margin);
           }
 
           & > span {
             grid-area: label;
             font-weight: var(--gcds-pagination-simple-label-font-weight);
-            text-decoration: underline;
           }
         }
 
         &.gcds-pagination-simple-previous {
           a {
             grid-template-areas:
-              "icon text"
-              "icon label";
+              'icon text'
+              'icon label';
             grid-template-columns: 0.25fr 1fr;
           }
         }
@@ -195,9 +198,9 @@
 
           a {
             grid-template-areas:
-              "text icon"
-              "label icon";
-            grid-template-columns: 1fr 0.25fr ;
+              'text icon'
+              'label icon';
+            grid-template-columns: 1fr 0.25fr;
           }
         }
       }

--- a/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
+++ b/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
@@ -121,8 +121,8 @@ export const Default = Template.bind({});
 Default.args = {
   display: 'list',
   label: 'Pagination',
-  currentPage: '5',
-  totalPages: '10',
+  currentPage: '9',
+  totalPages: '15',
   url: '',
   previousHref: '#previous',
   previousLabel: '',

--- a/packages/web/src/components/gcds-radio/stories/gcds-radio.stories.tsx
+++ b/packages/web/src/components/gcds-radio/stories/gcds-radio.stories.tsx
@@ -135,9 +135,9 @@ const Template = (args) => (`
 export const Default = Template.bind({});
 Default.args = {
   radioId: 'radio',
-  label: 'Radio label',
+  label: 'Label',
   name: 'radio',
-  hint: '',
+  hint: 'Description or example to make the option clearer.',
   required: false,
   disabled: false,
   value: '',

--- a/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
+++ b/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
@@ -119,6 +119,11 @@ const Template = (args) => (`
   <option value="1">Option 1</option>
   <option value="2">Option 2</option>
   <option value="3">Option 3</option>
+  <option value="4">Option 4</option>
+  <option value="5">Option 5</option>
+  <option value="6">Option 6</option>
+  <option value="7">Option 7</option>
+  <option value="8">Option 8</option>
 </gcds-select>
 
 <!-- React code -->
@@ -137,6 +142,11 @@ const Template = (args) => (`
   <option value="1">Option 1</option>
   <option value="2">Option 2</option>
   <option value="3">Option 3</option>
+  <option value="4">Option 4</option>
+  <option value="5">Option 5</option>
+  <option value="6">Option 6</option>
+  <option value="7">Option 7</option>
+  <option value="8">Option 8</option>
 </GcdsSelect>
 `).replace(/\s\snull\n/g, '');
 
@@ -156,6 +166,11 @@ const TemplatePlayground = (args) => (`
   <option value="1">Option 1</option>
   <option value="2">Option 2</option>
   <option value="3">Option 3</option>
+  <option value="4">Option 4</option>
+  <option value="5">Option 5</option>
+  <option value="6">Option 6</option>
+  <option value="7">Option 7</option>
+  <option value="8">Option 8</option>
 </gcds-select>
 `);
 
@@ -165,9 +180,9 @@ export const Default = Template.bind({});
 Default.args = {
   selectId: 'example-default',
   label: 'Label',
-  hint: 'Hint / example message.',
+  hint: 'Hint / Example message.',
   value: '',
-  defaultValue: 'Choose an option.',
+  defaultValue: 'Select option.',
   errorMessage: '',
   required: false,
   disabled: false,
@@ -181,8 +196,8 @@ export const Disabled = Template.bind({});
 Disabled.args = {
   selectId: 'example-disabled',
   label: 'Label',
-  hint: 'Hint / example message.',
-  defaultValue: 'Choose an option.',
+  hint: 'Hint / Example message.',
+  defaultValue: 'Select option.',
   disabled: true,
   lang: 'en',
   validateOn: 'blur',
@@ -192,8 +207,9 @@ export const Error = Template.bind({});
 Error.args = {
   selectId: 'example-error',
   label: 'Label',
-  hint: 'Hint / example message.',
-  defaultValue: 'Choose an option.',
+  hint: 'Hint / Example message.',
+  defaultValue: 'Select option.',
+  required: true,
   errorMessage: 'Error message or validation message.',
   lang: 'en',
   validateOn: 'blur',
@@ -203,8 +219,8 @@ export const Required = Template.bind({});
 Required.args = {
   selectId: 'example-required',
   label: 'Label',
-  hint: 'Hint / example message.',
-  defaultValue: 'Choose an option.',
+  hint: 'Hint / Example message.',
+  defaultValue: 'Select option.',
   required: true,
   lang: 'en',
   validateOn: 'blur',
@@ -216,7 +232,7 @@ export const WithoutDefaultValue = Template.bind({});
 WithoutDefaultValue.args = {
   selectId: 'example-default',
   label: 'Label',
-  hint: 'Hint / example message.',
+  hint: 'Hint / Example message.',
   lang: 'en',
   validateOn: 'blur',
 };
@@ -227,9 +243,9 @@ export const Props = Template.bind({});
 Props.args = {
   selectId: 'example-default',
   label: 'Label',
-  hint: 'Hint / example message.',
+  hint: 'Hint / Example message.',
   value: '',
-  defaultValue: 'Choose an option.',
+  defaultValue: 'Select option.',
   errorMessage: '',
   required: false,
   disabled: false,
@@ -243,9 +259,9 @@ export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   selectId: 'example-playground',
   label: 'Label',
-  hint: 'Hint / example message.',
+  hint: 'Hint / Example message.',
   value: '',
-  defaultValue: 'Choose an option.',
+  defaultValue: 'Select option.',
   errorMessage: '',
   required: false,
   disabled: false,

--- a/packages/web/src/components/gcds-side-nav/stories/gcds-side-nav.stories.tsx
+++ b/packages/web/src/components/gcds-side-nav/stories/gcds-side-nav.stories.tsx
@@ -34,19 +34,19 @@ const Template = (args) => (`
   label="${args.label}"
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  <gcds-nav-link href="#">Installation</gcds-nav-link>
-  <gcds-nav-link href="#">Foundations</gcds-nav-link>
-  <gcds-nav-link href="#">Components</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
 
-  <gcds-nav-group open-trigger="Contact us" menu-label="Contact">
-    <gcds-nav-link href="#">Form</gcds-nav-link>
-    <gcds-nav-link href="#">GitHub</gcds-nav-link>
-    <gcds-nav-link href="#">Slack</gcds-nav-link>
+  <gcds-nav-group open-trigger="Nav group label" menu-label="Nav group label">
+    <gcds-nav-link href="#">Nav link</gcds-nav-link>
+    <gcds-nav-link href="#">Nav link</gcds-nav-link>
+    <gcds-nav-link href="#">Nav link</gcds-nav-link>
 
-    <gcds-nav-group open-trigger="Sub level 2" menu-label="sublevel">
-      <gcds-nav-link href="#">Link</gcds-nav-link>
-      <gcds-nav-link href="#">Link</gcds-nav-link>
-      <gcds-nav-link href="#">Link</gcds-nav-link>
+    <gcds-nav-group open-trigger="Nav group label" menu-label="Nav group label sublevel">
+      <gcds-nav-link href="#">Nav link</gcds-nav-link>
+      <gcds-nav-link href="#">Nav link</gcds-nav-link>
+      <gcds-nav-link href="#">Nav link</gcds-nav-link>
     </gcds-nav-group>
   </gcds-nav-group>
 </gcds-side-nav>
@@ -56,19 +56,19 @@ const Template = (args) => (`
   label="${args.label}"
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  <GcdsNavLink href="#">Installation</GcdsNavLink>
-  <GcdsNavLink href="#">Foundations</GcdsNavLink>
-  <GcdsNavLink href="#">Components</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
 
-  <GcdsNavGroup openTrigger="Contact us" menuLabel="Contact">
-    <GcdsNavLink href="#">Form</GcdsNavLink>
-    <GcdsNavLink href="#">GitHub</GcdsNavLink>
-    <GcdsNavLink href="#">Slack</GcdsNavLink>
+  <GcdsNavGroup openTrigger="Nav group label" menuLabel="Nav group label">
+    <GcdsNavLink href="#">Nav link</GcdsNavLink>
+    <GcdsNavLink href="#">Nav link</GcdsNavLink>
+    <GcdsNavLink href="#">Nav link</GcdsNavLink>
 
-    <GcdsNavGroup openTrigger="Sub level 2" menuLabel="sublevel">
-      <GcdsNavLink href="#">Link</GcdsNavLink>
-      <GcdsNavLink href="#">Link</GcdsNavLink>
-      <GcdsNavLink href="#">Link</GcdsNavLink>
+    <GcdsNavGroup openTrigger="Nav group label" menuLabel="Nav group label sublevel">
+      <GcdsNavLink href="#">Nav link</GcdsNavLink>
+      <GcdsNavLink href="#">Nav link</GcdsNavLink>
+      <GcdsNavLink href="#">Nav link</GcdsNavLink>
     </GcdsNavGroup>
   </GcdsNavGroup>
 </GcdsSideNav>
@@ -76,6 +76,6 @@ const Template = (args) => (`
 
 export const Default = Template.bind({});
 Default.args = {
-  label: 'Side navigation',
+  label: 'Label',
   lang: 'en'
 };

--- a/packages/web/src/components/gcds-signature/gcds-signature.css
+++ b/packages/web/src/components/gcds-signature/gcds-signature.css
@@ -1,7 +1,6 @@
 gcds-signature {
   display: block;
   width: fit-content;
-  margin: var(--gcds-signature-margin);
 
   .gcds-signature {
     display: flex;
@@ -14,7 +13,6 @@ gcds-signature {
   &:not([type='wordmark']) {
     svg {
       height: var(--gcds-signature-signature-height);
-      margin: var(--gcds-signature-signature-margin);
     }
 
     @media screen and (min-width: 64em) {
@@ -27,7 +25,6 @@ gcds-signature {
   &[type='wordmark'] {
     svg {
       height: var(--gcds-signature-wordmark-height);
-      margin: var(--gcds-signature-wordmark-margin);
       width: auto;
     }
   }

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -118,6 +118,14 @@ WordmarkWhite.args = {
   lang: 'en'
 };
 
+export const Props = Template.bind({});
+Props.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'en'
+};
+
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   type: 'signature',

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -1,0 +1,127 @@
+import { langProp } from '../../../utils/storybook/component-properties';
+
+export default {
+  title: 'Components/Signature',
+
+  argTypes: {
+    // Props
+    type: {
+      control: 'radio',
+      options: ['signature', 'wordmark'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'signature' }
+      },
+    },
+    hasLink: {
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false }
+      },
+    },
+    variant: {
+      control: 'radio',
+      options: ['colour', 'white'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'colour' }
+      },
+    },
+    ...langProp
+  },
+};
+
+const Template = (args) => (`
+<!-- Web component code (Angular, Vue) -->
+<gcds-signature
+  type="${args.type}"
+  has-link="${args.hasLink}"
+  variant="${args.variant}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</gcds-signature>
+
+<!-- React code -->
+<GcdsSignature
+  type="${args.type}"
+  hasLink="${args.hasLink}"
+  variant="${args.variant}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</GcdsSignature>
+`).replace(/\s\snull\n/g, '');
+
+const TemplatePlayground = (args) => (`
+<gcds-signature
+  type="${args.type}"
+  has-link="${args.hasLink}"
+  variant="${args.variant}"
+  ${args.lang != "en" ? `lang="${args.lang}"` : null}
+>
+</gcds-signature>
+`);
+
+export const Default = Template.bind({});
+Default.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'en'
+};
+
+export const Wordmark = Template.bind({});
+Wordmark.args = {
+  type: 'wordmark',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'en'
+};
+
+export const SignatureFrench = Template.bind({});
+SignatureFrench.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'fr'
+};
+
+export const WordmarkFrench = Template.bind({});
+WordmarkFrench.args = {
+  type: 'wordmark',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'fr'
+};
+
+export const HasLinkTrue = Template.bind({});
+HasLinkTrue.args = {
+  type: 'signature',
+  hasLink: 'true',
+  variant: 'colour',
+  lang: 'en'
+};
+
+export const SignatureWhite = Template.bind({});
+SignatureWhite.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'white',
+  lang: 'en'
+};
+
+export const WordmarkWhite = Template.bind({});
+WordmarkWhite.args = {
+  type: 'wordmark',
+  hasLink: 'false',
+  variant: 'white',
+  lang: 'en'
+};
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'en'
+};

--- a/packages/web/src/components/gcds-signature/stories/overview.mdx
+++ b/packages/web/src/components/gcds-signature/stories/overview.mdx
@@ -1,0 +1,111 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as Signature from './gcds-signature.stories';
+
+<Meta of={Signature} name="Overview" />
+
+# Signature<br/>`<gcds-signature>`
+
+_Also called: wordmark._
+
+The signature is the Government of Canada landmark identifier found in the header or footer.
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+## Examples
+<br/>
+
+### Type property
+
+#### Signature Type
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### Wordmark Type
+
+<Canvas
+  of={Signature.Wordmark}
+  story={{ inline: true }}
+/>
+
+### Language
+
+#### English Signature
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### French Signature
+
+<Canvas
+  of={Signature.SignatureFrench}
+  story={{ inline: true }}
+/>
+
+#### English Wordmark
+
+<Canvas
+  of={Signature.Wordmark}
+  story={{ inline: true }}
+/>
+
+#### French Wordmark
+
+<Canvas
+  of={Signature.WordmarkFrench}
+  story={{ inline: true }}
+/>
+
+
+### hasLink property
+
+#### hasLink = false
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### hasLink = true
+
+<Canvas
+  of={Signature.HasLinkTrue}
+  story={{ inline: true }}
+/>
+
+### Colour variants
+
+#### Signature variant = colour
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+/>
+
+#### Wordmark variant = colour
+
+<Canvas
+  of={Signature.Wordmark}
+  story={{ inline: true }}
+/>
+
+#### Signature variant = white
+
+<Canvas
+  of={Signature.SignatureWhite}
+  story={{ inline: true }}
+/>
+
+#### Wordmark variant = white
+
+<Canvas
+  of={Signature.WordmarkWhite}
+  story={{ inline: true }}
+/>

--- a/packages/web/src/components/gcds-signature/stories/properties.mdx
+++ b/packages/web/src/components/gcds-signature/stories/properties.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import * as Signature from './gcds-signature.stories';
+
+<Meta of={Signature} name="Events & properties" />
+
+# Events & properties
+
+<Canvas
+  of={Signature.Default}
+  story={{ inline: true }}
+  sourceState="shown"
+  type="dynamic"
+/>
+
+<Controls of={Signature.Default} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-signature/stories/properties.mdx
+++ b/packages/web/src/components/gcds-signature/stories/properties.mdx
@@ -6,10 +6,10 @@ import * as Signature from './gcds-signature.stories';
 # Events & properties
 
 <Canvas
-  of={Signature.Default}
+  of={Signature.Props}
   story={{ inline: true }}
   sourceState="shown"
   type="dynamic"
 />
 
-<Controls of={Signature.Default} sort="requiredFirst" />
+<Controls of={Signature.Props} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-stepper/stories/gcds-stepper.stories.tsx
+++ b/packages/web/src/components/gcds-stepper/stories/gcds-stepper.stories.tsx
@@ -56,7 +56,7 @@ export const Default = Template.bind({});
 Default.args = {
   lang: 'en',
   currentStep: 1,
-  totalSteps: 5,
+  totalSteps: 4,
 };
 
 // ------ Stepper french ------
@@ -65,7 +65,7 @@ export const French = Template.bind({});
 French.args = {
   lang: 'fr',
   currentStep: 1,
-  totalSteps: 5,
+  totalSteps: 4,
 };
 
 // ------ Stepper events & props ------
@@ -74,7 +74,7 @@ export const Props = Template.bind({});
 Props.args = {
   lang: 'en',
   currentStep: 1,
-  totalSteps: 5,
+  totalSteps: 4,
 };
 
 // ------ Stepper playground ------
@@ -83,5 +83,5 @@ export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   lang: 'en',
   currentStep: 1,
-  totalSteps: 5,
+  totalSteps: 4,
 };

--- a/packages/web/src/components/gcds-textarea/stories/gcds-textarea.stories.tsx
+++ b/packages/web/src/components/gcds-textarea/stories/gcds-textarea.stories.tsx
@@ -146,8 +146,8 @@ const Template = (args) => (`
 export const Default = Template.bind({});
 Default.args = {
   textareaId: 'textarea',
-  label: 'Textarea label',
-  hint: '',
+  label: 'Label',
+  hint: 'Hint / Example message.',
   errorMessage: '',
   required: false,
   disabled: false,

--- a/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
+++ b/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
@@ -53,18 +53,15 @@ const Template = (args) => (`
   alignment="${args.alignment}"
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  ${args.home ?
-    `<gcds-nav-link href="#home" slot="home">${args.home}</gcds-nav-link>
-    `
-  : null}
-  <gcds-nav-link href="#">Installation</gcds-nav-link>
-  <gcds-nav-group  open-trigger="Contact" menu-label="Contact">
-    <gcds-nav-link href="#">Form</gcds-nav-link>
-    <gcds-nav-link href="#">GitHub</gcds-nav-link>
-    <gcds-nav-link href="#">Slack</gcds-nav-link>
+  ${args.home ? `<gcds-nav-link href="#home" slot="home">${args.home}</gcds-nav-link> ` : null}
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
+  <gcds-nav-group  open-trigger="Nav group label" menu-label="Nav group label">
+    <gcds-nav-link href="#">Nav link</gcds-nav-link>
+    <gcds-nav-link href="#">Nav link</gcds-nav-link>
+    <gcds-nav-link href="#">Nav link</gcds-nav-link>
   </gcds-nav-group>
-  <gcds-nav-link href="#">Foundations</gcds-nav-link>
-  <gcds-nav-link href="#">Components</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
+  <gcds-nav-link href="#">Nav link</gcds-nav-link>
 </gcds-top-nav>
 
 <!-- React code -->
@@ -73,18 +70,15 @@ const Template = (args) => (`
   alignment="${args.alignment}"
   ${args.lang != "en" ? `lang="${args.lang}"` : null}
 >
-  ${args.home ?
-    `<GcdsNavLink href="#home" slot="home">${args.home}</GcdsNavLink>
-    `
-  : null}
-  <GcdsNavLink href="#">Installation</GcdsNavLink>
-  <GcdsNavGroup  openTrigger="Contact" menuLabel="Contact">
-    <GcdsNavLink href="#">Form</GcdsNavLink>
-    <GcdsNavLink href="#">GitHub</GcdsNavLink>
-    <GcdsNavLink href="#">Slack</GcdsNavLink>
+  ${args.home ? `<GcdsNavLink href="#home" slot="home">${args.home}</GcdsNavLink> ` : null}
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
+  <GcdsNavGroup  openTrigger="Nav group label" menuLabel="Nav group label">
+    <GcdsNavLink href="#">Nav link</GcdsNavLink>
+    <GcdsNavLink href="#">Nav link</GcdsNavLink>
+    <GcdsNavLink href="#">Nav link</GcdsNavLink>
   </GcdsNavGroup>
-  <GcdsNavLink href="#">Foundations</GcdsNavLink>
-  <GcdsNavLink href="#">Components</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
+  <GcdsNavLink href="#">Nav link</GcdsNavLink>
 </GcdsTopNav>
 `).replace(/\s\snull\n/g, '');
 
@@ -92,6 +86,6 @@ export const Default = Template.bind({});
 Default.args = {
   label: 'Top navigation',
   alignment: 'right',
-  home: '',
+  home: 'Home nav link',
   lang: 'en'
 };

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,5 @@
       "before 6am on the first day of the month"
     ]
   },
-  "baseBranches": ["staging"]
+  "baseBranches": ["develop"]
 }


### PR DESCRIPTION
# Summary | Résumé

Publish v0.13.0 of component packages.

## v0.13.0


### New features

- Search component (`gcds-search`)
  - New `gcds-search` component for canada.ca compliance

### Breaking changes

- Header component (`gcds-header`)
  - `topnav` slot in the `gcds-header` has been renamed to `skip-to-nav`

### Minor

- https://github.com/cds-snc/gcds-components/pull/212 - [c8f0aa1](https://github.com/cds-snc/gcds-components/commit/c8f0aa1107404b5093731548f072d22e8bb699a3) - Add `gcds-search` to component library
- https://github.com/cds-snc/gcds-components/pull/225 - [2bc48f9](https://github.com/cds-snc/gcds-components/commit/2bc48f9f51e967c0d12b20b191fbfe2ff54790e1) - Rename `topnav` slot in `gcds-header` to `skip-to-nav`

### Patch

- https://github.com/cds-snc/gcds-components/pull/219 - [bfb7a58](https://github.com/cds-snc/gcds-components/commit/bfb7a58925b5a474e5885d02e6405faf18fe2d1f) - Update `gcds-top-nav` component style to match design files
- https://github.com/cds-snc/gcds-components/pull/221 - [fd82057](https://github.com/cds-snc/gcds-components/commit/fd8205708aac28da71d18d794db8f4af9fa2455a) - Update hover styles for `gcds-file-uploader` and `gcds-pagination`
- https://github.com/cds-snc/gcds-components/pull/225 - [2bc48f9](https://github.com/cds-snc/gcds-components/commit/2bc48f9f51e967c0d12b20b191fbfe2ff54790e1) - Update text in `gcds-file-uploader` button to `Choose file`
- https://github.com/cds-snc/gcds-components/pull/227 - [0effdc8](https://github.com/cds-snc/gcds-components/commit/0effdc89e8c4866e023853e38c57c7e7d13c47aa) - Remove icon from `gcds-file-uploader` button label
