### PR TITLE
Update focus styles for consistent look

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.9.0",
+    "@cdssnc/gcds-tokens": "^1.9.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "^0.8.1",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.9.1",
+    "@cdssnc/gcds-tokens": "^1.9.2",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "^0.8.1",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-button/gcds-button.css
+++ b/packages/web/src/components/gcds-button/gcds-button.css
@@ -27,6 +27,7 @@
       outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
+      box-shadow: var(--gcds-button-shared-focus-box-shadow);
     }
 
     &:active {
@@ -49,6 +50,7 @@
       outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
+      box-shadow: var(--gcds-button-shared-focus-box-shadow);
     }
 
     &:active {
@@ -74,6 +76,7 @@
       outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
+      box-shadow: var(--gcds-button-shared-focus-box-shadow);
 
       &:hover {
         border-color: var(--gcds-button-shared-focus-background);
@@ -109,6 +112,7 @@
       outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
+      box-shadow: var(--gcds-button-shared-focus-box-shadow);
       text-decoration: none;
     }
 
@@ -140,6 +144,7 @@
       outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
+      box-shadow: var(--gcds-button-shared-focus-box-shadow);
       text-decoration: none;
     }
 

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.css
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.css
@@ -78,6 +78,7 @@
           left: 0;
           top: var(--gcds-checkbox-top);
           border-radius: var(--gcds-checkbox-input-border-radius);
+          transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, outline ease-in-out .15s;
         }
 
         &:after {
@@ -99,6 +100,8 @@
         &:before {
           outline: var( --gcds-checkbox-focus-outline-width) solid currentcolor;
           outline-offset: var(--gcds-checkbox-input-border-width);
+          box-shadow: var(--gcds-checkbox-focus-box-shadow);
+          background: var(--gcds-checkbox-focus-background);
         }
 
         &:after {

--- a/packages/web/src/components/gcds-input/gcds-input.css
+++ b/packages/web/src/components/gcds-input/gcds-input.css
@@ -33,12 +33,13 @@
   border: var(--gcds-input-border-width) solid currentColor;
   border-radius: var(--gcds-input-border-radius);
   box-sizing: border-box;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, outline ease-in-out .15s;
 
   &:focus {
     border-color: var(--gcds-input-focus-text);
     outline: var(--gcds-input-outline-width) solid var(--gcds-input-focus-text);
     outline-offset: var(--gcds-input-border-width);
+    box-shadow: var(--gcds-input-focus-box-shadow);
   }
 
   &:disabled {

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.css
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.css
@@ -23,6 +23,7 @@
           background-color: var(--gcds-pagination-focus-background);
           outline: var(--gcds-pagination-focus-outline-width) solid var(--gcds-pagination-focus-background);
           outline-offset: var(--gcds-pagination-border-width);
+          box-shadow: var(--gcds-pagination-focus-box-shadow);
           text-decoration: none;
         }
 

--- a/packages/web/src/components/gcds-radio/gcds-radio.css
+++ b/packages/web/src/components/gcds-radio/gcds-radio.css
@@ -80,6 +80,7 @@
           width: var(--gcds-radio-input-height-and-width);
           left: 0;
           top: var(--gcds-radio-top);
+          transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, outline ease-in-out .15s;
         }
 
         &:after {
@@ -100,6 +101,8 @@
         &:before {
           outline: var( --gcds-radio-focus-outline-width) solid currentcolor;
           outline-offset: var(--gcds-radio-input-border-width);
+          box-shadow: var(--gcds-radio-focus-box-shadow);
+          background: var(--gcds-radio-focus-background);
         }
 
         &:after {

--- a/packages/web/src/components/gcds-select/gcds-select.css
+++ b/packages/web/src/components/gcds-select/gcds-select.css
@@ -48,6 +48,7 @@
     border-color: var(--gcds-select-focus-text);
     outline: var(--gcds-select-outline-width) solid var(--gcds-select-focus-text);
     outline-offset: var(--gcds-select-border-width);
+    box-shadow: var(--gcds-select-focus-box-shadow);
   }
 
   &:disabled {

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.css
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.css
@@ -37,12 +37,13 @@
   border: var(--gcds-textarea-border-width) solid currentColor;
   border-radius: var(--gcds-textarea-border-radius);
   box-sizing: border-box;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, outline ease-in-out .15s;
 
   &:focus {
     border-color: var(--gcds-textarea-focus-text);
     outline: var(--gcds-textarea-outline-width) solid var(--gcds-textarea-focus-text);
     outline-offset: var(--gcds-textarea-border-width);
+    box-shadow: var(--gcds-textarea-focus-box-shadow);
   }
 
   &:disabled {

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -104,8 +104,6 @@
 
       <h2>Components</h2>
 
-      <gcds-search></gcds-search>
-
       <!-- ------------- Alerts ------------- -->
 
       <h3 class="mt-500 mb-400 bb-sm">Alerts</h3>


### PR DESCRIPTION
# Summary | Résumé

Add additional CSS and tokens for a focus `box-shadow` in `gcds-button`, `gcds-checkbox`, `gcds-input`, `gcds-pagination`, `gcds-radio`, `gcds-select` and `gcds-textarea` to be consistent with other components.

Depends on https://github.com/cds-snc/gcds-tokens/pull/177
