### PR TITLE
add gcds-text component

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -883,6 +883,28 @@ export declare interface GcdsStepper extends Components.GcdsStepper {}
 
 
 @ProxyCmp({
+  inputs: ['characterLimit', 'display', 'marginBottom', 'marginTop', 'size', 'textRole', 'textStyle', 'weight']
+})
+@Component({
+  selector: 'gcds-text',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['characterLimit', 'display', 'marginBottom', 'marginTop', 'size', 'textRole', 'textStyle', 'weight'],
+})
+export class GcdsText {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface GcdsText extends Components.GcdsText {}
+
+
+@ProxyCmp({
   inputs: ['blurHandler', 'changeHandler', 'characterCount', 'cols', 'disabled', 'errorMessage', 'focusHandler', 'hideLabel', 'hint', 'label', 'required', 'rows', 'textareaId', 'validateOn', 'validator', 'value'],
   methods: ['validate']
 })

--- a/packages/angular/src/lib/stencil-generated/index.ts
+++ b/packages/angular/src/lib/stencil-generated/index.ts
@@ -33,6 +33,7 @@ export const DIRECTIVES = [
   d.GcdsSideNav,
   d.GcdsSignature,
   d.GcdsStepper,
+  d.GcdsText,
   d.GcdsTextarea,
   d.GcdsTopNav,
   d.GcdsTopicMenu,

--- a/packages/react/src/components/stencil-generated/index.ts
+++ b/packages/react/src/components/stencil-generated/index.ts
@@ -39,6 +39,7 @@ export const GcdsSelect = /*@__PURE__*/createReactComponent<JSX.GcdsSelect, HTML
 export const GcdsSideNav = /*@__PURE__*/createReactComponent<JSX.GcdsSideNav, HTMLGcdsSideNavElement>('gcds-side-nav');
 export const GcdsSignature = /*@__PURE__*/createReactComponent<JSX.GcdsSignature, HTMLGcdsSignatureElement>('gcds-signature');
 export const GcdsStepper = /*@__PURE__*/createReactComponent<JSX.GcdsStepper, HTMLGcdsStepperElement>('gcds-stepper');
+export const GcdsText = /*@__PURE__*/createReactComponent<JSX.GcdsText, HTMLGcdsTextElement>('gcds-text');
 export const GcdsTextarea = /*@__PURE__*/createReactComponent<JSX.GcdsTextarea, HTMLGcdsTextareaElement>('gcds-textarea');
 export const GcdsTopNav = /*@__PURE__*/createReactComponent<JSX.GcdsTopNav, HTMLGcdsTopNavElement>('gcds-top-nav');
 export const GcdsTopicMenu = /*@__PURE__*/createReactComponent<JSX.GcdsTopicMenu, HTMLGcdsTopicMenuElement>('gcds-topic-menu');

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -2,13 +2,18 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
   href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
-  rel="stylesheet" />
+  rel="stylesheet"
+/>
 <link
   href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap"
-  rel="stylesheet" />
+  rel="stylesheet"
+/>
 
 <!-- Font Awesome (Icons) -->
-<link href="https://unpkg.com/font-awesome/css/font-awesome.min.css" rel="stylesheet">
+<link
+  href="https://unpkg.com/font-awesome/css/font-awesome.min.css"
+  rel="stylesheet"
+/>
 
 <style>
   body {
@@ -33,7 +38,7 @@
   /* ----- PROPERTIES PAGE ----- */
 
   /* Component Preview - hide React code */
-  .sb-show-main #storybook-docs .sb-story>div>*:not(.hydrated) {
+  .sb-show-main #storybook-docs .sb-story > div > *:not(.hydrated) {
     font-size: 0;
     color: var(--gcds-text-light);
     padding: 0 !important;
@@ -41,7 +46,7 @@
   }
 
   /* Copy & hide code btns */
-  .docs-story>.css-1wjen9k {
+  .docs-story > .css-1wjen9k {
     padding-block-end: var(--gcds-spacing-700);
   }
 
@@ -65,8 +70,9 @@
     border-radius: var(--gcds-button-border-radius) !important;
     box-sizing: border-box;
     font: var(--gcds-button-font) !important;
-    font-size: .875rem !important;
-    margin: 0 var(--gcds-spacing-150) var(--gcds-spacing-250) var(--gcds-spacing-300) !important;
+    font-size: 0.875rem !important;
+    margin: 0 var(--gcds-spacing-150) var(--gcds-spacing-250)
+      var(--gcds-spacing-300) !important;
     padding: var(--gcds-spacing-200) var(--gcds-spacing-150) !important;
     transition: all 0.15s ease-in-out 0s;
   }
@@ -87,7 +93,7 @@
   }
 
   .css-3s4ai0 .css-otxova:hover:not(:focus) {
-    background-color: rgba(255, 255, 255, .2) !important;
+    background-color: rgba(255, 255, 255, 0.2) !important;
   }
 
   .docs-story .docblock-code-toggle:focus,
@@ -95,7 +101,8 @@
     background-color: var(--gcds-focus-background) !important;
     border-color: var(--gcds-focus-background) !important;
     color: var(--gcds-focus-text) !important;
-    outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-focus-background) !important;
+    outline: var(--gcds-button-shared-focus-outline-width) solid
+      var(--gcds-focus-background) !important;
     outline-offset: var(--gcds-button-border-width) !important;
     box-shadow: none !important;
   }
@@ -130,7 +137,7 @@
   /* Table Styling */
   .docblock-argstable-head tr th,
   .docblock-argstable-body tr td.css-11nj37o,
