### PR TITLE
Add slot styles to help with chrome accessibility tree rendering

### DIFF
--- a/packages/web/src/components/gcds-alert/gcds-alert.css
+++ b/packages/web/src/components/gcds-alert/gcds-alert.css
@@ -6,6 +6,10 @@
   padding: var(--gcds-alert-padding);
   border-inline-start: var(--gcds-alert-border-width) solid transparent;
 
+  slot {
+    display: inherit;
+  }
+
   /* Is Fixed */
   &.alert--is-fixed {
     position: sticky;

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -22,6 +22,10 @@
       text-decoration-thickness: var(--gcds-breadcrumbs-default-decoration-thickness);
       transition: background 0.15s ease-in-out, color 0.15s ease-in-out;
       white-space: normal;
+
+      slot {
+        display: inherit;
+      }
     }
   }
 

--- a/packages/web/src/components/gcds-button/gcds-button.css
+++ b/packages/web/src/components/gcds-button/gcds-button.css
@@ -12,6 +12,10 @@
   text-align: center;
   transition: all 0.15s ease-in-out;
 
+  slot {
+    display: inherit;
+  }
+
   /* Button Role Styles */
   &.button--role-danger {
     background-color: var(--gcds-button-danger-default-background);

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -87,6 +87,10 @@
         content: "";
       }
     }
+
+    slot {
+      display: inherit;
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-container/gcds-container.css
+++ b/packages/web/src/components/gcds-container/gcds-container.css
@@ -4,6 +4,10 @@
   padding: 0;
   box-sizing: border-box;
 
+  slot {
+    display: inherit;
+  }
+
   /* Container border */
   &.container-border {
     border: var(--gcds-container-border);

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -60,6 +60,10 @@
     padding: var(--gcds-details-panel-padding);
     border-inline-start: var(--gcds-details-panel-border-width) solid var(--gcds-details-panel-border-color);
 
+    slot {
+      display: inherit;
+    }
+
     ::slotted(*) {
       font: var(--gcds-details-font);
       margin: 0 0 var(--gcds-details-panel-slotted-margin);

--- a/packages/web/src/components/gcds-footer/gcds-footer.css
+++ b/packages/web/src/components/gcds-footer/gcds-footer.css
@@ -2,6 +2,10 @@
   display: block;
   font: var(--gcds-footer-font);
 
+  slot {
+    display: inherit;
+  }
+
   .sub__header,
   .themenav__header,
   .gcds-footer__header {

--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -2,6 +2,10 @@
   display: block;
   margin: var(--gcds-header-margin) !important;
 
+  slot {
+    display: inherit;
+  }
+
   .gcds-header__container {
     justify-content: space-between;
     width: 90%;

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
@@ -3,6 +3,10 @@
 @layer reset {
   :host a {
     box-sizing: border-box;
+
+    slot {
+      display: inherit;
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-phase-banner/gcds-phase-banner.css
+++ b/packages/web/src/components/gcds-phase-banner/gcds-phase-banner.css
@@ -2,6 +2,10 @@
   font: var(--gcds-phase-banner-font);
   line-height: var(--gcds-phase-banner-line-height);
 
+  slot {
+    display: inherit;
+  }
+
   /* Is Fixed */
   &.banner-is-fixed {
     position: sticky;

--- a/packages/web/src/components/gcds-select/gcds-select.css
+++ b/packages/web/src/components/gcds-select/gcds-select.css
@@ -6,6 +6,10 @@
   padding: 0;
   border: 0;
   transition: color ease-in-out .15s;
+  
+  slot {
+    display: inherit;
+  }
 
   &:focus-within {
     color: var(--gcds-select-focus-text);

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
@@ -7,5 +7,9 @@
     height: 0;
     margin: 0;
     overflow: hidden;
+
+    slot {
+      display: inherit;
+    }
   }
 }

--- a/packages/web/src/components/gcds-text/gcds-text.css
+++ b/packages/web/src/components/gcds-text/gcds-text.css
@@ -17,6 +17,10 @@ variants.weight;
       display: inherit;
       box-sizing: border-box;
       margin: 0;
+
+      slot {
+        display: inherit;
+      }
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

To fix the accessibility tree not populating properly in some versions of Chrome, add some default slot styles into component CSS. This was added to any component that could possibly receive static text through a slot, when text is passed in an element it seems to handle it properly.
