### PR TITLE
remove text-style and weight props from gcds-text to avoid misuse

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -904,14 +904,14 @@ export declare interface GcdsStepper extends Components.GcdsStepper {}
 
 
 @ProxyCmp({
-  inputs: ['characterLimit', 'display', 'marginBottom', 'marginTop', 'size', 'textRole', 'textStyle', 'weight']
+  inputs: ['characterLimit', 'display', 'marginBottom', 'marginTop', 'size', 'textRole']
 })
 @Component({
   selector: 'gcds-text',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['characterLimit', 'display', 'marginBottom', 'marginTop', 'size', 'textRole', 'textStyle', 'weight'],
+  inputs: ['characterLimit', 'display', 'marginBottom', 'marginTop', 'size', 'textRole'],
 })
 export class GcdsText {
   protected el: HTMLElement;

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1036,14 +1036,6 @@ export namespace Components {
           * Sets the main style of the text.
          */
         "textRole"?: 'light' | 'primary' | 'secondary';
-        /**
-          * Indicates if the text should be styled italic or normal.
-         */
-        "textStyle"?: 'italic' | 'normal';
-        /**
-          * Determines the font weight for the text.
-         */
-        "weight"?: 'bold' | 'regular';
     }
     interface GcdsTextarea {
         /**
@@ -2626,14 +2618,6 @@ declare namespace LocalJSX {
           * Sets the main style of the text.
          */
         "textRole"?: 'light' | 'primary' | 'secondary';
-        /**
-          * Indicates if the text should be styled italic or normal.
-         */
-        "textStyle"?: 'italic' | 'normal';
-        /**
-          * Determines the font weight for the text.
-         */
-        "weight"?: 'bold' | 'regular';
     }
     interface GcdsTextarea {
         /**

--- a/packages/web/src/components/gcds-text/gcds-text.css
+++ b/packages/web/src/components/gcds-text/gcds-text.css
@@ -231,19 +231,13 @@ variants.weight;
 }
 
 @layer variants.style {
-  :host .gcds-text.italic,
-  :host .gcds-text ::slotted(em),
-  :host .gcds-text.italic small,
-  :host .gcds-text.italic small ::slotted(em) {
+  :host .gcds-text ::slotted(em) {
     font-style: italic;
   }
 }
 
 @layer variants.weight {
-  :host .gcds-text {
-    strong,
-    ::slotted(strong) {
-      font-weight: var(--gcds-text-weight-bold);
-    }
+  :host .gcds-text ::slotted(strong) {
+    font-weight: var(--gcds-text-weight-bold);
   }
 }

--- a/packages/web/src/components/gcds-text/gcds-text.tsx
+++ b/packages/web/src/components/gcds-text/gcds-text.tsx
@@ -167,34 +167,6 @@ export class GcdsText {
     }
   }
 
-  /**
-   * Indicates if the text should be styled italic or normal.
-   */
-  @Prop({ mutable: true }) textStyle?: 'italic' | 'normal' = 'normal';
-
-  @Watch('textStyle')
-  validateTextStyle(newValue: string) {
-    const values = ['italic', 'normal'];
-
-    if (!values.includes(newValue)) {
-      this.textStyle = 'normal';
-    }
-  }
-
-  /**
-   * Determines the font weight for the text.
-   */
-  @Prop({ mutable: true }) weight?: 'bold' | 'regular' = 'regular';
-
-  @Watch('weight')
-  validateWeight(newValue: string) {
-    const values = ['bold', 'regular'];
-
-    if (!values.includes(newValue)) {
-      this.weight = 'regular';
-    }
-  }
-
   componentWillLoad() {
     // Validate attributes and set defaults
     this.validateTextRole(this.textRole);
@@ -202,21 +174,11 @@ export class GcdsText {
     this.validateMarginTop(this.marginTop);
     this.validateMarginBottom(this.marginBottom);
     this.validateSize(this.size);
-    this.validateTextStyle(this.textStyle);
-    this.validateWeight(this.weight);
   }
 
   render() {
-    const {
-      characterLimit,
-      display,
-      marginTop,
-      marginBottom,
-      size,
-      textRole,
-      textStyle,
-      weight,
-    } = this;
+    const { characterLimit, display, marginTop, marginBottom, size, textRole } =
+      this;
 
     return (
       <Host class={`${display != 'block' ? `d-${display}` : ''}`}>
@@ -224,7 +186,6 @@ export class GcdsText {
           class={`
             gcds-text
             ${textRole ? `role-${textRole}` : ''}
-            ${textStyle === 'italic' ? 'italic' : ''}
             ${characterLimit ? 'limit' : ''}
             ${marginTop ? `mt-${marginTop}` : ''}
             ${marginBottom ? `mb-${marginBottom}` : ''}
@@ -232,18 +193,8 @@ export class GcdsText {
         >
           {size === 'caption' ? (
             <small>
-              {weight === 'bold' ? (
-                <strong>
-                  <slot />
-                </strong>
-              ) : (
-                <slot />
-              )}
-            </small>
-          ) : weight === 'bold' ? (
-            <strong>
               <slot />
-            </strong>
+            </small>
           ) : (
             <slot />
           )}

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -15,8 +15,6 @@
 | `marginTop`      | `margin-top`      | Adds margin above the text.                                                                                         | `"0" \| "100" \| "1000" \| "150" \| "200" \| "250" \| "300" \| "400" \| "450" \| "50" \| "500" \| "550" \| "600" \| "700" \| "800" \| "900"` | `undefined` |
 | `size`           | `size`            | Sets the appropriate HTML tags for the selected size.                                                               | `"body" \| "caption"`                                                                                                                        | `'body'`    |
 | `textRole`       | `text-role`       | Sets the main style of the text.                                                                                    | `"light" \| "primary" \| "secondary"`                                                                                                        | `'primary'` |
-| `textStyle`      | `text-style`      | Indicates if the text should be styled italic or normal.                                                            | `"italic" \| "normal"`                                                                                                                       | `'normal'`  |
-| `weight`         | `weight`          | Determines the font weight for the text.                                                                            | `"bold" \| "regular"`                                                                                                                        | `'regular'` |
 
 
 ----------------------------------------------

--- a/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
+++ b/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
@@ -95,23 +95,6 @@ export default {
         defaultValue: { summary: 'primary' },
       },
     },
-    textStyle: {
-      name: 'text-style',
-      control: { type: 'select' },
-      options: ['italic', 'normal'],
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'normal' },
-      },
-    },
-    weight: {
-      control: { type: 'select' },
-      options: ['bold', 'regular'],
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'regular' },
-      },
-    },
 
     // Slots
     default: {
@@ -134,9 +117,7 @@ const Template = args =>
     !args.characterLimit ? `character-limit="${args.characterLimit}"` : null
   } ${args.display != 'block' ? `display="${args.display}"` : null} ${
     args.marginTop ? `margin-top="${args.marginTop}"` : null
-  } ${args.marginBottom ? `margin-bottom="${args.marginBottom}"` : null} ${
-    args.textStyle != 'normal' ? `text-style="${args.textStyle}"` : null
-  } ${args.weight != 'regular' ? `weight="${args.weight}"` : null}>
+  } ${args.marginBottom ? `margin-bottom="${args.marginBottom}"` : null}>
   ${args.default}
 </gcds-text>
 
@@ -147,9 +128,7 @@ const Template = args =>
     !args.characterLimit ? `characterLimit="${args.characterLimit}"` : null
   } ${args.display != 'block' ? `display="${args.display}"` : null} ${
     args.marginTop ? `marginTop="${args.marginTop}"` : null
-  } ${args.marginBottom ? `marginBottom="${args.marginBottom}"` : null} ${
-    args.textStyle != 'normal' ? `textStyle="${args.textStyle}"` : null
-  } ${args.weight != 'regular' ? `weight="${args.weight}"` : null}>
+  } ${args.marginBottom ? `marginBottom="${args.marginBottom}"` : null}>
   ${args.default}
 </GcdsText>
 `.replace(/ null/g, '');
@@ -162,8 +141,6 @@ const TemplatePlayground = args => `
   ${args.display != 'block' ? `display="${args.display}"` : null}
   ${args.marginTop ? `margin-top="${args.marginTop}"` : null}
   ${args.marginBottom ? `margin-bottom="${args.marginBottom}"` : null}
-  ${args.textStyle != 'normal' ? `text-style="${args.textStyle}"` : null}
-  ${args.weight != 'regular' ? `weight="${args.weight}"` : null}
 >
   ${args.default}
 </gcds-text>
@@ -177,8 +154,6 @@ Default.args = {
   display: 'block',
   size: 'body',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -191,8 +166,6 @@ Primary.args = {
   display: 'block',
   size: 'body',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -203,8 +176,6 @@ Secondary.args = {
   display: 'block',
   size: 'body',
   textRole: 'secondary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -215,8 +186,6 @@ Light.args = {
   display: 'block',
   size: 'body',
   textRole: 'light',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -229,8 +198,6 @@ SizeBody.args = {
   display: 'block',
   size: 'body',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -241,8 +208,6 @@ SizeCaption.args = {
   display: 'block',
   size: 'caption',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -255,8 +220,6 @@ CharacterLimit.args = {
   display: 'block',
   size: 'body',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -267,60 +230,6 @@ NoCharacterLimit.args = {
   display: 'block',
   size: 'body',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
-  default:
-    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
-};
-
-// ------ Text style ------
-
-export const StyleNormal = Template.bind({});
-StyleNormal.args = {
-  characterLimit: true,
-  display: 'block',
-  size: 'body',
-  textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
-  default:
-    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
-};
-
-export const StyleItalic = Template.bind({});
-StyleItalic.args = {
-  characterLimit: true,
-  display: 'block',
-  size: 'body',
-  textRole: 'primary',
-  textStyle: 'italic',
-  weight: 'regular',
-  default:
-    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
-};
-
-// ------ Text weight ------
-
-export const WeightRegular = Template.bind({});
-WeightRegular.args = {
-  characterLimit: true,
-  display: 'block',
-  size: 'body',
-  textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
-  default:
-    'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
-};
-
-export const WeightBold = Template.bind({});
-WeightBold.args = {
-  characterLimit: true,
-  display: 'block',
-  size: 'body',
-  textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'bold',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -333,8 +242,6 @@ Props.args = {
   display: 'block',
   size: 'body',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };
@@ -347,8 +254,6 @@ Playground.args = {
   display: 'block',
   size: 'body',
   textRole: 'primary',
-  textStyle: 'normal',
-  weight: 'regular',
   default:
     'This is some example content to display the gcds-text component. It is a paragraph displaying non-heading content with matching GC Design System styles to provide accessible text sizes and colour contrast.',
 };

--- a/packages/web/src/components/gcds-text/stories/overview.mdx
+++ b/packages/web/src/components/gcds-text/stories/overview.mdx
@@ -49,26 +49,6 @@ Text is a paragraph displaying non-heading content with matching GC Design Syste
 
 <Canvas of={Text.NoCharacterLimit} story={{ inline: true }} />
 
-### Text style
-
-#### Text style normal.
-
-<Canvas of={Text.StyleNormal} story={{ inline: true }} />
-
-#### Text style italic.
-
-<Canvas of={Text.StyleItalic} story={{ inline: true }} />
-
-### Text weight
-
-#### Text weight regular.
-
-<Canvas of={Text.WeightRegular} story={{ inline: true }} />
-
-#### Text weight bold.
-
-<Canvas of={Text.WeightBold} story={{ inline: true }} />
-
 ## Resources
 
 {/* prettier-ignore */}

--- a/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
+++ b/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
@@ -244,48 +244,4 @@ describe('gcds-text', () => {
       </gcds-text>
     `);
   });
-
-  /**
-    Text style
-   */
-  it('renders text style italic', async () => {
-    const { root } = await newSpecPage({
-      components: [GcdsText],
-      html: `
-        <gcds-text text-style="italic">This is some text.</gcds-text>
-      `,
-    });
-    expect(root).toEqualHtml(`
-      <gcds-text text-style="italic">
-        <mock:shadow-root>
-          <p class="gcds-text limit role-primary italic">
-            <slot></slot>
-          </p>
-        </mock:shadow-root>
-        This is some text.
-      </gcds-text>
-    `);
-  });
-
-  /**
-    Weight
-   */
-  it('renders text weight bold', async () => {
-    const { root } = await newSpecPage({
-      components: [GcdsText],
-      html: `
-        <gcds-text weight="bold">This is some text.</gcds-text>
-      `,
-    });
-    expect(root).toEqualHtml(`
-      <gcds-text weight="bold">
-        <mock:shadow-root>
-          <p class="gcds-text limit role-primary">
-            <strong><slot></slot></strong>
-          </p>
-        </mock:shadow-root>
-        This is some text.
-      </gcds-text>
-    `);
-  });
 });

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -403,54 +403,54 @@
 
       <h3 class="mt-700 mb-400 bb-sm">Text</h3>
       <gcds-text margin-bottom="400"
-        >This text is primary text using the default body size with regular
-        weight and normal text style. The margin bottom is set to "400". The
-        character limit is set to "true" (default value) which means that the
-        text will take up a maximum of 65 characters per line.</gcds-text
+        >This text is primary text using the default body size. The margin
+        bottom is set to "400". The character limit is set to "true" (default
+        value) which means that the text will take up a maximum of 65 characters
+        per line.</gcds-text
       >
 
       <gcds-text character-limit="false" margin-bottom="400"
-        >This text is primary text using the default body size with regular
-        weight and normal text style. The margin bottom is set to "400". The
-        characters limit is set to "false" which means that the text will take
-        up all available space.</gcds-text
+        >This text is primary text using the default body size. The margin
+        bottom is set to "400". The characters limit is set to "false" which
+        means that the text will take up all available space.</gcds-text
       >
 
-      <gcds-text text-role="secondary" size="caption" margin-bottom="400"
-        >This text is secondary text using the caption size with regular weight
-        and normal text style. The margin bottom is set to "400". The character
-        limit is set to "true" (default value) which means that the text will
-        take up a maximum of 65 characters per line.</gcds-text
+      <gcds-text text-role="secondary" margin-bottom="400"
+        >This text is secondary text using the default body size. The margin
+        bottom is set to "400". The character limit is set to "true" (default
+        value) which means that the text will take up a maximum of 65 characters
+        per line.</gcds-text
       >
 
       <div class="bg-dark mb-400 p-200">
         <gcds-text text-role="light"
-          >This text is light text using the default body size with regular
-          weight and normal text style. The character limit is set to "true"
-          (default value) which means that the text will take up a maximum of 65
-          characters per line.</gcds-text
+          >This text is light text using the default body size. The character
+          limit is set to "true" (default value) which means that the text will
+          take up a maximum of 65 characters per line.</gcds-text
         >
       </div>
 
-      <gcds-text weight="bold" margin-bottom="400"
-        >This text is primary text using the default body size with bold weight
-        and normal text style. The margin bottom is set to "400". The character
-        limit is set to "true" (default value) which means that the text will
-        take up a maximum of 65 characters per line.</gcds-text
+      <gcds-text size="caption" margin-bottom="400"
+        >This text is primary text using the caption size. The margin bottom is
+        set to "400". The character limit is set to "true" (default value) which
+        means that the text will take up a maximum of 65 characters per
+        line.</gcds-text
       >
 
-      <gcds-text size="caption" weight="bold" margin-bottom="400"
-        >This text is primary text using the caption size with bold weight and
-        normal text style. The margin bottom is set to "400". The character
-        limit is set to "true" (default value) which means that the text will
-        take up a maximum of 65 characters per line.</gcds-text
+      <gcds-text margin-bottom="400"
+        >This text is primary text using the default body size
+        <strong>with some bold text included</strong>. The margin bottom is set
+        to "400". The character limit is set to "true" (default value) which
+        means that the text will take up a maximum of 65 characters per
+        line.</gcds-text
       >
 
-      <gcds-text text-style="italic" margin-bottom="400"
-        >This text is primary text using the default body size with regular
-        weight and italic text style. The margin bottom is set to "400". The
-        character limit is set to "true" (default value) which means that the
-        text will take up a maximum of 65 characters per line.</gcds-text
+      <gcds-text margin-bottom="400"
+        >This text is primary text using the default body size
+        <em>with some italic text included</em>. The margin bottom is set to
+        "400". The character limit is set to "true" (default value) which means
+        that the text will take up a maximum of 65 characters per
+        line.</gcds-text
       >
 
       <!-- ------------- Icons ------------- -->
@@ -512,7 +512,9 @@
       <h3 class="mt-700 mb-400 bb-sm">Screen reader only</h3>
       <gcds-text>There is invisible text below this</gcds-text>
       <gcds-sr-only>
-        <gcds-text>This text is only available to assistive technologies.</gcds-text>
+        <gcds-text
+          >This text is only available to assistive technologies.</gcds-text
+        >
       </gcds-sr-only>
 
       <!-- ------------- Side nav ------------- -->


### PR DESCRIPTION
# Summary | Résumé

Removing `text-style` and `weight` props from the `gcds-text` component to avoid misuse. Including them as props and adding these styles to an entire block of text would lead to a bad and less accessible user experience and therefore they should not be available as default props.