-  .docblock-argstable-body tr .css-11nj37o~td {
+  .docblock-argstable-body tr .css-11nj37o ~ td {
     background-color: var(--gcds-color-grayscale-0) !important;
     border-radius: 0 !important;
     color: var(--gcds-text-primary) !important;
@@ -194,7 +201,8 @@
     vertical-align: middle !important;
     background-color: #262626 !important;
     color: var(--gcds-text-light);
-    border-bottom: var(--gcds-border-width-sm) solid var(--gcds-color-grayscale-700) !important;
+    border-bottom: var(--gcds-border-width-sm) solid
+      var(--gcds-color-grayscale-700) !important;
   }
 
   .docblock-argstable-body td span.css-a2cl28 {
@@ -211,7 +219,7 @@
 
   .css-je0wjx {
     font-weight: var(--gcds-font-weights-semibold) !important;
-    letter-spacing: .75px;
+    letter-spacing: 0.75px;
     background-color: transparent !important;
     color: var(--gcds-text-light) !important;
     border: 0 !important;
@@ -238,14 +246,14 @@
     fill: var(--gcds-text-light) !important;
   }
 
-  .css-tvcum3 input:checked~span:last-of-type,
-  .css-tvcum3 input:not(:checked)~span:first-of-type,
-  .css-f2g3hl input:checked~span:last-of-type,
-  .css-f2g3hl input:not(:checked)~span:first-of-type,
-  .css-172ajqq input:checked~span:last-of-type,
-  .css-172ajqq input:not(:checked)~span:first-of-type,
-  .css-e3ijes input:checked~span:last-of-type,
-  .css-e3ijes input:not(:checked)~span:first-of-type {
+  .css-tvcum3 input:checked ~ span:last-of-type,
+  .css-tvcum3 input:not(:checked) ~ span:first-of-type,
+  .css-f2g3hl input:checked ~ span:last-of-type,
+  .css-f2g3hl input:not(:checked) ~ span:first-of-type,
+  .css-172ajqq input:checked ~ span:last-of-type,
+  .css-172ajqq input:not(:checked) ~ span:first-of-type,
+  .css-e3ijes input:checked ~ span:last-of-type,
+  .css-e3ijes input:not(:checked) ~ span:first-of-type {
     background: var(--gcds-color-grayscale-0) !important;
     color: var(--gcds-text-primary) !important;
   }
@@ -259,11 +267,17 @@
     background-color: var(--gcds-color-grayscale-50);
   }
 
+  /* Code preview white space */
+  .language-html {
+    white-space: break-spaces !important;
+    border: 1px solid red;
+  }
+
   /* ----- COMPONENT SPECIFIC ----- */
 
   /* gcds-button */
-  .sbdocs-preview .docs-story gcds-button.hydrated+gcds-button.hydrated,
-  .sb-show-main #storybook-root gcds-button.hydrated+gcds-button.hydrated {
+  .sbdocs-preview .docs-story gcds-button.hydrated + gcds-button.hydrated,
+  .sb-show-main #storybook-root gcds-button.hydrated + gcds-button.hydrated {
     margin: 0 0 0 var(--gcds-spacing-400);
   }
 
@@ -298,6 +312,12 @@
   /* gcds-signature */
   .sbdocs-preview .docs-story #story--components-signature--signature-white,
   .sbdocs-preview .docs-story #story--components-signature--wordmark-white {
+    background: var(--gcds-color-grayscale-900);
+    padding: var(--gcds-spacing-450);
+  }
+
+  /* gcds-text */
+  .sbdocs-preview .docs-story #story--components-text--light {
     background: var(--gcds-color-grayscale-900);
     padding: var(--gcds-spacing-450);
   }

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -270,7 +270,6 @@
   /* Code preview white space */
   .language-html {
     white-space: break-spaces !important;
-    border: 1px solid red;
   }
 
   /* ----- COMPONENT SPECIFIC ----- */

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -20,7 +20,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.6.1",
+        "@cdssnc/gcds-tokens": "^1.9.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "^0.8.1",
         "@stencil/postcss": "^2.1.0",
@@ -2072,9 +2072,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.6.1.tgz",
-      "integrity": "sha512-bmesAeFKYdYOxSksSejwtBq3FywrMY2KIljxCIty4gjfByQN6uHLBug2Tg3Ni6MIJkBnoUlrCcV9mXNyE6A/bA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.9.0.tgz",
+      "integrity": "sha512-zsWsqralW8uCaTPiFxyFKGqKOHEgLWirmExoK+fY99kzKDzvhw4QBIhy/h/+LhIG8EgClKZb12RPjfp6Tcl9Kg==",
       "dev": true
     },
     "node_modules/@colors/colors": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.6.1",
+    "@cdssnc/gcds-tokens": "^1.9.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "^0.8.1",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -974,6 +974,75 @@ export namespace Components {
          */
         "totalSteps": number;
     }
+    interface GcdsText {
+        /**
+          * Sets the line length to a maximum amount of characters per line to ensure a comfortable, accessible reading length.
+         */
+        "characterLimit"?: boolean;
+        /**
+          * Specifies the display behaviour of the text.
+         */
+        "display"?: | 'block'
+    | 'flex'
+    | 'inline'
+    | 'inline-block'
+    | 'inline-flex'
+    | 'none';
+        /**
+          * Adds margin below the text.
+         */
+        "marginBottom"?: | '0'
+    | '50'
+    | '100'
+    | '150'
+    | '200'
+    | '250'
+    | '300'
+    | '400'
+    | '450'
+    | '500'
+    | '550'
+    | '600'
+    | '700'
+    | '800'
+    | '900'
+    | '1000';
+        /**
+          * Adds margin above the text.
+         */
+        "marginTop"?: | '0'
+    | '50'
+    | '100'
+    | '150'
+    | '200'
+    | '250'
+    | '300'
+    | '400'
+    | '450'
+    | '500'
+    | '550'
+    | '600'
+    | '700'
+    | '800'
+    | '900'
+    | '1000';
+        /**
+          * Sets the appropriate HTML tags for the selected size.
+         */
+        "size"?: 'body' | 'caption';
+        /**
+          * Sets the main style of the text.
+         */
+        "textRole"?: 'light' | 'primary' | 'secondary';
+        /**
+          * Indicates if the text should be styled italic or normal.
+         */
+        "textStyle"?: 'italic' | 'normal';
+        /**
+          * Determines the font weight for the text.
+         */
+        "weight"?: 'bold' | 'regular';
+    }
     interface GcdsTextarea {
         /**
           * Custom callback function on blur event
@@ -1329,6 +1398,12 @@ declare global {
         prototype: HTMLGcdsStepperElement;
         new (): HTMLGcdsStepperElement;
     };
+    interface HTMLGcdsTextElement extends Components.GcdsText, HTMLStencilElement {
+    }
+    var HTMLGcdsTextElement: {
+        prototype: HTMLGcdsTextElement;
+        new (): HTMLGcdsTextElement;
+    };
     interface HTMLGcdsTextareaElement extends Components.GcdsTextarea, HTMLStencilElement {
     }
     var HTMLGcdsTextareaElement: {
@@ -1385,6 +1460,7 @@ declare global {
         "gcds-side-nav": HTMLGcdsSideNavElement;
         "gcds-signature": HTMLGcdsSignatureElement;
         "gcds-stepper": HTMLGcdsStepperElement;
+        "gcds-text": HTMLGcdsTextElement;
         "gcds-textarea": HTMLGcdsTextareaElement;
         "gcds-top-nav": HTMLGcdsTopNavElement;
         "gcds-topic-menu": HTMLGcdsTopicMenuElement;
@@ -2479,6 +2555,75 @@ declare namespace LocalJSX {
          */
         "totalSteps": number;
     }
