### PR TITLE
Improve storybook a11y

### DIFF
--- a/packages/web/.storybook/manager-head.html
+++ b/packages/web/.storybook/manager-head.html
@@ -1,5 +1,8 @@
 <!-- Load GCDS tokens -->
-<link rel="stylesheet" href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@latest/dist/gcds/gcds.css">
+<link
+  rel="stylesheet"
+  href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@latest/dist/gcds/gcds.css"
+/>
 <style>
   /* ----- SIDEBAR ----- */
   .sidebar-container {
@@ -7,7 +10,8 @@
   }
 
   .sidebar-container .os-content {
-    padding: var(--gcds-spacing-100) var(--gcds-spacing-250) var(--gcds-spacing-400) !important;
+    padding: var(--gcds-spacing-100) var(--gcds-spacing-250)
+      var(--gcds-spacing-400) !important;
   }
 
   /* Sidebar header */
@@ -30,13 +34,13 @@
 
   /* Sidebar subheadings + welcome story */
   .sidebar-subheading,
-  div.sidebar-item[data-item-id="welcome--stories"] {
+  div.sidebar-item[data-item-id='welcome--stories'] {
     margin-block-end: var(--gcds-spacing-250) !important;
     padding-inline: var(--gcds-spacing-400) !important;
   }
 
   .sidebar-subheading,
-  div.sidebar-item[data-item-id="welcome--stories"] a {
+  div.sidebar-item[data-item-id='welcome--stories'] a {
     font-size: 1rem !important;
     font-weight: var(--gcds-font-weights-regular) !important;
     letter-spacing: 0.1rem !important;
@@ -113,7 +117,8 @@
   }
 
   .sidebar-item:hover {
-    background-color: var(--gcds-link-default) !important;
+    background-color: var(--gcds-color-grayscale-0) !important;
+    color: var(--gcds-text-primary) !important;
   }
 
   .sidebar-item svg {
@@ -121,12 +126,14 @@
   }
 
   button.sidebar-item {
-    border-block-start: var(--gcds-border-width-sm) solid rgba(255, 255, 255, .15) !important;
+    border-block-start: var(--gcds-border-width-sm) solid
+      rgba(255, 255, 255, 0.15) !important;
     padding: var(--gcds-spacing-250) var(--gcds-spacing-400) !important;
   }
 
   button.sidebar-item:last-of-type {
-    border-block-start: var(--gcds-border-width-sm) solid rgba(255, 255, 255, .15) !important;
+    border-block-start: var(--gcds-border-width-sm) solid
+      rgba(255, 255, 255, 0.15) !important;
   }
 
   button.sidebar-item span {
@@ -134,23 +141,24 @@
     margin-inline-end: var(--gcds-spacing-150);
   }
 
-  div.sidebar-item:not([data-item-id="welcome--stories"]) {
-    background-color: rgba(255, 255, 255, .1);
+  div.sidebar-item:not([data-item-id='welcome--stories']) {
+    background-color: rgba(255, 255, 255, 0.1);
   }
 
   /* Style selected sidebar item */
-  .sidebar-item[data-selected="true"] {
+  .sidebar-item[data-selected='true'] {
     background-color: var(--gcds-color-grayscale-0) !important;
     color: var(--gcds-color-blue-900) !important;
   }
 
-  button.sidebar-item[aria-expanded="true"] {
-    background-color: rgba(255, 255, 255, .1);
-    border-block-end: var(--gcds-border-width-sm) solid rgba(255, 255, 255, .15) !important;
+  button.sidebar-item[aria-expanded='true'] {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-block-end: var(--gcds-border-width-sm) solid
+      rgba(255, 255, 255, 0.15) !important;
   }
 
   /* Hide all stories from sidebar, except playground story */
-  .sidebar-item[data-nodetype="story"]:not([data-item-id*="playground"]) {
+  .sidebar-item[data-nodetype='story']:not([data-item-id*='playground']) {
     display: none;
   }
 

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -276,7 +276,7 @@
     box-shadow: 0 0 0 var(--gcds-border-width-md) #262626 !important;
     outline-offset: var(--gcds-input-border-width) !important;
     border-color: #262626 !important;
-    outline: var(--gcds-input-outline-width) solid #4d76fb !important;
+    outline: var(--gcds-input-outline-width) solid var(--gcds-color-grayscale-0) !important;
   }
 
   .css-tvcum3 input[type='checkbox']:focus {

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -104,7 +104,7 @@
     outline: var(--gcds-button-shared-focus-outline-width) solid
       var(--gcds-focus-background) !important;
     outline-offset: var(--gcds-button-border-width) !important;
-    box-shadow: none !important;
+    box-shadow: var(--gcds-button-shared-focus-box-shadow);
   }
 
   /* Change props table headings */
@@ -228,7 +228,8 @@
   .css-tvcum3,
   .css-f2g3hl,
   .css-172ajqq,
-  .css-e3ijes {
+  .css-e3ijes,
+  .css-1p58akv {
     background-color: var(--gcds-color-grayscale-700) !important;
     border: var(--gcds-border-width-sm) solid var(--gcds-color-grayscale-0) !important;
     padding: var(--gcds-spacing-50) !important;
@@ -238,7 +239,8 @@
   .css-f2g3hl span,
   .css-172ajqq span,
   .css-e3ijes spa,
-  .css-130cftl {
+  .css-130cftl,
+  .css-1p58akv {
     color: var(--gcds-text-light) !important;
   }
 
@@ -260,6 +262,39 @@
 
   .css-184lgrq {
     background-color: var(--gcds-color-grayscale-700) !important;
+  }
+
+  /* Props table focus styles - form elements */
+  .css-6wu5zk:focus-within {
+    overflow: visible !important;
+  }
+
+  .css-1jvt1oy:focus,
+  .css-1qot2ot:focus,
+  .css-1p58akv:focus,
+  .css-tvcum3:focus-within {
+    box-shadow: 0 0 0 var(--gcds-border-width-md) #262626 !important;
+    outline-offset: var(--gcds-input-border-width) !important;
+    border-color: #262626 !important;
+    outline: var(--gcds-input-outline-width) solid #4d76fb !important;
+  }
+
+  .css-tvcum3 input[type='checkbox']:focus {
+    box-shadow: none !important;
+  }
+
+  /* Props table focus styles - table headings */
+
+  .css-d474as:focus {
+    font-size: 0.75rem;
+    background-color: var(--gcds-focus-background) !important;
+    border-color: var(--gcds-focus-background) !important;
+    color: var(--gcds-focus-text) !important;
+    border-radius: var(--gcds-button-border-radius) !important;
+    outline: var(--gcds-button-shared-focus-outline-width) solid
+      var(--gcds-focus-background) !important;
+    outline-offset: var(--gcds-button-border-width) !important;
+    box-shadow: var(--gcds-button-shared-focus-box-shadow);
   }
 
   /* Canvas preview */

--- a/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
@@ -7,7 +7,8 @@ export default {
     // Props
     hideCanadaLink: {
       name: 'hide-canada-link',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
+++ b/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
@@ -29,7 +29,8 @@ export default {
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
@@ -53,7 +53,7 @@ export default {
       },
     },
     type: {
-      control: 'radio',
+      control: 'select',
       options: ['link', 'action'],
       table: {
         type: { summary: 'string' },
@@ -61,7 +61,7 @@ export default {
       },
     },
     titleElement: {
-      control: 'radio',
+      control: 'select',
       options: ['h3', 'h4', 'h5', 'h6', 'a'],
       table: {
         type: { summary: 'string' },

--- a/packages/web/src/components/gcds-checkbox/stories/gcds-checkbox.stories.tsx
+++ b/packages/web/src/components/gcds-checkbox/stories/gcds-checkbox.stories.tsx
@@ -37,14 +37,16 @@ export default {
       },
     },
     checked: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -76,7 +78,8 @@ export default {
       },
     },
     required: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
+++ b/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
@@ -4,14 +4,16 @@ export default {
   argTypes: {
     // Props
     border: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
       },
     },
     centered: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
+++ b/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
@@ -15,7 +15,8 @@ export default {
       },
     },
     open: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
+++ b/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
@@ -37,7 +37,7 @@ const Template = args =>
   `
 <!-- Web component code (Angular, Vue) -->
 <gcds-error-summary
-  ${args.listen && args.errorLinks ? `listen` : null}
+  ${args.listen && !args.errorLinks ? `listen` : null}
   ${args.errorLinks ? `error-links='${args.errorLinks}'` : null}
   ${args.heading ? `heading="${args.heading}"` : null}
 >
@@ -45,7 +45,7 @@ const Template = args =>
 
 <!-- React code -->
 <GcdsErrorSummary
-  ${args.listen && args.errorLinks ? `listen` : null}
+  ${args.listen && !args.errorLinks ? `listen` : null}
   ${args.errorLinks ? `errorLinks='${args.errorLinks}'` : null}
   ${args.heading ? `heading="${args.heading}"` : null}
 >
@@ -54,7 +54,7 @@ const Template = args =>
 
 const TemplatePlayground = args => `
 <gcds-error-summary
-  ${args.listen && args.errorLinks ? `listen` : null}
+  ${args.listen && !args.errorLinks ? `listen` : null}
   ${args.errorLinks ? `error-links='${args.errorLinks}'` : null}
   ${args.heading ? `heading="${args.heading}"` : null}
 >

--- a/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
+++ b/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
@@ -6,7 +6,8 @@ export default {
   argTypes: {
     // Props
     listen: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: true },
@@ -36,7 +37,7 @@ const Template = args =>
   `
 <!-- Web component code (Angular, Vue) -->
 <gcds-error-summary
-  ${args.listen && !args.errorLinks ? `listen` : null}
+  ${args.listen && args.errorLinks ? `listen` : null}
   ${args.errorLinks ? `error-links='${args.errorLinks}'` : null}
   ${args.heading ? `heading="${args.heading}"` : null}
 >
@@ -44,7 +45,7 @@ const Template = args =>
 
 <!-- React code -->
 <GcdsErrorSummary
-  ${args.listen && !args.errorLinks ? `listen` : null}
+  ${args.listen && args.errorLinks ? `listen` : null}
   ${args.errorLinks ? `errorLinks='${args.errorLinks}'` : null}
   ${args.heading ? `heading="${args.heading}"` : null}
 >
@@ -53,7 +54,7 @@ const Template = args =>
 
 const TemplatePlayground = args => `
 <gcds-error-summary
-  ${args.listen && !args.errorLinks ? `listen` : null}
+  ${args.listen && args.errorLinks ? `listen` : null}
   ${args.errorLinks ? `error-links='${args.errorLinks}'` : null}
   ${args.heading ? `heading="${args.heading}"` : null}
 >

--- a/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
+++ b/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
@@ -37,7 +37,8 @@ export default {
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -59,7 +60,8 @@ export default {
       },
     },
     required: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
+++ b/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
@@ -23,7 +23,8 @@ export default {
       },
     },
     multiple: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: '-' },
@@ -41,7 +42,8 @@ export default {
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -73,7 +75,8 @@ export default {
       },
     },
     required: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-footer/stories/gcds-footer.stories.tsx
+++ b/packages/web/src/components/gcds-footer/stories/gcds-footer.stories.tsx
@@ -6,7 +6,7 @@ export default {
   argTypes: {
     // Props
     display: {
-      control: 'radio',
+      control: 'select',
       options: ['compact', 'full'],
       table: {
         type: { summary: 'string' },

--- a/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
+++ b/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
@@ -29,7 +29,8 @@ export default {
     },
     signatureHasLink: {
       name: 'signature-has-link',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: true },
@@ -37,7 +38,7 @@ export default {
     },
     signatureVariant: {
       name: 'signature-variant',
-      control: 'radio',
+      control: 'select',
       options: ['colour', 'white'],
       table: {
         type: { summary: 'string' },
@@ -185,6 +186,7 @@ Default.args = {
   menu: '',
   breadcrumb: '',
   search: '',
+  skipTo: '',
   toggle: '',
   banner: '',
   lang: 'en',
@@ -263,6 +265,7 @@ Playground.args = {
   menu: '',
   breadcrumb: '',
   search: '',
+  skipTo: '',
   toggle: '',
   banner: '',
   lang: 'en',

--- a/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
+++ b/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
@@ -16,7 +16,8 @@ export default {
     },
     characterLimit: {
       name: 'character-limit',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: true },

--- a/packages/web/src/components/gcds-icon/stories/gcds-icon.stories.tsx
+++ b/packages/web/src/components/gcds-icon/stories/gcds-icon.stories.tsx
@@ -83,7 +83,8 @@ export default {
     },
     fixedWidth: {
       name: 'fixed-width',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -336,7 +337,7 @@ const TemplatePlayground = args => `
 
 export const Default = Template.bind({});
 Default.args = {
-  name: 'tree',
+  name: 'close',
   size: 'text',
   iconStyle: 'solid',
 };
@@ -345,7 +346,7 @@ Default.args = {
 
 export const Name = TemplateMultiple.bind({});
 Name.args = {
-  name1: 'times',
+  name1: 'close',
   name2: 'external-link',
   name3: 'caret-up',
   name4: 'caret-down',
@@ -369,15 +370,15 @@ Name.args = {
 
 export const Sizes = TemplateMultiple.bind({});
 Sizes.args = {
-  name1: 'tree',
-  name2: 'tree',
-  name3: 'tree',
-  name4: 'tree',
-  name5: 'tree',
-  name6: 'tree',
-  name7: 'tree',
-  name8: 'tree',
-  name9: 'tree',
+  name1: 'close',
+  name2: 'close',
+  name3: 'close',
+  name4: 'close',
+  name5: 'close',
+  name6: 'close',
+  name7: 'close',
+  name8: 'close',
+  name9: 'close',
   size1: 'inherit',
   size2: 'caption',
   size3: 'text',
@@ -393,7 +394,7 @@ Sizes.args = {
 
 export const MarginLeft = TemplateMargin.bind({});
 MarginLeft.args = {
-  name: 'tree',
+  name: 'close',
   marginLeft0: '0',
   marginLeft50: '50',
   marginLeft100: '100',
@@ -416,7 +417,7 @@ MarginLeft.args = {
 
 export const MarginRight = TemplateMargin.bind({});
 MarginRight.args = {
-  name: 'tree',
+  name: 'close',
   marginRight0: '0',
   marginRight50: '50',
   marginRight100: '100',
@@ -464,7 +465,7 @@ Props.args = {
   fixedWidth: false,
   iconStyle: 'solid',
   label: '',
-  name: 'tree',
+  name: 'close',
   size: 'text',
 };
 
@@ -477,6 +478,6 @@ Playground.args = {
   label: '',
   marginLeft: '0',
   marginRight: '0',
-  name: 'tree',
+  name: 'close',
   size: 'text',
 };

--- a/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
+++ b/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
@@ -17,7 +17,8 @@ export default {
     // Props
     hideLabel: {
       name: 'hide-label',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -58,7 +59,8 @@ export default {
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -90,7 +92,8 @@ export default {
       },
     },
     required: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -329,7 +332,7 @@ Props.args = {
   errorMessage: '',
   required: false,
   disabled: false,
-  size: '',
+  size: null,
   value: '',
   lang: 'en',
   autocomplete: 'off',

--- a/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
+++ b/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
@@ -37,7 +37,8 @@ export default {
     },
     open: {
       name: 'open',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
+++ b/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
@@ -16,7 +16,8 @@ export default {
     },
     current: {
       name: 'current',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
+++ b/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
@@ -17,7 +17,7 @@ export default {
       },
     },
     display: {
-      control: 'radio',
+      control: 'select',
       options: ['list', 'simple'],
       table: {
         type: { summary: 'string' },

--- a/packages/web/src/components/gcds-radio/stories/gcds-radio.stories.tsx
+++ b/packages/web/src/components/gcds-radio/stories/gcds-radio.stories.tsx
@@ -34,14 +34,16 @@ export default {
       },
     },
     checked: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -65,7 +67,8 @@ export default {
       },
     },
     required: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-search/stories/gcds-search.stories.tsx
+++ b/packages/web/src/components/gcds-search/stories/gcds-search.stories.tsx
@@ -30,7 +30,7 @@ export default {
       },
     },
     method: {
-      control: 'radio',
+      control: 'select',
       options: ['get', 'post'],
       table: {
         type: { summary: 'string' },

--- a/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
+++ b/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
@@ -35,7 +35,8 @@ export default {
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -67,7 +68,8 @@ export default {
       },
     },
     required: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -6,7 +6,7 @@ export default {
   argTypes: {
     // Props
     type: {
-      control: 'radio',
+      control: 'select',
       options: ['signature', 'wordmark'],
       table: {
         type: { summary: 'string' },
@@ -14,14 +14,15 @@ export default {
       },
     },
     hasLink: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
       },
     },
     variant: {
-      control: 'radio',
+      control: 'select',
       options: ['colour', 'white'],
       table: {
         type: { summary: 'string' },
@@ -35,23 +36,21 @@ export default {
 const Template = args =>
   `
 <!-- Web component code (Angular, Vue) -->
-<gcds-signature
-  ${args.type != 'signature' ? `type="${args.type}"` : null}
-  ${args.hasLink != 'false' ? `has-link="${args.hasLink}"` : null}
-  ${args.variant != 'colour' ? `variant="${args.variant}"` : null}
-  ${args.lang != 'en' ? `lang="${args.lang}"` : null}
->
+<gcds-signature ${args.type != 'signature' ? `type="${args.type}"` : null} ${
+    args.hasLink != false ? `has-link="${args.hasLink}"` : null
+  } ${args.variant != 'colour' ? `variant="${args.variant}"` : null} ${
+    args.lang != 'en' ? `lang="${args.lang}"` : null
+  }>
 </gcds-signature>
 
 <!-- React code -->
-<GcdsSignature
-  ${args.type != 'signature' ? `type="${args.type}"` : null}
-  ${args.hasLink != 'false' ? `hasLink="${args.hasLink}"` : null}
-  ${args.variant != 'colour' ? `variant="${args.variant}"` : null}
-  ${args.lang != 'en' ? `lang="${args.lang}"` : null}
->
+<GcdsSignature ${args.type != 'signature' ? `type="${args.type}"` : null} ${
+    args.hasLink != false ? `hasLink="${args.hasLink}"` : null
+  } ${args.variant != 'colour' ? `variant="${args.variant}"` : null} ${
+    args.lang != 'en' ? `lang="${args.lang}"` : null
+  }>
 </GcdsSignature>
-`.replace(/\s\snull\n/g, '');
+`.replace(/ null/g, '');
 
 const TemplatePlayground = args => `
 <gcds-signature
@@ -66,7 +65,7 @@ const TemplatePlayground = args => `
 export const Default = Template.bind({});
 Default.args = {
   type: 'signature',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'colour',
   lang: 'en',
 };
@@ -74,7 +73,7 @@ Default.args = {
 export const Wordmark = Template.bind({});
 Wordmark.args = {
   type: 'wordmark',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'colour',
   lang: 'en',
 };
@@ -82,7 +81,7 @@ Wordmark.args = {
 export const SignatureFrench = Template.bind({});
 SignatureFrench.args = {
   type: 'signature',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'colour',
   lang: 'fr',
 };
@@ -90,7 +89,7 @@ SignatureFrench.args = {
 export const WordmarkFrench = Template.bind({});
 WordmarkFrench.args = {
   type: 'wordmark',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'colour',
   lang: 'fr',
 };
@@ -106,7 +105,7 @@ HasLinkTrue.args = {
 export const SignatureWhite = Template.bind({});
 SignatureWhite.args = {
   type: 'signature',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'white',
   lang: 'en',
 };
@@ -114,7 +113,7 @@ SignatureWhite.args = {
 export const WordmarkWhite = Template.bind({});
 WordmarkWhite.args = {
   type: 'wordmark',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'white',
   lang: 'en',
 };
@@ -122,7 +121,7 @@ WordmarkWhite.args = {
 export const Props = Template.bind({});
 Props.args = {
   type: 'signature',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'colour',
   lang: 'en',
 };
@@ -130,7 +129,7 @@ Props.args = {
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   type: 'signature',
-  hasLink: 'false',
+  hasLink: false,
   variant: 'colour',
   lang: 'en',
 };

--- a/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
+++ b/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
@@ -5,7 +5,8 @@ export default {
     // Props
     characterLimit: {
       name: 'character-limit',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: true },

--- a/packages/web/src/components/gcds-textarea/stories/gcds-textarea.stories.tsx
+++ b/packages/web/src/components/gcds-textarea/stories/gcds-textarea.stories.tsx
@@ -17,7 +17,8 @@ export default {
     // Props
     hideLabel: {
       name: 'hide-label',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -50,7 +51,8 @@ export default {
       },
     },
     disabled: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -82,7 +84,8 @@ export default {
       },
     },
     required: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },

--- a/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
+++ b/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
@@ -17,7 +17,7 @@ export default {
       },
     },
     alignment: {
-      control: { type: 'radio' },
+      control: { type: 'select' },
       options: ['right', 'left', 'center'],
       table: {
         type: { summary: 'string' },

--- a/packages/web/src/components/gcds-topic-menu/stories/gcds-topic-menu.stories.tsx
+++ b/packages/web/src/components/gcds-topic-menu/stories/gcds-topic-menu.stories.tsx
@@ -6,7 +6,8 @@ export default {
   argTypes: {
     // Props
     home: {
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },
@@ -19,19 +20,17 @@ export default {
 const Template = args =>
   `
 <!-- Web component code (Angular, Vue) -->
-<gcds-topic-menu
-  ${args.home ? `home` : null}
-  ${args.lang != 'en' ? `lang="${args.lang}"` : null}
->
+<gcds-topic-menu ${args.home ? `home` : null} ${
+    args.lang != 'en' ? `lang="${args.lang}"` : null
+  }>
 </gcds-topic-menu>
 
 <!-- React code -->
-<GcdsTopicMenu
-  ${args.home ? `home` : null}
-  ${args.lang != 'en' ? `lang="${args.lang}"` : null}
->
+<GcdsTopicMenu ${args.home ? `home` : null} ${
+    args.lang != 'en' ? `lang="${args.lang}"` : null
+  }>
 </GcdsTopicMenu>
-`.replace(/\s\snull\n/g, '');
+`.replace(/ null/g, '');
 
 const TemplatePlayground = args => `
 <gcds-topic-menu

--- a/packages/web/src/components/gcds-verify-banner/stories/gcds-verify-banner.stories.tsx
+++ b/packages/web/src/components/gcds-verify-banner/stories/gcds-verify-banner.stories.tsx
@@ -15,7 +15,8 @@ export default {
     },
     isFixed: {
       name: 'is-fixed',
-      control: 'boolean',
+      control: { type: 'select' },
+      options: [false, true],
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: false },


### PR DESCRIPTION
# Summary | Résumé

In our last round of Fable testing, some users pointed out that it was really hard to see where the focus was when interacting with our live demo control elements. I updated the focus to be much more visible.

The users also pointed out that it was difficult/impossible to use the control toggles as they aren't coded accessibly by Storybook and therefore the labels don't get read aloud properly. After testing Storybook's radio buttons, I realized that those weren't coded properly either. Because of the poor accessibility of toggles and radio buttons within Storybook, I switched all toggles and radio buttons in our stories to use selects as this seems to be the only accessible option available.