### PR TITLE
Fix focusout logic in gcds-topic-menu

### DIFF
--- a/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.tsx
+++ b/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.tsx
@@ -54,7 +54,7 @@ export class GcdsTopicMenu {
   */
   @Listen("focusout", { target: "document" })
   async focusOutListener(e) {
-    if (!this.el.contains(e.relatedTarget)) {
+    if (!this.el.contains(e.relatedTarget) && this.open) {
       this.toggleNav();
     }
   }


### PR DESCRIPTION
# Summary | Résumé

Add additional logic checking to see if the theme and topic menu is open in the `focusout` listener. This prevents the menu from being toggled open if the closed menu button had focus on focus out.
