### PR TITLE
feat: report deployment status to Sentinel

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -76,6 +76,16 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
         working-directory: ${{ matrix.package }}
 
+      - name: Report deployment to Sentinel
+        if: steps.publish.outputs.id != ''
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+          input_data: '{"product": "design-system", "sha": "${{ github.sha }}", "version": "${{steps.publish.outputs.id}}", "repository": "${{ github.repository }}", "environment": "production", "status": "${{ job.status }}"}'
+          log_type: CDS_Product_Deployment_Data
+          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+
       - name: Slack notify on failure
         if: failure()
         run: |
@@ -156,6 +166,15 @@ jobs:
 
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
         working-directory: ${{ matrix.package }}
+
+      - name: Report deployment to Sentinel
+        if: steps.publish.outputs.id != ''
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+          input_data: '{"product": "design-system", "sha": "${{ github.sha }}", "version": "${{steps.publish.outputs.id}}", "repository": "${{ github.repository }}", "environment": "production", "status": "${{ job.status }}"}'
+          log_type: CDS_Product_Deployment_Data
+          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
       - name: Slack notify on failure
         if: failure()


### PR DESCRIPTION
# Summary | Résumé

Sends a log to sentinel when a deployment happens off of the main branch. 

This sends logs when the following actions run: 

- publish-web
- publish-reach-angular

This is related to: https://github.com/cds-snc/platform-core-services/issues/350
