### PR TITLE
storybook: hide events & properties heading for demo

### DIFF
--- a/packages/web/src/components/gcds-breadcrumbs/stories/properties.mdx
+++ b/packages/web/src/components/gcds-breadcrumbs/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Breadcrumbs from './gcds-breadcrumbs.stories';
 
 <Meta of={Breadcrumbs} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Breadcrumbs.Props}

--- a/packages/web/src/components/gcds-button/stories/properties.mdx
+++ b/packages/web/src/components/gcds-button/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Button from './gcds-button.stories';
 
 <Meta of={Button} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Button.Props}

--- a/packages/web/src/components/gcds-card/stories/properties.mdx
+++ b/packages/web/src/components/gcds-card/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Card from './gcds-card.stories';
 
 <Meta of={Card} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Card.Default}

--- a/packages/web/src/components/gcds-checkbox/stories/properties.mdx
+++ b/packages/web/src/components/gcds-checkbox/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Checkbox from './gcds-checkbox.stories';
 
 <Meta of={Checkbox} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Checkbox.Default}

--- a/packages/web/src/components/gcds-container/stories/properties.mdx
+++ b/packages/web/src/components/gcds-container/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Container from './gcds-container.stories';
 
 <Meta of={Container} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Container.Props}

--- a/packages/web/src/components/gcds-date-modified/stories/properties.mdx
+++ b/packages/web/src/components/gcds-date-modified/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as DateModified from './gcds-date-modified.stories';
 
 <Meta of={DateModified} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={DateModified.Props}

--- a/packages/web/src/components/gcds-details/stories/properties.mdx
+++ b/packages/web/src/components/gcds-details/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Details from './gcds-details.stories';
 
 <Meta of={Details} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Details.Props}

--- a/packages/web/src/components/gcds-error-message/stories/properties.mdx
+++ b/packages/web/src/components/gcds-error-message/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as ErrorMessage from './gcds-error-message.stories';
 
 <Meta of={ErrorMessage} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={ErrorMessage.Props}

--- a/packages/web/src/components/gcds-error-summary/stories/properties.mdx
+++ b/packages/web/src/components/gcds-error-summary/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as ErrorSummary from './gcds-error-summary.stories';
 
 <Meta of={ErrorSummary} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={ErrorSummary.Props}

--- a/packages/web/src/components/gcds-fieldset/stories/properties.mdx
+++ b/packages/web/src/components/gcds-fieldset/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Button from './gcds-fieldset.stories';
 
 <Meta of={Button} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Button.Default}

--- a/packages/web/src/components/gcds-file-uploader/stories/properties.mdx
+++ b/packages/web/src/components/gcds-file-uploader/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as FileUploader from './gcds-file-uploader.stories';
 
 <Meta of={FileUploader} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={FileUploader.Props}

--- a/packages/web/src/components/gcds-footer/stories/properties.mdx
+++ b/packages/web/src/components/gcds-footer/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Footer from './gcds-footer.stories';
 
 <Meta of={Footer} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Footer.Default}

--- a/packages/web/src/components/gcds-header/stories/properties.mdx
+++ b/packages/web/src/components/gcds-header/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Header from './gcds-header.stories';
 
 <Meta of={Header} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Header.Default}

--- a/packages/web/src/components/gcds-icon/stories/properties.mdx
+++ b/packages/web/src/components/gcds-icon/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Icon from './gcds-icon.stories';
 
 <Meta of={Icon} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Icon.Props}

--- a/packages/web/src/components/gcds-input/stories/properties.mdx
+++ b/packages/web/src/components/gcds-input/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Input from './gcds-input.stories';
 
 <Meta of={Input} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Input.Props}

--- a/packages/web/src/components/gcds-lang-toggle/stories/properties.mdx
+++ b/packages/web/src/components/gcds-lang-toggle/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as LangToggle from './gcds-lang-toggle.stories';
 
 <Meta of={LangToggle} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={LangToggle.Props}

--- a/packages/web/src/components/gcds-nav-group/stories/properties.mdx
+++ b/packages/web/src/components/gcds-nav-group/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as NavGroup from './gcds-nav-group.stories';
 
 <Meta of={NavGroup} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={NavGroup.Default}

--- a/packages/web/src/components/gcds-nav-link/stories/properties.mdx
+++ b/packages/web/src/components/gcds-nav-link/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as NavLink from './gcds-nav-link.stories';
 
 <Meta of={NavLink} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={NavLink.Default}

--- a/packages/web/src/components/gcds-pagination/stories/properties.mdx
+++ b/packages/web/src/components/gcds-pagination/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Pagination from './gcds-pagination.stories';
 
 <Meta of={Pagination} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Pagination.Default}

--- a/packages/web/src/components/gcds-radio/stories/properties.mdx
+++ b/packages/web/src/components/gcds-radio/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Radio from './gcds-radio.stories';
 
 <Meta of={Radio} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Radio.Default}

--- a/packages/web/src/components/gcds-search/stories/properties.mdx
+++ b/packages/web/src/components/gcds-search/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Search from './gcds-search.stories';
 
 <Meta of={Search} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Search.Props}

--- a/packages/web/src/components/gcds-select/stories/properties.mdx
+++ b/packages/web/src/components/gcds-select/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Select from './gcds-select.stories';
 
 <Meta of={Select} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Select.Props}

--- a/packages/web/src/components/gcds-side-nav/stories/properties.mdx
+++ b/packages/web/src/components/gcds-side-nav/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as SideNav from './gcds-side-nav.stories';
 
 <Meta of={SideNav} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={SideNav.Default}

--- a/packages/web/src/components/gcds-signature/stories/properties.mdx
+++ b/packages/web/src/components/gcds-signature/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Signature from './gcds-signature.stories';
 
 <Meta of={Signature} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Signature.Props}

--- a/packages/web/src/components/gcds-stepper/stories/properties.mdx
+++ b/packages/web/src/components/gcds-stepper/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Stepper from './gcds-stepper.stories';
 
 <Meta of={Stepper} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Stepper.Props}

--- a/packages/web/src/components/gcds-textarea/stories/properties.mdx
+++ b/packages/web/src/components/gcds-textarea/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as Textarea from './gcds-textarea.stories';
 
 <Meta of={Textarea} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={Textarea.Default}

--- a/packages/web/src/components/gcds-top-nav/stories/properties.mdx
+++ b/packages/web/src/components/gcds-top-nav/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as TopNav from './gcds-top-nav.stories';
 
 <Meta of={TopNav} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={TopNav.Default}

--- a/packages/web/src/components/gcds-topic-menu/stories/properties.mdx
+++ b/packages/web/src/components/gcds-topic-menu/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as TopicMenu from './gcds-topic-menu.stories';
 
 <Meta of={TopicMenu} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={TopicMenu.Props}

--- a/packages/web/src/components/gcds-verify-banner/stories/properties.mdx
+++ b/packages/web/src/components/gcds-verify-banner/stories/properties.mdx
@@ -3,7 +3,7 @@ import * as VerifyBanner from './gcds-verify-banner.stories';
 
 <Meta of={VerifyBanner} name="Events & properties" />
 
-# Events & properties
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
 
 <Canvas
   of={VerifyBanner.Props}


### PR DESCRIPTION
# Summary | Résumé

Hide `Events & properties` heading in each story for live demos on our documentation site.