+    interface GcdsText {
+        /**
+          * Sets the line length to a maximum amount of characters per line to ensure a comfortable, accessible reading length.
+         */
+        "characterLimit"?: boolean;
+        /**
+          * Specifies the display behaviour of the text.
+         */
+        "display"?: | 'block'
+    | 'flex'
+    | 'inline'
+    | 'inline-block'
+    | 'inline-flex'
+    | 'none';
+        /**
+          * Adds margin below the text.
+         */
+        "marginBottom"?: | '0'
+    | '50'
+    | '100'
+    | '150'
+    | '200'
+    | '250'
+    | '300'
+    | '400'
+    | '450'
+    | '500'
+    | '550'
+    | '600'
+    | '700'
+    | '800'
+    | '900'
+    | '1000';
+        /**
+          * Adds margin above the text.
+         */
+        "marginTop"?: | '0'
+    | '50'
+    | '100'
+    | '150'
+    | '200'
+    | '250'
+    | '300'
+    | '400'
+    | '450'
+    | '500'
+    | '550'
+    | '600'
+    | '700'
+    | '800'
+    | '900'
+    | '1000';
+        /**
+          * Sets the appropriate HTML tags for the selected size.
+         */
+        "size"?: 'body' | 'caption';
+        /**
+          * Sets the main style of the text.
+         */
+        "textRole"?: 'light' | 'primary' | 'secondary';
+        /**
+          * Indicates if the text should be styled italic or normal.
+         */
+        "textStyle"?: 'italic' | 'normal';
+        /**
+          * Determines the font weight for the text.
+         */
+        "weight"?: 'bold' | 'regular';
+    }
     interface GcdsTextarea {
         /**
           * Custom callback function on blur event
@@ -2625,6 +2770,7 @@ declare namespace LocalJSX {
         "gcds-side-nav": GcdsSideNav;
         "gcds-signature": GcdsSignature;
         "gcds-stepper": GcdsStepper;
+        "gcds-text": GcdsText;
         "gcds-textarea": GcdsTextarea;
         "gcds-top-nav": GcdsTopNav;
         "gcds-topic-menu": GcdsTopicMenu;
@@ -2666,6 +2812,7 @@ declare module "@stencil/core" {
             "gcds-side-nav": LocalJSX.GcdsSideNav & JSXBase.HTMLAttributes<HTMLGcdsSideNavElement>;
             "gcds-signature": LocalJSX.GcdsSignature & JSXBase.HTMLAttributes<HTMLGcdsSignatureElement>;
             "gcds-stepper": LocalJSX.GcdsStepper & JSXBase.HTMLAttributes<HTMLGcdsStepperElement>;
+            "gcds-text": LocalJSX.GcdsText & JSXBase.HTMLAttributes<HTMLGcdsTextElement>;
             "gcds-textarea": LocalJSX.GcdsTextarea & JSXBase.HTMLAttributes<HTMLGcdsTextareaElement>;
             "gcds-top-nav": LocalJSX.GcdsTopNav & JSXBase.HTMLAttributes<HTMLGcdsTopNavElement>;
             "gcds-topic-menu": LocalJSX.GcdsTopicMenu & JSXBase.HTMLAttributes<HTMLGcdsTopicMenuElement>;

--- a/packages/web/src/components/gcds-text/gcds-text.css
+++ b/packages/web/src/components/gcds-text/gcds-text.css
@@ -14,6 +14,7 @@ variants.weight;
     color: var(--gcds-text-role-primary);
 
     .gcds-text {
+      display: inherit;
       box-sizing: border-box;
       margin: 0;
     }
@@ -31,7 +32,7 @@ variants.weight;
 }
 
 @layer variants.display {
-  :host .gcds-text {
+  :host {
     &.d-block {
       display: block;
     }

--- a/packages/web/src/components/gcds-text/gcds-text.css
+++ b/packages/web/src/components/gcds-text/gcds-text.css
@@ -1,0 +1,248 @@
+@layer reset,
+defaults,
+variants.display,
+variants.limit,
+variants.margin,
+variants.role,
+variants.size,
+variants.style,
+variants.weight;
+
+@layer reset {
+  :host {
+    display: block;
+    color: var(--gcds-text-role-primary);
+
+    .gcds-text {
+      box-sizing: border-box;
+      margin: 0;
+    }
+  }
+}
+
+@layer defaults {
+  :host .gcds-text {
+    font: var(--gcds-text-size-body-desktop);
+
+    @media only screen and (width < 48em) {
+      font: var(--gcds-text-size-body-mobile);
+    }
+  }
+}
+
+@layer variants.display {
+  :host .gcds-text {
+    &.d-block {
+      display: block;
+    }
+
+    &.d-flex {
+      display: flex;
+    }
+
+    &.d-inline {
+      display: inline;
+    }
+
+    &.d-inline-block {
+      display: inline-block;
+    }
+
+    &.d-inline-flex {
+      display: inline-flex;
+    }
+
+    &.d-none {
+      display: none;
+    }
+  }
+}
+
+@layer variants.limit {
+  :host .gcds-text {
+    &.limit {
+      max-width: var(--gcds-text-character-limit);
+    }
+  }
+}
+
+@layer variants.margin {
+  :host .gcds-text {
+    /* Margin top */
+    &.mt-0 {
+      margin-block-start: var(--gcds-text-spacing-0);
+    }
+
+    &.mt-50 {
+      margin-block-start: var(--gcds-text-spacing-50);
+    }
+
+    &.mt-100 {
+      margin-block-start: var(--gcds-text-spacing-100);
+    }
+
+    &.mt-150 {
+      margin-block-start: var(--gcds-text-spacing-150);
+    }
+
+    &.mt-200 {
+      margin-block-start: var(--gcds-text-spacing-200);
+    }
+
+    &.mt-250 {
+      margin-block-start: var(--gcds-text-spacing-250);
+    }
+
+    &.mt-300 {
+      margin-block-start: var(--gcds-text-spacing-300);
+    }
+
+    &.mt-400 {
+      margin-block-start: var(--gcds-text-spacing-400);
+    }
+
+    &.mt-450 {
+      margin-block-start: var(--gcds-text-spacing-450);
+    }
+
+    &.mt-500 {
+      margin-block-start: var(--gcds-text-spacing-500);
+    }
+
+    &.mt-550 {
+      margin-block-start: var(--gcds-text-spacing-550);
+    }
+
+    &.mt-600 {
+      margin-block-start: var(--gcds-text-spacing-600);
+    }
+
+    &.mt-700 {
+      margin-block-start: var(--gcds-text-spacing-700);
+    }
+
+    &.mt-800 {
+      margin-block-start: var(--gcds-text-spacing-800);
+    }
+
+    &.mt-900 {
+      margin-block-start: var(--gcds-text-spacing-900);
+    }
+
+    &.mt-1000 {
+      margin-block-start: var(--gcds-text-spacing-1000);
+    }
+
+    /* Margin bottom */
+    &.mb-0 {
+      margin-block-end: var(--gcds-text-spacing-0);
+    }
+
+    &.mb-50 {
+      margin-block-end: var(--gcds-text-spacing-50);
+    }
+
+    &.mb-100 {
+      margin-block-end: var(--gcds-text-spacing-100);
+    }
+
+    &.mb-150 {
+      margin-block-end: var(--gcds-text-spacing-150);
+    }
+
+    &.mb-200 {
+      margin-block-end: var(--gcds-text-spacing-200);
+    }
+
+    &.mb-250 {
+      margin-block-end: var(--gcds-text-spacing-250);
+    }
+
+    &.mb-300 {
+      margin-block-end: var(--gcds-text-spacing-300);
+    }
+
+    &.mb-400 {
+      margin-block-end: var(--gcds-text-spacing-400);
+    }
+
+    &.mb-450 {
+      margin-block-end: var(--gcds-text-spacing-450);
+    }
+
+    &.mb-500 {
+      margin-block-end: var(--gcds-text-spacing-500);
+    }
+
+    &.mb-550 {
+      margin-block-end: var(--gcds-text-spacing-550);
+    }
+
+    &.mb-600 {
+      margin-block-end: var(--gcds-text-spacing-600);
+    }
+
+    &.mb-700 {
+      margin-block-end: var(--gcds-text-spacing-700);
+    }
+
+    &.mb-800 {
+      margin-block-end: var(--gcds-text-spacing-800);
+    }
+
+    &.mb-900 {
+      margin-block-end: var(--gcds-text-spacing-900);
+    }
+
+    &.mb-1000 {
+      margin-block-end: var(--gcds-text-spacing-1000);
+    }
+  }
+}
+
+@layer variants.role {
+  :host .gcds-text {
+    &.role-primary {
+      color: var(--gcds-text-role-primary);
+    }
+
+    &.role-secondary {
+      color: var(--gcds-text-role-secondary);
+    }
+
+    &.role-light {
+      color: var(--gcds-text-role-light);
+    }
+  }
+}
+
+@layer variants.size {
+  :host .gcds-text {
+    small,
+    ::slotted(small) {
+      font: var(--gcds-text-size-caption-desktop);
+
+      @media only screen and (width < 48em) {
+        font: var(--gcds-text-size-caption-mobile);
+      }
+    }
+  }
+}
+
+@layer variants.style {
+  :host .gcds-text.italic,
+  :host .gcds-text ::slotted(em),
+  :host .gcds-text.italic small,
+  :host .gcds-text.italic small ::slotted(em) {
+    font-style: italic;
+  }
+}
+
+@layer variants.weight {
+  :host .gcds-text {
+    strong,
+    ::slotted(strong) {
+      font-weight: var(--gcds-text-weight-bold);
+    }
+  }
+}

