### PR TITLE
Create a separate story for event & properties

### DIFF
--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -118,6 +118,14 @@ WordmarkWhite.args = {
   lang: 'en'
 };
 
+export const Props = Template.bind({});
+Props.args = {
+  type: 'signature',
+  hasLink: 'false',
+  variant: 'colour',
+  lang: 'en'
+};
+
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   type: 'signature',

--- a/packages/web/src/components/gcds-signature/stories/properties.mdx
+++ b/packages/web/src/components/gcds-signature/stories/properties.mdx
@@ -6,10 +6,10 @@ import * as Signature from './gcds-signature.stories';
 # Events & properties
 
 <Canvas
-  of={Signature.Default}
+  of={Signature.Props}
   story={{ inline: true }}
   sourceState="shown"
   type="dynamic"
 />
 
-<Controls of={Signature.Default} sort="requiredFirst" />
+<Controls of={Signature.Props} sort="requiredFirst" />


### PR DESCRIPTION
# Summary | Résumé

To prevent the Events and properties story from changing the Default story, create separate story for Events and properties.