### PR TITLE
fix: Change slot CSS in gcds-breadcrumbs to display text underline

### DIFF
--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -24,7 +24,7 @@
       white-space: normal;
 
       slot {
-        display: inherit;
+        display: block;
       }
     }
   }


### PR DESCRIPTION
# Summary | Résumé

With the new slot CSS added to the components, the `gcds-breadcrumbs-items` component no longer had a text underline. Modified the slot CSS to display the underline properly.