--- a/packages/web/src/components/gcds-text/gcds-text.tsx
+++ b/packages/web/src/components/gcds-text/gcds-text.tsx
@@ -219,14 +219,13 @@ export class GcdsText {
     } = this;
 
     return (
-      <Host>
+      <Host class={`${display != 'block' ? `d-${display}` : ''}`}>
         <p
           class={`
             gcds-text
             ${textRole ? `role-${textRole}` : ''}
             ${textStyle === 'italic' ? 'italic' : ''}
             ${characterLimit ? 'limit' : ''}
-            ${display != 'block' ? `d-${display}` : ''}
             ${marginTop ? `mt-${marginTop}` : ''}
             ${marginBottom ? `mb-${marginBottom}` : ''}
           `}

--- a/packages/web/src/components/gcds-text/gcds-text.tsx
+++ b/packages/web/src/components/gcds-text/gcds-text.tsx
@@ -1,0 +1,255 @@
+import { Component, Element, Host, Watch, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'gcds-text',
+  styleUrl: 'gcds-text.css',
+  shadow: true,
+})
+export class GcdsText {
+  @Element() el: HTMLElement;
+
+  /**
+   * Props
+   */
+
+  /**
+   * Sets the main style of the text.
+   */
+  @Prop({ mutable: true }) textRole?: 'light' | 'primary' | 'secondary' =
+    'primary';
+
+  @Watch('textRole')
+  validateTextRole(newValue: string) {
+    const values = ['light', 'primary', 'secondary'];
+
+    if (!values.includes(newValue)) {
+      this.textRole = 'primary';
+    }
+  }
+
+  /**
+   * Sets the line length to a maximum amount of characters per line to ensure a comfortable, accessible reading length.
+   */
+  @Prop() characterLimit?: boolean = true;
+
+  /**
+   * Specifies the display behaviour of the text.
+   */
+  @Prop({ mutable: true }) display?:
+    | 'block'
+    | 'flex'
+    | 'inline'
+    | 'inline-block'
+    | 'inline-flex'
+    | 'none' = 'block';
+
+  @Watch('display')
+  validateDisplay(newValue: string) {
+    const values = [
+      'block',
+      'flex',
+      'inline',
+      'inline-block',
+      'inline-flex',
+      'none',
+    ];
+
+    if (!values.includes(newValue)) {
+      this.display = 'block';
+    }
+  }
+
+  /**
+   * Adds margin above the text.
+   */
+  @Prop({ mutable: true }) marginTop?:
+    | '0'
+    | '50'
+    | '100'
+    | '150'
+    | '200'
+    | '250'
+    | '300'
+    | '400'
+    | '450'
+    | '500'
+    | '550'
+    | '600'
+    | '700'
+    | '800'
+    | '900'
+    | '1000';
+
+  @Watch('marginTop')
+  validateMarginTop(newValue: string) {
+    const values = [
+      '0',
+      '50',
+      '100',
+      '150',
+      '200',
+      '250',
+      '300',
+      '400',
+      '450',
+      '500',
+      '550',
+      '600',
+      '700',
+      '800',
+      '900',
+      '1000',
+    ];
+
+    if (this.marginTop && !values.includes(newValue)) {
+      console.error('Not a valid margin.');
+    }
+  }
+
+  /**
+   * Adds margin below the text.
+   */
+  @Prop({ mutable: true }) marginBottom?:
+    | '0'
+    | '50'
+    | '100'
+    | '150'
+    | '200'
+    | '250'
+    | '300'
+    | '400'
+    | '450'
+    | '500'
+    | '550'
+    | '600'
+    | '700'
+    | '800'
+    | '900'
+    | '1000';
+
+  @Watch('marginBottom')
+  validateMarginBottom(newValue: string) {
+    const values = [
+      '0',
+      '50',
+      '100',
+      '150',
+      '200',
+      '250',
+      '300',
+      '400',
+      '450',
+      '500',
+      '550',
+      '600',
+      '700',
+      '800',
+      '900',
+      '1000',
+    ];
+
+    if (this.marginBottom && !values.includes(newValue)) {
+      console.error('Not a valid margin.');
+    }
+  }
+
+  /**
+   * Sets the appropriate HTML tags for the selected size.
+   */
+  @Prop({ mutable: true }) size?: 'body' | 'caption' = 'body';
+
+  @Watch('size')
+  validateSize(newValue: string) {
+    const values = ['body', 'caption'];
+
+    if (!values.includes(newValue)) {
+      this.size = 'body';
+    }
+  }
+
+  /**
+   * Indicates if the text should be styled italic or normal.
+   */
+  @Prop({ mutable: true }) textStyle?: 'italic' | 'normal' = 'normal';
+
+  @Watch('textStyle')
+  validateTextStyle(newValue: string) {
+    const values = ['italic', 'normal'];
+
+    if (!values.includes(newValue)) {
+      this.textStyle = 'normal';
+    }
+  }
+
+  /**
+   * Determines the font weight for the text.
+   */
+  @Prop({ mutable: true }) weight?: 'bold' | 'regular' = 'regular';
+
+  @Watch('weight')
+  validateWeight(newValue: string) {
+    const values = ['bold', 'regular'];
+
+    if (!values.includes(newValue)) {
+      this.weight = 'regular';
+    }
+  }
+
+  componentWillLoad() {
+    // Validate attributes and set defaults
+    this.validateTextRole(this.textRole);
+    this.validateDisplay(this.display);
+    this.validateMarginTop(this.marginTop);
+    this.validateMarginBottom(this.marginBottom);
+    this.validateSize(this.size);
+    this.validateTextStyle(this.textStyle);
+    this.validateWeight(this.weight);
+  }
+
+  render() {
+    const {
+      characterLimit,
+      display,
+      marginTop,
+      marginBottom,
+      size,
+      textRole,
+      textStyle,
+      weight,
+    } = this;
+
+    return (
+      <Host>
+        <p
+          class={`
+            gcds-text
+            ${textRole ? `role-${textRole}` : ''}
+            ${textStyle === 'italic' ? 'italic' : ''}
+            ${characterLimit ? 'limit' : ''}
+            ${display != 'block' ? `d-${display}` : ''}
+            ${marginTop ? `mt-${marginTop}` : ''}
+            ${marginBottom ? `mb-${marginBottom}` : ''}
+          `}
+        >
+          {size === 'caption' ? (
+            <small>
+              {weight === 'bold' ? (
+                <strong>
+                  <slot />
+                </strong>
+              ) : (
+                <slot />
+              )}
+            </small>
+          ) : weight === 'bold' ? (
+            <strong>
+              <slot />
+            </strong>
+          ) : (
+            <slot />
+          )}
+        </p>
+      </Host>
+    );
+  }
+}

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -1,0 +1,24 @@
+# gcds-text
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property         | Attribute         | Description                                                                                                         | Type                                                                                                                                         | Default     |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `characterLimit` | `character-limit` | Sets the line length to a maximum amount of characters per line to ensure a comfortable, accessible reading length. | `boolean`                                                                                                                                    | `true`      |
+| `display`        | `display`         | Specifies the display behaviour of the text.                                                                        | `"block" \| "flex" \| "inline" \| "inline-block" \| "inline-flex" \| "none"`                                                                 | `'block'`   |
+| `marginBottom`   | `margin-bottom`   | Adds margin below the text.                                                                                         | `"0" \| "100" \| "1000" \| "150" \| "200" \| "250" \| "300" \| "400" \| "450" \| "50" \| "500" \| "550" \| "600" \| "700" \| "800" \| "900"` | `undefined` |
+| `marginTop`      | `margin-top`      | Adds margin above the text.                                                                                         | `"0" \| "100" \| "1000" \| "150" \| "200" \| "250" \| "300" \| "400" \| "450" \| "50" \| "500" \| "550" \| "600" \| "700" \| "800" \| "900"` | `undefined` |
+| `size`           | `size`            | Sets the appropriate HTML tags for the selected size.                                                               | `"body" \| "caption"`                                                                                                                        | `'body'`    |
+| `textRole`       | `text-role`       | Sets the main style of the text.                                                                                    | `"light" \| "primary" \| "secondary"`                                                                                                        | `'primary'` |
+| `textStyle`      | `text-style`      | Indicates if the text should be styled italic or normal.                                                            | `"italic" \| "normal"`                                                                                                                       | `'normal'`  |
+| `weight`         | `weight`          | Determines the font weight for the text.                                                                            | `"bold" \| "regular"`                                                                                                                        | `'regular'` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
+++ b/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
@@ -1,0 +1,354 @@
+export default {
+  title: 'Components/Text',
+
+  argTypes: {
+    // Props
+    characterLimit: {
+      name: 'character-limit',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: true },
+      },
+    },
+    display: {
+      control: { type: 'select' },
+      options: [
+        'block',
+        'flex',
+        'inline',
+        'inline-block',
+        'inline-flex',
+        'none',
+      ],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'block' },
+      },
+    },
+    marginTop: {
+      name: 'margin-top',
+      control: { type: 'select' },
+      options: [
+        '0',
+        '50',
+        '100',
+        '150',
+        '200',
+        '250',
+        '300',
+        '400',
+        '450',
+        '500',
+        '550',
+        '600',
+        '700',
+        '800',
+        '900',
+        '1000',
+      ],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    marginBottom: {
+      name: 'margin-bottom',
+      control: { type: 'select' },
+      options: [
+        '0',
+        '50',
+        '100',
+        '150',
+        '200',
+        '250',
+        '300',
+        '400',
+        '450',
+        '500',
+        '550',
+        '600',
+        '700',
+        '800',
+        '900',
+        '1000',
+      ],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['body', 'caption'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'body' },
+      },
+    },
+    textRole: {
+      name: 'text-role',
+      control: { type: 'select' },
+      options: ['light', 'primary', 'secondary'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'primary' },
+      },
+    },
+    textStyle: {
+      name: 'text-style',
+      control: { type: 'select' },
+      options: ['italic', 'normal'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'normal' },
+      },
+    },
+    weight: {
+      control: { type: 'select' },
+      options: ['bold', 'regular'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'regular' },
+      },
+    },
+
+    // Slots
+    default: {
+      control: {
+        type: 'text',
+      },
+      table: {
+        category: 'Slots | Fentes',
+      },
+    },
+  },
+};
+
+const Template = args =>
+  `
+<!-- Web component code (Angular, Vue) -->
+<gcds-text ${
+    args.textRole != 'primary' ? `text-role="${args.textRole}"` : null
+  } ${args.size != 'body' ? `size="${args.size}"` : null} ${
+    !args.characterLimit ? `character-limit="${args.characterLimit}"` : null
+  } ${args.display != 'block' ? `display="${args.display}"` : null} ${
+    args.marginTop ? `margin-top="${args.marginTop}"` : null
+  } ${args.marginBottom ? `margin-bottom="${args.marginBottom}"` : null} ${
+    args.textStyle != 'normal' ? `text-style="${args.textStyle}"` : null
+  } ${args.weight != 'regular' ? `weight="${args.weight}"` : null}>
+  ${args.default}
+</gcds-text>
+
+<!-- React code -->
+<GcdsText ${
+    args.textRole != 'primary' ? `textRole="${args.textRole}"` : null
+  } ${args.size != 'body' ? `size="${args.size}"` : null} ${
+    !args.characterLimit ? `characterLimit="${args.characterLimit}"` : null
+  } ${args.display != 'block' ? `display="${args.display}"` : null} ${
+    args.marginTop ? `marginTop="${args.marginTop}"` : null
+  } ${args.marginBottom ? `marginBottom="${args.marginBottom}"` : null} ${
+    args.textStyle != 'normal' ? `textStyle="${args.textStyle}"` : null
+  } ${args.weight != 'regular' ? `weight="${args.weight}"` : null}>
+  ${args.default}
+</GcdsText>
+`.replace(/ null/g, '');
+
+const TemplatePlayground = args => `
+<gcds-text
+  ${args.textRole != 'primary' ? `text-role="${args.textRole}"` : null}
+  ${args.size != 'body' ? `size="${args.size}"` : null}
+  ${!args.characterLimit ? `character-limit="${args.characterLimit}"` : null}
+  ${args.display != 'block' ? `display="${args.display}"` : null}
+  ${args.marginTop ? `margin-top="${args.marginTop}"` : null}
+  ${args.marginBottom ? `margin-bottom="${args.marginBottom}"` : null}
+  ${args.textStyle != 'normal' ? `text-style="${args.textStyle}"` : null}
+  ${args.weight != 'regular' ? `weight="${args.weight}"` : null}
+>
+  ${args.default}
+</gcds-text>
+`;
+
+// ------ Text default ------
+
+export const Default = Template.bind({});
+Default.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+// ------ Text role ------
+
+export const Primary = Template.bind({});
+Primary.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'secondary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+export const Light = Template.bind({});
+Light.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'light',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+// ------ Text size ------
+
+export const SizeBody = Template.bind({});
+SizeBody.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+export const SizeCaption = Template.bind({});
+SizeCaption.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'caption',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+// ------ Text character limit ------
+
+export const CharacterLimit = Template.bind({});
+CharacterLimit.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+export const NoCharacterLimit = Template.bind({});
+NoCharacterLimit.args = {
+  characterLimit: false,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+// ------ Text style ------
+
+export const StyleNormal = Template.bind({});
+StyleNormal.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+export const StyleItalic = Template.bind({});
+StyleItalic.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'italic',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+// ------ Text weight ------
+
+export const WeightRegular = Template.bind({});
+WeightRegular.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+export const WeightBold = Template.bind({});
+WeightBold.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'bold',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+// ------ Text events & props ------
+
+export const Props = Template.bind({});
+Props.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};
+
+// ------ Text playground ------
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
+  characterLimit: true,
+  display: 'block',
+  size: 'body',
+  textRole: 'primary',
+  textStyle: 'normal',
+  weight: 'regular',
+  default:
+    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
+};

