### PR TITLE
Add screen reader only component

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -861,6 +861,27 @@ export declare interface GcdsSignature extends Components.GcdsSignature {}
 
 
 @ProxyCmp({
+})
+@Component({
+  selector: 'gcds-sr-only',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [],
+})
+export class GcdsSrOnly {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface GcdsSrOnly extends Components.GcdsSrOnly {}
+
+
+@ProxyCmp({
   inputs: ['currentStep', 'totalSteps']
 })
 @Component({

--- a/packages/angular/src/lib/stencil-generated/index.ts
+++ b/packages/angular/src/lib/stencil-generated/index.ts
@@ -32,6 +32,7 @@ export const DIRECTIVES = [
   d.GcdsSelect,
   d.GcdsSideNav,
   d.GcdsSignature,
+  d.GcdsSrOnly,
   d.GcdsStepper,
   d.GcdsText,
   d.GcdsTextarea,

--- a/packages/react/src/components/stencil-generated/index.ts
+++ b/packages/react/src/components/stencil-generated/index.ts
@@ -38,6 +38,7 @@ export const GcdsSearch = /*@__PURE__*/createReactComponent<JSX.GcdsSearch, HTML
 export const GcdsSelect = /*@__PURE__*/createReactComponent<JSX.GcdsSelect, HTMLGcdsSelectElement>('gcds-select');
 export const GcdsSideNav = /*@__PURE__*/createReactComponent<JSX.GcdsSideNav, HTMLGcdsSideNavElement>('gcds-side-nav');
 export const GcdsSignature = /*@__PURE__*/createReactComponent<JSX.GcdsSignature, HTMLGcdsSignatureElement>('gcds-signature');
+export const GcdsSrOnly = /*@__PURE__*/createReactComponent<JSX.GcdsSrOnly, HTMLGcdsSrOnlyElement>('gcds-sr-only');
 export const GcdsStepper = /*@__PURE__*/createReactComponent<JSX.GcdsStepper, HTMLGcdsStepperElement>('gcds-stepper');
 export const GcdsText = /*@__PURE__*/createReactComponent<JSX.GcdsText, HTMLGcdsTextElement>('gcds-text');
 export const GcdsTextarea = /*@__PURE__*/createReactComponent<JSX.GcdsTextarea, HTMLGcdsTextareaElement>('gcds-textarea');

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -964,6 +964,8 @@ export namespace Components {
          */
         "variant": 'colour' | 'white';
     }
+    interface GcdsSrOnly {
+    }
     interface GcdsStepper {
         /**
           * Defines the current step.
@@ -1392,6 +1394,12 @@ declare global {
         prototype: HTMLGcdsSignatureElement;
         new (): HTMLGcdsSignatureElement;
     };
+    interface HTMLGcdsSrOnlyElement extends Components.GcdsSrOnly, HTMLStencilElement {
+    }
+    var HTMLGcdsSrOnlyElement: {
+        prototype: HTMLGcdsSrOnlyElement;
+        new (): HTMLGcdsSrOnlyElement;
+    };
     interface HTMLGcdsStepperElement extends Components.GcdsStepper, HTMLStencilElement {
     }
     var HTMLGcdsStepperElement: {
@@ -1459,6 +1467,7 @@ declare global {
         "gcds-select": HTMLGcdsSelectElement;
         "gcds-side-nav": HTMLGcdsSideNavElement;
         "gcds-signature": HTMLGcdsSignatureElement;
+        "gcds-sr-only": HTMLGcdsSrOnlyElement;
         "gcds-stepper": HTMLGcdsStepperElement;
         "gcds-text": HTMLGcdsTextElement;
         "gcds-textarea": HTMLGcdsTextareaElement;
@@ -2545,6 +2554,8 @@ declare namespace LocalJSX {
          */
         "variant"?: 'colour' | 'white';
     }
+    interface GcdsSrOnly {
+    }
     interface GcdsStepper {
         /**
           * Defines the current step.
@@ -2769,6 +2780,7 @@ declare namespace LocalJSX {
         "gcds-select": GcdsSelect;
         "gcds-side-nav": GcdsSideNav;
         "gcds-signature": GcdsSignature;
+        "gcds-sr-only": GcdsSrOnly;
         "gcds-stepper": GcdsStepper;
         "gcds-text": GcdsText;
         "gcds-textarea": GcdsTextarea;
@@ -2811,6 +2823,7 @@ declare module "@stencil/core" {
             "gcds-select": LocalJSX.GcdsSelect & JSXBase.HTMLAttributes<HTMLGcdsSelectElement>;
             "gcds-side-nav": LocalJSX.GcdsSideNav & JSXBase.HTMLAttributes<HTMLGcdsSideNavElement>;
             "gcds-signature": LocalJSX.GcdsSignature & JSXBase.HTMLAttributes<HTMLGcdsSignatureElement>;
+            "gcds-sr-only": LocalJSX.GcdsSrOnly & JSXBase.HTMLAttributes<HTMLGcdsSrOnlyElement>;
             "gcds-stepper": LocalJSX.GcdsStepper & JSXBase.HTMLAttributes<HTMLGcdsStepperElement>;
             "gcds-text": LocalJSX.GcdsText & JSXBase.HTMLAttributes<HTMLGcdsTextElement>;
             "gcds-textarea": LocalJSX.GcdsTextarea & JSXBase.HTMLAttributes<HTMLGcdsTextareaElement>;

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
@@ -1,0 +1,11 @@
+@layer default;
+
+@layer default {
+  :host {
+    display: block;
+    width: 0;
+    height: 0;
+    margin: 0;
+    overflow: hidden;
+  }
+}

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.tsx
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.tsx
@@ -1,0 +1,16 @@
+import { Component, Host, h } from '@stencil/core';
+
+@Component({
+  tag: 'gcds-sr-only',
+  styleUrl: 'gcds-sr-only.css',
+  shadow: true,
+})
+export class GcdsSrOnly {
+  render() {
+    return (
+      <Host>
+        <slot></slot>
+      </Host>
+    );
+  }
+}

--- a/packages/web/src/components/gcds-sr-only/readme.md
+++ b/packages/web/src/components/gcds-sr-only/readme.md
@@ -1,0 +1,10 @@
+# gcds-hidden
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
+++ b/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
@@ -1,0 +1,55 @@
+export default {
+  title: 'Components/Screen reader only',
+
+  argTypes: {
+    // Slots
+    default: {
+      control: {
+        type: 'text',
+      },
+      table: {
+        category: 'Slots | Fentes',
+      },
+    },
+  },
+};
+
+const Template = args =>
+  `
+<!-- Web component code (Angular, Vue) -->
+<gcds-sr-only>
+  ${args.default}
+</gcds-sr-only>
+
+<!-- React code -->
+<GcdsSrOnly>
+  ${args.default}
+</GcdsSrOnly>
+`.replace(/ null/g, '');
+
+const TemplatePlayground = args => `
+<gcds-sr-only>
+  ${args.default}
+</gcds-sr-only>
+`;
+
+// ------ Screen reader only default ------
+
+export const Default = Template.bind({});
+Default.args = {
+  default: 'Text only seen by assistive technologies',
+};
+
+// ------ Screen reader only  events & props ------
+
+export const Props = Template.bind({});
+Props.args = {
+  default: 'Text only seen by assistive technologies',
+};
+
+// ------ Screen reader only  playground ------
+
+export const Playground = TemplatePlayground.bind({});
+Playground.args = {
+  default: 'Text only seen by assistive technologies',
+};

--- a/packages/web/src/components/gcds-sr-only/stories/overview.mdx
+++ b/packages/web/src/components/gcds-sr-only/stories/overview.mdx
@@ -1,0 +1,24 @@
+import { Meta, Canvas, Story } from '@storybook/blocks';
+import * as SROnly from './gcds-sr-only.stories';
+
+<Meta of={SROnly} name="Overview" />
+
+# Screen reader only<br/>`<gcds-sr-only>`
+
+_Also called: visually hidden, assistive text._
+
+<Canvas
+  of={SROnly.Default}
+  story={{ inline: true }}
+/>
+
+## Resources
+
+<ul>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://design-system.alpha.canada.ca/en/components/screen-reader-only/" target="_blank">Guidance</gcds-button>
+  </li>
+  <li>
+    <gcds-button type="link" button-style="text-only" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-sr-only" target="_blank">Github</gcds-button>
+  </li>
+</ul>

--- a/packages/web/src/components/gcds-sr-only/stories/properties.mdx
+++ b/packages/web/src/components/gcds-sr-only/stories/properties.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import * as SROnly from './gcds-sr-only.stories';
+
+<Meta of={SROnly} name="Events & properties" />
+
+{!(new URLSearchParams(window.location.search)).get('demo') && <h1>Events & properties</h1>}
+
+<Canvas
+  of={SROnly.Props}
+  story={{ inline: true }}
+  sourceState="shown"
+  type="dynamic"
+/>
+
+<Controls of={SROnly.Props} sort="requiredFirst" />

--- a/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.e2e.ts
+++ b/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('gcds-sr-only', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<gcds-sr-only></gcds-sr-only>');
+
+    const element = await page.find('gcds-sr-only');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
+++ b/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
@@ -1,0 +1,19 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GcdsSrOnly } from '../gcds-sr-only';
+
+describe('gcds-sr-only', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only>Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+});

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -507,6 +507,14 @@
         <p slot="banner-text">Exciting announcement.</p>
       </gcds-phase-banner>
 
+      <!-- ------------- Screen reader only ------------- -->
+
+      <h3 class="mt-700 mb-400 bb-sm">Screen reader only</h3>
+      <gcds-text>There is invisible text below this</gcds-text>
+      <gcds-sr-only>
+        <gcds-text>This text is only available to assistive technologies.</gcds-text>
+      </gcds-sr-only>
+
       <!-- ------------- Side nav ------------- -->
 
       <gcds-side-nav class="mt-700" label="Sidenav">


### PR DESCRIPTION
# Summary | Résumé

Add `gcds-sr-only` component to component library.

## Usage

To use the screen reader only component, simply wrap the text you want hidden in the component

```html
<gcds-sr-only>
  Text only available for assistive technologies.
</gcds-sr-only>
```
