### PR TITLE
update-topic-menu-guidance-link

### DIFF
--- a/packages/web/src/components/gcds-topic-menu/stories/overview.mdx
+++ b/packages/web/src/components/gcds-topic-menu/stories/overview.mdx
@@ -42,7 +42,7 @@ Navigate to the top tasks from all Government of Canada websites.
 
 <ul>
   <li>
-    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/theme-topic-menu/" target="_blank">Guidance</gcds-button>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/theme-and-topic-menu/" target="_blank">Guidance</gcds-button>
   </li>
   <li>
     <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-topic-men" target="_blank">Github</gcds-button>


### PR DESCRIPTION
# Summary | Résumé

Updating the guidance link for the topic menu on the Storybook overview page as the current link is broken.