--- a/packages/web/src/components/gcds-text/stories/overview.mdx
+++ b/packages/web/src/components/gcds-text/stories/overview.mdx
@@ -1,0 +1,82 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as Text from './gcds-text.stories';
+
+<Meta of={Text} name="Overview" />
+
+# Text<br/>`<gcds-text>`
+
+_Also called: text block, copy, caption, body text, paragraph._
+
+Text is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.
+
+<Canvas of={Text.Default} story={{ inline: true }} />
+
+## Examples
+
+<br />
+
+### Role
+
+#### Primary
+
+<Canvas of={Text.Primary} story={{ inline: true }} />
+
+#### Secondary
+
+<Canvas of={Text.Secondary} story={{ inline: true }} />
+
+#### Light
+
+<Canvas of={Text.Light} story={{ inline: true }} />
+
+### Size
+
+#### Text size body.
+
+<Canvas of={Text.SizeBody} story={{ inline: true }} />
+
+#### Text size caption.
+
+<Canvas of={Text.SizeCaption} story={{ inline: true }} />
+
+### Character limit
+
+#### Text with character limit
+
+<Canvas of={Text.CharacterLimit} story={{ inline: true }} />
+
+#### Text without character limit
+
+<Canvas of={Text.NoCharacterLimit} story={{ inline: true }} />
+
+### Text style
+
+#### Text style normal.
+
+<Canvas of={Text.StyleNormal} story={{ inline: true }} />
+
+#### Text style italic.
+
+<Canvas of={Text.StyleItalic} story={{ inline: true }} />
+
+### Text weight
+
+#### Text weight regular.
+
+<Canvas of={Text.WeightRegular} story={{ inline: true }} />
+
+#### Text weight bold.
+
+<Canvas of={Text.WeightBold} story={{ inline: true }} />
+
+## Resources
+
+{/* prettier-ignore */}
+<ul>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/text/" target="_blank">Guidance</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-text" target="_blank">Github</gcds-button>
+  </li>
+</ul>

