### PR TITLE
Update stencil configuration for better build

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -16,7 +16,6 @@
     "outDir": "dist",
     "removeComments": false,
     "skipLibCheck": true,
-    "sourceMap": true,
     "jsx": "react",
     "target": "es2015"
   },

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^4.0.0",
+        "@stencil/core": "^4.7.2",
         "@stencil/react-output-target": "^0.5.3",
         "@storybook/addon-a11y": "^7.4.0",
         "@storybook/addons": "^7.4.0",
@@ -5139,9 +5139,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.7.0.tgz",
-      "integrity": "sha512-hl3hD5FA8F9kZiDJSus08Kno1QRl+fXeMBzrl5DjWAzAu0JHxL1AqTph5oQSekjvkSahaa8JtsXnHRZU93eivg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.7.2.tgz",
+      "integrity": "sha512-sPPDYrXiTbfeUF5CCyfqysXK/yfTHC4xYR1+nHzGkS2vhRSBOLp0oPuB+xkJLKA+K2ZqDJUxpOnDxy1CLWwBXA==",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,7 @@
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/types/components.d.ts",
+  "types": "dist/types/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/stencil-starter-project-name/stencil-starter-project-name.esm.js",
@@ -32,7 +32,7 @@
     "lint-and-fix": "eslint . --fix"
   },
   "dependencies": {
-    "@stencil/core": "^4.0.0",
+    "@stencil/core": "^4.7.2",
     "@stencil/react-output-target": "^0.5.3",
     "@storybook/addon-a11y": "^7.4.0",
     "@storybook/addons": "^7.4.0",

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -23,6 +23,7 @@ export const config: Config = {
     {
       type: 'dist',
       esmLoaderPath: '../loader',
+      isPrimaryPackageOutputTarget: true,
     },
     {
       type: 'dist-custom-elements',
@@ -44,8 +45,8 @@ export const config: Config = {
     },
     setupFiles: ['./src/utils/test/setupMock.js'],
   },
-  buildEs5: 'prod',
+  validatePrimaryPackageOutputTarget: true,
   extras: {
-    experimentalImportInjection: true,
+    enableImportInjection: true,
   },
 };


### PR DESCRIPTION
# Summary | Résumé

Update stencil to `v4.7.2` and the update and remove some configuration properties in `stencil.config.ts`.

- Added `validatePrimaryPackageOutputTarget` to validate package on build
- Remove `buildEs5` as it was causing issues with some frameworks
- Updated `experimentalImportInjection` to `enableImportInjection` as it is no longer experimental
- Removed `"sourceMaps": true` from `tsconfig` in react package to hopefully stop warnings when using components in `create-react-app`. This will also decrease the package size.
