### PR TITLE
Details accessibility fix

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -21,7 +21,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.6.0",
+        "@cdssnc/gcds-tokens": "^1.6.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@node-minify/core": "^6.2.0",
         "@node-minify/uglify-es": "^6.2.0",
@@ -2593,9 +2593,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.6.0.tgz",
-      "integrity": "sha512-hpQRDb2ov175d3v35GwPolD9mbU/oXsLHlfrl3+HW8ERyH4E8QQZhlr0yVMfT/pjaOk9OEusZbRYpDneuO+1sw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.6.1.tgz",
+      "integrity": "sha512-bmesAeFKYdYOxSksSejwtBq3FywrMY2KIljxCIty4gjfByQN6uHLBug2Tg3Ni6MIJkBnoUlrCcV9mXNyE6A/bA==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -25936,9 +25936,9 @@
       "dev": true
     },
     "@cdssnc/gcds-tokens": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.6.0.tgz",
-      "integrity": "sha512-hpQRDb2ov175d3v35GwPolD9mbU/oXsLHlfrl3+HW8ERyH4E8QQZhlr0yVMfT/pjaOk9OEusZbRYpDneuO+1sw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.6.1.tgz",
+      "integrity": "sha512-bmesAeFKYdYOxSksSejwtBq3FywrMY2KIljxCIty4gjfByQN6uHLBug2Tg3Ni6MIJkBnoUlrCcV9mXNyE6A/bA==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.6.0",
+    "@cdssnc/gcds-tokens": "^1.6.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@node-minify/core": "^6.2.0",
     "@node-minify/uglify-es": "^6.2.0",

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -1,13 +1,21 @@
-:host .gcds-details {
-  font: var(--gcds-details-font);
-
-  summary {
+:host {
+  .details__summary {
     position: relative;
     cursor: pointer;
     display: inline-block;
-    padding: var(--gcds-details-summary-padding);
+    /* padding: var(--gcds-details-summary-padding); */
+    padding: 0.375rem 0.375rem 0.375rem 2.25rem;
     color: var(--gcds-details-default-text);
     transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+    border-color: transparent;
+    background-color: transparent;
+    font: var(--gcds-details-font);
+    /* margin: var(--gcds-details-summary-text-margin); */
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: var(--gcds-details-default-decoration-thickness);
+    text-align: start;
 
     &:focus {
       border-radius: var(--gcds-details-focus-border-radius);
@@ -16,10 +24,7 @@
       box-shadow: var(--gcds-details-focus-box-shadow);
       outline-offset: var(--gcds-details-focus-outline-offset);
       outline: var(--gcds-details-focus-outline);
-
-      p {
-        text-decoration: none;
-      }
+      text-decoration: none;
     }
 
     &:before {
@@ -35,14 +40,12 @@
       transition: transform 0.15s ease-in-out;
     }
 
-    p {
-      display: inline-block;
-      font: var(--gcds-details-font);
-      margin: var(--gcds-details-summary-text-margin);
-      text-decoration: underline;
-      text-underline-offset: 0.2em;
-      text-decoration-color: currentColor;
-      text-decoration-thickness: var(--gcds-details-default-decoration-thickness);
+    &[aria-expanded=false] + .details__panel {
+      display: none;
+    }
+
+    &[aria-expanded=true]::before {
+      transform: rotate(90deg);
     }
   }
 

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -9,10 +9,8 @@
     border-color: transparent;
     background-color: transparent;
     font: var(--gcds-details-font);
-    text-decoration: underline;
+    text-decoration: underline var(--gcds-details-default-decoration-thickness);
     text-underline-offset: 0.2em;
-    text-decoration-color: currentColor;
-    text-decoration-thickness: var(--gcds-details-default-decoration-thickness);
     text-align: start;
 
     &:hover:not(:focus) {

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -2,7 +2,7 @@
   .details__summary {
     position: relative;
     cursor: pointer;
-    display: inline-block;
+    display: block;
     padding: var(--gcds-details-summary-padding);
     color: var(--gcds-details-default-text);
     transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -3,19 +3,27 @@
     position: relative;
     cursor: pointer;
     display: inline-block;
-    /* padding: var(--gcds-details-summary-padding); */
-    padding: 0.375rem 0.375rem 0.375rem 2.25rem;
+    padding: var(--gcds-details-summary-padding);
     color: var(--gcds-details-default-text);
     transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
     border-color: transparent;
     background-color: transparent;
     font: var(--gcds-details-font);
-    /* margin: var(--gcds-details-summary-text-margin); */
     text-decoration: underline;
     text-underline-offset: 0.2em;
     text-decoration-color: currentColor;
     text-decoration-thickness: var(--gcds-details-default-decoration-thickness);
     text-align: start;
+
+    &:hover:not(:focus) {
+      color: var(--gcds-details-hover-text);
+      text-underline-offset: 0.2em;
+      text-decoration-thickness: var(--gcds-details-hover-decoration-thickness);
+
+      &:before {
+        color: var(--gcds-details-hover-text);
+      }
+    }
 
     &:focus {
       border-radius: var(--gcds-details-focus-border-radius);
@@ -50,7 +58,7 @@
   }
 
   .details__panel {
-    margin: var(--gcds-spacing-200) 0 0 0;
+    margin: var(--gcds-details-panel-margin);
     padding: var(--gcds-details-panel-padding);
     border-inline-start: var(--gcds-details-panel-border-width) solid var(--gcds-details-panel-border-color);
 
@@ -76,23 +84,5 @@
     ::slotted(small) {
       font: var(--gcds-details-font-small);
     }
-  }
-
-  &:hover {
-    summary:not(:focus) {
-      &:before {
-        color: var(--gcds-details-hover-text);
-      }
-
-      p {
-        color: var(--gcds-details-hover-text);
-        text-underline-offset: 0.2em;
-        text-decoration-thickness: var(--gcds-details-hover-decoration-thickness);
-      }
-    }
-  }
-
-  &[open] summary:before {
-    transform: rotate(90deg);
   }
 }

--- a/packages/web/src/components/gcds-details/gcds-details.tsx
+++ b/packages/web/src/components/gcds-details/gcds-details.tsx
@@ -30,12 +30,18 @@ export class GcdsDetails {
       <Host>
         <button
           aria-expanded={open.toString()}
+          aria-controls="details__panel"
           onClick={() => this.open = !open}
           class="details__summary"
+          id="details__summary"
         >
           { detailsTitle }
         </button>
-        <div class="details__panel">
+        <div
+          id="details__panel"
+          class="details__panel"
+          aria-labelledby="details__summary"
+        >
           <slot></slot>
         </div>
       </Host>

--- a/packages/web/src/components/gcds-details/gcds-details.tsx
+++ b/packages/web/src/components/gcds-details/gcds-details.tsx
@@ -21,19 +21,23 @@ export class GcdsDetails {
   /**
    * Defines if the details panel is open by default or not.
    */
-  @Prop() open?: boolean = false;
+  @Prop({mutable: true, reflect: true}) open?: boolean = false;
 
   render() {
     const { detailsTitle, open } = this;
 
     return (
       <Host>
-        <details class="gcds-details" open={open ? true : false}>
-          <summary><p>{ detailsTitle }</p></summary>
-          <div class="details__panel">
-            <slot></slot>
-          </div>
-        </details>
+        <button
+          aria-expanded={open.toString()}
+          onClick={() => this.open = !open}
+          class="details__summary"
+        >
+          { detailsTitle }
+        </button>
+        <div class="details__panel">
+          <slot></slot>
+        </div>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-details/test/gcds-details.spec.tsx
+++ b/packages/web/src/components/gcds-details/test/gcds-details.spec.tsx
@@ -10,12 +10,12 @@ describe('gcds-details', () => {
     expect(page.root).toEqualHtml(`
       <gcds-details details-title="Learn more about this topic">
         <mock:shadow-root>
-          <details class="gcds-details">
-            <summary><p>Learn more about this topic</p></summary>
-            <div class="details__panel">
-              <slot></slot>
-            </div>
-          </details>
+          <button class="details__summary" aria-expanded="false">
+            Learn more about this topic
+          </button>
+          <div class="details__panel">
+            <slot></slot>
+          </div>
         </mock:shadow-root>
       </gcds-details>
     `);
@@ -29,12 +29,12 @@ describe('gcds-details', () => {
     expect(page.root).toEqualHtml(`
       <gcds-details details-title="Learn more about this topic" open>
         <mock:shadow-root>
-          <details class="gcds-details" open>
-            <summary><p>Learn more about this topic</p></summary>
-            <div class="details__panel">
-              <slot></slot>
-            </div>
-          </details>
+          <button class="details__summary" aria-expanded="true">
+            Learn more about this topic
+          </button>
+          <div class="details__panel">
+            <slot></slot>
+          </div>
         </mock:shadow-root>
       </gcds-details>
     `);

--- a/packages/web/src/components/gcds-details/test/gcds-details.spec.tsx
+++ b/packages/web/src/components/gcds-details/test/gcds-details.spec.tsx
@@ -10,10 +10,10 @@ describe('gcds-details', () => {
     expect(page.root).toEqualHtml(`
       <gcds-details details-title="Learn more about this topic">
         <mock:shadow-root>
-          <button class="details__summary" aria-expanded="false">
+          <button id="details__summary" class="details__summary" aria-expanded="false" aria-controls="details__panel">
             Learn more about this topic
           </button>
-          <div class="details__panel">
+          <div id="details__panel" class="details__panel" aria-labelledby="details__summary">
             <slot></slot>
           </div>
         </mock:shadow-root>
@@ -29,10 +29,10 @@ describe('gcds-details', () => {
     expect(page.root).toEqualHtml(`
       <gcds-details details-title="Learn more about this topic" open>
         <mock:shadow-root>
-          <button class="details__summary" aria-expanded="true">
+        <button id="details__summary" class="details__summary" aria-expanded="true" aria-controls="details__panel">
             Learn more about this topic
           </button>
-          <div class="details__panel">
+          <div id="details__panel" class="details__panel" aria-labelledby="details__summary">
             <slot></slot>
           </div>
         </mock:shadow-root>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -217,6 +217,7 @@
       <gcds-details details-title="Find out more">
         <p>Details about stuff.</p>
       </gcds-details>
+      
       <!-- ------------- Stepper + Form Elements ------------- -->
 
       <h3 class="mt-700 mb-400 bb-sm">Form elements (including stepper and error summary)</h3>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -217,6 +217,9 @@
       <gcds-details details-title="Find out more">
         <p>Details about stuff.</p>
       </gcds-details>
+      <gcds-details details-title="Find out more">
+        <p>Details about stuff.</p>
+      </gcds-details>
 
       <!-- ------------- Stepper + Form Elements ------------- -->
 

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -217,10 +217,6 @@
       <gcds-details details-title="Find out more">
         <p>Details about stuff.</p>
       </gcds-details>
-      <gcds-details details-title="Find out more">
-        <p>Details about stuff.</p>
-      </gcds-details>
-
       <!-- ------------- Stepper + Form Elements ------------- -->
 
       <h3 class="mt-700 mb-400 bb-sm">Form elements (including stepper and error summary)</h3>


### PR DESCRIPTION
# Summary | Résumé

Reformat elements in `gcds-details` to no longer use `details` element since the iOS version of Voiceover doesn't seem to recognize the element.

Uses tokens from https://github.com/cds-snc/gcds-tokens/pull/150
