### PR TITLE
Update typescript to v 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "ng-packagr": "^16.0.0",
         "nx": "^16.0.0",
         "sass": "^1.43.5",
-        "typescript": "~4.9.0",
+        "typescript": "~5.1.0",
         "workbox-build": "^7.0.0"
       }
     },
@@ -17582,16 +17582,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ng-packagr": "^16.0.0",
     "nx": "^16.0.0",
     "sass": "^1.43.5",
-    "typescript": "~4.9.0",
+    "typescript": "~5.1.0",
     "workbox-build": "^7.0.0"
   },
   "license": "MIT"

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -16,7 +16,7 @@
         "@types/react-dom": "^18.0.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "typescript": "^4.9.5"
+        "typescript": "~5.1.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1635,16 +1635,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
     "@types/react-dom": "^18.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^4.9.5"
+    "typescript": "~5.1.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
# Summary | Résumé

Update typescript to v 5.1.0, fixes [Renovate PR #262 ](https://github.com/cds-snc/gcds-components/pull/262)