### PR TITLE
Gcds-header: Remove label from nav landmark to avoid confusion

### DIFF
--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -64,7 +64,7 @@ export class GcdsHeader {
       return <slot name="skip-to-nav"></slot>;
     } else if (this.skipToHref) {
       return (
-        <nav aria-label={i18n[this.lang].skip} class="gcds-header__skip-to-nav">
+        <nav class="gcds-header__skip-to-nav">
           <gcds-button
             type="link"
             button-role="skip-to-content"

--- a/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
+++ b/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
@@ -31,7 +31,7 @@ describe('gcds-header', () => {
     expect(page.root).toEqualHtml(`
       <gcds-header lang-href="/fr/" role="banner" signature-has-link="true" signature-variant="colour" skip-to-href="#main">
         <mock:shadow-root>
-          <nav aria-label="Skip to main content" class="gcds-header__skip-to-nav">
+          <nav class="gcds-header__skip-to-nav">
             <gcds-button button-role="skip-to-content" type="link" href="#main">
               Skip to main content
             </gcds-button>


### PR DESCRIPTION
# Summary | Résumé

Remove the "skip to main content" label from the navigation landmark to avoid confusion when navigating the header using a screen reader.
