### PR TITLE
fix gcds-link external icon spacing

### DIFF
--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -184,7 +184,7 @@ export class GcdsLink {
             <gcds-icon
               name="external-link"
               label={i18n[lang].external}
-              margin-left="200"
+              margin-left="100"
             />
           ) : download !== undefined ? (
             <gcds-icon

--- a/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
+++ b/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
@@ -34,7 +34,7 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" role="link" tabindex="0">
             <slot></slot>
-            <gcds-icon name="external-link" label="${i18n.en.external}" margin-left="200" />
+            <gcds-icon name="external-link" label="${i18n.en.external}" margin-left="100" />
           </a>
         </mock:shadow-root>
         External Link
@@ -52,7 +52,7 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" role="link" tabindex="0">
             <slot></slot>
-            <gcds-icon name="external-link" label="${i18n.fr.external}" margin-left="200" />
+            <gcds-icon name="external-link" label="${i18n.fr.external}" margin-left="100" />
           </a>
         </mock:shadow-root>
         External Link


### PR DESCRIPTION
# Summary | Résumé

The external icon for the link component was using `margin-left="200"` instead of `margin-left="100"` like the other icons for this component. Fixed the value to `100` to be consistent.