### PR TITLE
Update mobile view and French text of pagination component

### DIFF
--- a/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
@@ -157,7 +157,7 @@ export class GcdsPagination {
               class={!mobile ? "gcds-pagination-end-button" : "gcds-pagination-end-button-mobile"}
             >
               <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-              {I18N[this.lang].previous}
+              {mobile ? I18N[this.lang].previousMobile : I18N[this.lang].previous}
             </a>
           }
         </li>

--- a/packages/web/src/components/gcds-pagination/i18n/i18n.js
+++ b/packages/web/src/components/gcds-pagination/i18n/i18n.js
@@ -2,6 +2,7 @@ const I18N = {
   "en": {
     next: "Next",
     previous: "Previous",
+    previousMobile: "Prev",
     nextPage: "Next page",
     previousPage: "Previous page",
     pageNumber: "Page {#}",
@@ -9,7 +10,8 @@ const I18N = {
   },
   "fr": {
     next: "Suivante",
-    previous: "Précédente",
+    previous: "Précédent",
+    previousMobile: "Préc.",
     nextPage: "Page suivante",
     previousPage: "Page précédente",
     pageNumber: "Page {#}",

--- a/packages/web/src/components/gcds-pagination/test/gcds-pagination.spec.tsx
+++ b/packages/web/src/components/gcds-pagination/test/gcds-pagination.spec.tsx
@@ -102,7 +102,7 @@ describe('gcds-pagination', () => {
             <a aria-label="Page précédente: Previous label" href="#previous">
               <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
               <div class="gcds-pagination-simple-text">
-              Précédente
+              Précédent
               </div>
               <span>
                 Previous label
@@ -142,7 +142,7 @@ describe('gcds-pagination', () => {
             <a aria-label="Page précédente" href="#previous">
               <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
               <div class="gcds-pagination-simple-text">
-                Précédente
+                Précédent
               </div>
               <span>
               </span>
@@ -250,7 +250,7 @@ describe('gcds-pagination', () => {
             <li>
               <a aria-label="Previous page: Page 4 of 9 of Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                 <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-                Previous
+                Prev
               </a>
             </li>
             <li>
@@ -342,7 +342,7 @@ describe('gcds-pagination', () => {
             <li>
               <a aria-label="Previous page: Page 9 of 20 of Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                 <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-                Previous
+                Prev
               </a>
             </li>
             <li>
@@ -375,7 +375,7 @@ describe('gcds-pagination', () => {
             <li>
               <a aria-label="Page précédente: Page 4 sur 9 des Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
                 <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-                Précédente
+                Précédent
               </a>
             </li>
             <li>
@@ -444,7 +444,7 @@ describe('gcds-pagination', () => {
             <li>
               <a aria-label="Page précédente: Page 4 sur 9 des Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                 <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-                Précédente
+                Préc.
               </a>
             </li>
             <li>
@@ -477,7 +477,7 @@ describe('gcds-pagination', () => {
             <li>
               <a aria-label="Page précédente: Page 9 sur 20 des Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
                 <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-                Précédente
+                Précédent
               </a>
             </li>
             <li>
@@ -536,7 +536,7 @@ describe('gcds-pagination', () => {
             <li>
               <a aria-label="Page précédente: Page 9 sur 20 des Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                 <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
-                Précédente
+                Préc.
               </a>
             </li>
             <li>


### PR DESCRIPTION
# Summary | Résumé

Update the French text for pagination's Previous buttons and shorten `Previous` to `Prev` while in mobile list view.