--- a/packages/web/src/components/gcds-text/stories/properties.mdx
+++ b/packages/web/src/components/gcds-text/stories/properties.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import * as Text from './gcds-text.stories';
+
+<Meta of={Text} name="Events & properties" />
+
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
+
+<Canvas
+  of={Text.Props}
+  story={{ inline: true }}
+  sourceState="shown"
+  type="dynamic"
+/>
+
+<Controls of={Text.Props} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-text/test/gcds-text.e2e.ts
+++ b/packages/web/src/components/gcds-text/test/gcds-text.e2e.ts
@@ -1,0 +1,64 @@
+import { newE2EPage } from '@stencil/core/testing';
+const { AxePuppeteer } = require('@axe-core/puppeteer');
+
+describe('gcds-text', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<gcds-text>This is some text.</gcds-text>');
+
+    const element = await page.find('gcds-text');
+    expect(element).toHaveClass('hydrated');
+  });
+});
+
+/**
+ * Accessibility tests
+ * Axe-core rules: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-21-level-a--aa-rules
+ */
+
+describe('gcds-text a11y tests', () => {
+  /**
+   * Colour contrast test
+   */
+  it('colour contrast - primary text', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <gcds-text text-role="primary">This is some primary text.</gcds-text>
+    `);
+
+    const colorContrastTest = new AxePuppeteer(page)
+      .withRules('color-contrast')
+      .analyze();
+    const results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('colour contrast - secondary text', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <gcds-text text-role="secondary">This is some secondary text.</gcds-text>
+    `);
+
+    const colorContrastTest = new AxePuppeteer(page)
+      .withRules('color-contrast')
+      .analyze();
+    const results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+
+  it('colour contrast - light text', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <gcds-text text-role="light">This is some light text.</gcds-text>
+    `);
+
+    const colorContrastTest = new AxePuppeteer(page)
+      .withRules('color-contrast')
+      .analyze();
+    const results = await colorContrastTest;
+
+    expect(results.violations.length).toBe(0);
+  });
+});

--- a/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
+++ b/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
@@ -152,9 +152,9 @@ describe('gcds-text', () => {
       `,
     });
     expect(root).toEqualHtml(`
-      <gcds-text display="flex">
+      <gcds-text class="d-flex" display="flex">
         <mock:shadow-root>
-          <p class="gcds-text d-flex limit role-primary">
+          <p class="gcds-text limit role-primary">
             <slot></slot>
           </p>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
+++ b/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
@@ -1,0 +1,291 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GcdsText } from '../gcds-text';
+
+describe('gcds-text', () => {
+  it('renders text', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text>This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text>
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  /**
+    Text roles
+   */
+  it('renders primary text', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text text-role="primary">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text text-role="primary">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  it('renders secondary text', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text text-role="secondary">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text text-role="secondary">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-secondary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  it('renders light text', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text text-role="light">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text text-role="light">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-light">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  /**
+    Character limits
+   */
+  it('renders text with character limit by default', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text>This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text>
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  it('renders text without character limit', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text character-limit="false">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text character-limit="false">
+        <mock:shadow-root>
+          <p class="gcds-text role-primary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  /**
+    Display
+   */
+  it('renders text as block by default', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text>This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text>
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  it('renders text as flex', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text display="flex">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text display="flex">
+        <mock:shadow-root>
+          <p class="gcds-text d-flex limit role-primary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  /**
+    Spacing tests
+   */
+  it('renders margin-top', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text margin-top="400">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text margin-top="400">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary mt-400">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  it('renders margin-bottom', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text margin-bottom="400">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text margin-bottom="400">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary mb-400">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  /**
+    Size
+   */
+  it('renders body text size by default', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text>This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text>
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  it('renders caption text size', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text size="caption">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text size="caption">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary">
+            <small><slot></slot></small>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  /**
+    Text style
+   */
+  it('renders text style italic', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text text-style="italic">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text text-style="italic">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary italic">
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+
+  /**
+    Weight
+   */
+  it('renders text weight bold', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsText],
+      html: `
+        <gcds-text weight="bold">This is some text.</gcds-text>
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-text weight="bold">
+        <mock:shadow-root>
+          <p class="gcds-text limit role-primary">
+            <strong><slot></slot></strong>
+          </p>
+        </mock:shadow-root>
+        This is some text.
+      </gcds-text>
+    `);
+  });
+});

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -1,32 +1,52 @@
-<!DOCTYPE html>
+<!doctype html>
 <html dir="ltr" lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
     <title>Stencil Component Starter</title>
 
     <!-- Utility framework -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/cds-snc/gcds-utilities/dist/gcds-utility.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/cds-snc/gcds-utilities/dist/gcds-utility.css"
+    />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap"
+      rel="stylesheet"
+    />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap"
+      rel="stylesheet"
+    />
 
     <!-- Font awesome 6 kit for this demo page. Anyone can create a free kit for open source. -->
-    <script src="https://kit.fontawesome.com/892cb27850.js" crossorigin="anonymous"></script>
+    <script
+      src="https://kit.fontawesome.com/892cb27850.js"
+      crossorigin="anonymous"
+    ></script>
 
     <!-- Local components -->
     <link rel="stylesheet" href="/dist/gcds/gcds.css" />
     <script type="module" src="/dist/gcds/gcds.esm.js"></script>
     <script nomodule src="/dist/gcds.js"></script>
-
 
     <style>
       html {
@@ -102,7 +122,6 @@
         <p>Example content</p>
       </gcds-alert>
 
-
       <!-- ------------- Buttons ------------- -->
 
       <h3 class="mt-700 mb-400 bb-sm">Buttons</h3>
@@ -110,7 +129,9 @@
       <gcds-button button-role="secondary">Secondary</gcds-button>
       <gcds-button button-role="danger">Danger</gcds-button>
       <gcds-button button-role="skip-to-content">Skip to content</gcds-button>
-      <gcds-button type="link" button-style="text-only" href="#">Link</gcds-button>
+      <gcds-button type="link" button-style="text-only" href="#"
+        >Link</gcds-button
+      >
       <gcds-button
         type="link"
         button-style="text-only"
@@ -176,7 +197,9 @@
           description="Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
           img-src="https://picsum.photos/480/270"
         >
-          <gcds-button type="button" button-role="secondary" slot="footer">Action</gcds-button>
+          <gcds-button type="button" button-role="secondary" slot="footer"
+            >Action</gcds-button
+          >
         </gcds-card>
         <gcds-card
           type="action"
@@ -186,7 +209,9 @@
           description="This is a card with an img and possibly more"
           img-src="https://picsum.photos/480/270"
         >
-          <gcds-button type="button" button-role="secondary" slot="footer">Action</gcds-button>
+          <gcds-button type="button" button-role="secondary" slot="footer"
+            >Action</gcds-button
+          >
         </gcds-card>
       </gcds-grid>
 
@@ -202,13 +227,16 @@
 
       <h3 class="mt-700 mb-400 bb-sm">Containers</h3>
       <gcds-container size="full" border padding="400">
-        <p>I'm a responsive container. My size is only limited by the size of my parent container.</p>
+        <p>
+          I'm a responsive container. My size is only limited by the size of my
+          parent container.
+        </p>
       </gcds-container>
-      <br/>
+      <br />
       <gcds-container size="lg" centered border padding="400">
         <p>I'm a large, centred container. My max size is 64rem (1024px).</p>
       </gcds-container>
-      <br/>
+      <br />
       <gcds-container size="xs" border padding="400">
         <p>I'm an extra-small container. My max size is 20rem (320px).</p>
       </gcds-container>
@@ -222,13 +250,12 @@
 
       <!-- ------------- Stepper + Form Elements ------------- -->
 
-      <h3 class="mt-700 mb-400 bb-sm">Form elements (including stepper and error summary)</h3>
+      <h3 class="mt-700 mb-400 bb-sm">
+        Form elements (including stepper and error summary)
+      </h3>
       <gcds-stepper current-step="1" total-steps="3"></gcds-stepper>
       <form novalidate>
-
-        <gcds-error-summary
-          listen
-        ></gcds-error-summary>
+        <gcds-error-summary listen></gcds-error-summary>
 
         <gcds-input
           input-id="form-name"
@@ -329,9 +356,7 @@
           required
         ></gcds-file-uploader>
 
-        <gcds-button type="submit">
-            Submit
-        </gcds-button>
+        <gcds-button type="submit"> Submit </gcds-button>
       </form>
 
       <!-- ------------- Grid ------------- -->
@@ -344,11 +369,89 @@
         columns="1fr"
         gap="500"
       >
-        <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.</p>
-        <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.</p>
-        <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.</p>
-        <p>Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.</p>
+        <p>
+          Lorem Ipsum has been the industry's standard dummy text ever since the
+          1500s, when an unknown printer took a galley of type and scrambled it
+          to make a type specimen book. It has survived not only five centuries,
+          but also the leap into electronic typesetting, remaining essentially
+          unchanged.
+        </p>
+        <p>
+          Lorem Ipsum has been the industry's standard dummy text ever since the
+          1500s, when an unknown printer took a galley of type and scrambled it
+          to make a type specimen book. It has survived not only five centuries,
+          but also the leap into electronic typesetting, remaining essentially
+          unchanged.
+        </p>
+        <p>
+          Lorem Ipsum has been the industry's standard dummy text ever since the
+          1500s, when an unknown printer took a galley of type and scrambled it
+          to make a type specimen book. It has survived not only five centuries,
+          but also the leap into electronic typesetting, remaining essentially
+          unchanged.
+        </p>
+        <p>
+          Lorem Ipsum has been the industry's standard dummy text ever since the
+          1500s, when an unknown printer took a galley of type and scrambled it
+          to make a type specimen book. It has survived not only five centuries,
+          but also the leap into electronic typesetting, remaining essentially
+          unchanged.
+        </p>
       </gcds-grid>
+
+      <!-- ------------- Text ------------- -->
+
+      <h3 class="mt-700 mb-400 bb-sm">Text</h3>
+      <gcds-text margin-bottom="400"
+        >This text is primary text using the default body size with regular
+        weight and normal text style. The margin bottom is set to "400". The
+        character limit is set to "true" (default value) which means that the
+        text will take up a maximum of 65 characters per line.</gcds-text
+      >
+
+      <gcds-text character-limit="false" margin-bottom="400"
+        >This text is primary text using the default body size with regular
+        weight and normal text style. The margin bottom is set to "400". The
+        characters limit is set to "false" which means that the text will take
+        up all available space.</gcds-text
+      >
+
+      <gcds-text text-role="secondary" size="caption" margin-bottom="400"
+        >This text is secondary text using the caption size with regular weight
+        and normal text style. The margin bottom is set to "400". The character
+        limit is set to "true" (default value) which means that the text will
+        take up a maximum of 65 characters per line.</gcds-text
+      >
+
+      <div class="bg-dark mb-400 p-200">
+        <gcds-text text-role="light"
+          >This text is light text using the default body size with regular
+          weight and normal text style. The character limit is set to "true"
+          (default value) which means that the text will take up a maximum of 65
+          characters per line.</gcds-text
+        >
+      </div>
+
+      <gcds-text weight="bold" margin-bottom="400"
+        >This text is primary text using the default body size with bold weight
+        and normal text style. The margin bottom is set to "400". The character
+        limit is set to "true" (default value) which means that the text will
+        take up a maximum of 65 characters per line.</gcds-text
+      >
+
+      <gcds-text size="caption" weight="bold" margin-bottom="400"
+        >This text is primary text using the caption size with bold weight and
+        normal text style. The margin bottom is set to "400". The character
+        limit is set to "true" (default value) which means that the text will
+        take up a maximum of 65 characters per line.</gcds-text
+      >
+
+      <gcds-text text-style="italic" margin-bottom="400"
+        >This text is primary text using the default body size with regular
+        weight and italic text style. The margin bottom is set to "400". The
+        character limit is set to "true" (default value) which means that the
+        text will take up a maximum of 65 characters per line.</gcds-text
+      >
 
       <!-- ------------- Icons ------------- -->
 
@@ -384,7 +487,7 @@
         total-pages="22"
         current-page="8"
         url='{"queryStrings": { "querystring::offset": 10 }, "fragment": "main" }'
-        pageChangeHandler={}
+        pageChangeHandler="{}"
       ></gcds-pagination>
 
       <gcds-pagination
@@ -413,7 +516,10 @@
         <gcds-nav-group menu-label="Contact submenu" open-trigger="Contact">
           <gcds-nav-link href="#red">Site</gcds-nav-link>
           <gcds-nav-link href="#red">GitHub</gcds-nav-link>
-          <gcds-nav-group menu-label="Sub level submenu" open-trigger="Sub level">
+          <gcds-nav-group
+            menu-label="Sub level submenu"
+            open-trigger="Sub level"
+          >
             <gcds-nav-link href="#red">Site</gcds-nav-link>
             <gcds-nav-link href="#red">GitHub</gcds-nav-link>
             <gcds-nav-link href="#red">Slack</gcds-nav-link>
@@ -428,8 +534,11 @@
         <gcds-nav-link href="#red" slot="home">Home</gcds-nav-link>
         <gcds-nav-link href="#red">Installation</gcds-nav-link>
         <gcds-nav-link href="#red">Foundations</gcds-nav-link>
-        <gcds-nav-link href="#red" current >Components</gcds-nav-link>
-        <gcds-nav-group menu-label="Contact us submenu"  open-trigger="Contact us">
+        <gcds-nav-link href="#red" current>Components</gcds-nav-link>
+        <gcds-nav-group
+          menu-label="Contact us submenu"
+          open-trigger="Contact us"
+        >
           <gcds-nav-link href="#red">Form</gcds-nav-link>
           <gcds-nav-link href="#red">GitHub</gcds-nav-link>
           <gcds-nav-link href="#red">Slack</gcds-nav-link>


### PR DESCRIPTION
# Summary | Résumé

Add new `gcds-text` component.

## Supported properties

### Character limit
Sets the line length to a maximum amount of characters per line to ensure a comfortable, accessible reading length.

### Display
Specifies the display behavior of the text.

### Margin-top
Adds margin above the text.

### Margin-bottom
Adds margin below the text.

### Text-role
Sets the main style of the text.

### Size
Sets the appropriate HTML tags for the selected size.

### Style
Indicates if the text should be styled italic or normal. 

### Weight
Determines the font weight for the text.

