### PR TITLE
fix: change slot styles to initial

### DIFF
--- a/packages/web/src/components/gcds-alert/gcds-alert.css
+++ b/packages/web/src/components/gcds-alert/gcds-alert.css
@@ -7,7 +7,7 @@
   border-inline-start: var(--gcds-alert-border-width) solid transparent;
 
   slot {
-    display: inherit;
+    display: initial;
   }
 
   /* Is Fixed */
@@ -140,8 +140,10 @@
     &:focus {
       border-color: var(--gcds-alert-button-focus-background);
       background-color: var(--gcds-alert-button-focus-background);
-      box-shadow: 0 0 0 var(--gcds-alert-button-border-width) var(--gcds-alert-button-focus-text);
-      outline: var(--gcds-alert-button-outline-width) solid var(--gcds-alert-button-focus-background);
+      box-shadow: 0 0 0 var(--gcds-alert-button-border-width)
+        var(--gcds-alert-button-focus-text);
+      outline: var(--gcds-alert-button-outline-width) solid
+        var(--gcds-alert-button-focus-background);
       outline-offset: var(--gcds-alert-button-border-width);
       color: var(--gcds-alert-button-focus-text);
     }

--- a/packages/web/src/components/gcds-button/gcds-button.css
+++ b/packages/web/src/components/gcds-button/gcds-button.css
@@ -13,7 +13,7 @@
   transition: all 0.15s ease-in-out;
 
   slot {
-    display: inherit;
+    display: initial;
   }
 
   /* Button Role Styles */
@@ -28,7 +28,8 @@
     &:focus {
       background-color: var(--gcds-button-shared-focus-background);
       color: var(--gcds-button-shared-focus-text);
-      outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
+      outline: var(--gcds-button-shared-focus-outline-width) solid
+        var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
       box-shadow: var(--gcds-button-shared-focus-box-shadow);
@@ -51,7 +52,8 @@
     &:focus {
       background-color: var(--gcds-button-shared-focus-background);
       color: var(--gcds-button-shared-focus-text);
-      outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
+      outline: var(--gcds-button-shared-focus-outline-width) solid
+        var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
       box-shadow: var(--gcds-button-shared-focus-box-shadow);
@@ -77,7 +79,8 @@
     &:focus {
       background-color: var(--gcds-button-shared-focus-background);
       color: var(--gcds-button-shared-focus-text);
-      outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
+      outline: var(--gcds-button-shared-focus-outline-width) solid
+        var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
       box-shadow: var(--gcds-button-shared-focus-box-shadow);
@@ -101,19 +104,24 @@
       text-decoration: underline;
       text-underline-offset: 0.2em;
       text-decoration-color: currentColor;
-      text-decoration-thickness: var(--gcds-button-text-only-default-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-button-text-only-default-decoration-thickness
+      );
     }
 
     &:hover {
       background-color: var(--gcds-button-text-only-default-background);
       color: var(--gcds-button-text-only-hover-text);
-      text-decoration-thickness: var(--gcds-button-text-only-hover-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-button-text-only-hover-decoration-thickness
+      );
     }
 
     &:focus {
       background-color: var(--gcds-button-shared-focus-background);
       color: var(--gcds-button-shared-focus-text);
-      outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
+      outline: var(--gcds-button-shared-focus-outline-width) solid
+        var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
       box-shadow: var(--gcds-button-shared-focus-box-shadow);
@@ -145,7 +153,8 @@
     &:focus {
       background-color: var(--gcds-button-shared-focus-background);
       color: var(--gcds-button-shared-focus-text);
-      outline: var(--gcds-button-shared-focus-outline-width) solid var(--gcds-button-shared-focus-background);
+      outline: var(--gcds-button-shared-focus-outline-width) solid
+        var(--gcds-button-shared-focus-background);
       outline-offset: var(--gcds-button-border-width);
       border-color: var(--gcds-button-shared-focus-background);
       box-shadow: var(--gcds-button-shared-focus-box-shadow);

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -11,7 +11,7 @@
 @layer defaults {
   :host {
     display: block;
-  
+
     .gcds-card {
       border: var(--gcds-card-border);
       border-radius: var(--gcds-card-border-radius);
@@ -35,17 +35,19 @@
         font: var(--gcds-card-tag-font);
         color: var(--gcds-card-tag-color);
       }
-  
+
       .gcds-card__title,
       .gcds-card__title > a {
         color: var(--gcds-card-title-color);
         font: var(--gcds-card-title-font);
         text-underline-offset: var(--gcds-card-title-text-underline-offset);
         text-decoration-color: currentColor;
-        text-decoration-thickness: var(--gcds-card-title-text-decoration-thickness);
+        text-decoration-thickness: var(
+          --gcds-card-title-text-decoration-thickness
+        );
         width: fit-content;
       }
-  
+
       .gcds-card__description {
         max-width: var(--gcds-card-description-max-width);
       }
@@ -84,12 +86,12 @@
         left: 0;
         z-index: 1;
         pointer-events: auto;
-        content: "";
+        content: '';
       }
     }
 
     slot {
-      display: inherit;
+      display: initial;
     }
   }
 }
@@ -104,14 +106,18 @@
       .gcds-card__title > a,
       a.gcds-card__title {
         color: var(--gcds-card-hover-title-color);
-        text-decoration-thickness: var(--gcds-card-hover-title-text-decoration-thickness);
+        text-decoration-thickness: var(
+          --gcds-card-hover-title-text-decoration-thickness
+        );
       }
     }
 
     .gcds-card__title > a:hover,
     a.gcds-card__title:hover {
       color: var(--gcds-card-hover-title-color);
-      text-decoration-thickness: var(--gcds-card-hover-title-text-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-card-hover-title-text-decoration-thickness
+      );
     }
   }
 }

--- a/packages/web/src/components/gcds-container/gcds-container.css
+++ b/packages/web/src/components/gcds-container/gcds-container.css
@@ -5,7 +5,7 @@
   box-sizing: border-box;
 
   slot {
-    display: inherit;
+    display: initial;
   }
 
   /* Container border */

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -5,7 +5,9 @@
     display: block;
     padding: var(--gcds-details-summary-padding);
     color: var(--gcds-details-default-text);
-    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+    transition:
+      background-color 0.15s ease-in-out,
+      color 0.15s ease-in-out;
     border-color: transparent;
     background-color: transparent;
     font: var(--gcds-details-font);
@@ -40,17 +42,20 @@
       width: 0;
       height: 0;
       content: '';
-      border-block-start: var(--gcds-details-summary-arrow-border-top-bottom) solid transparent;
-      border-block-end: var(--gcds-details-summary-arrow-border-top-bottom) solid transparent;
-      border-inline-start: var(--gcds-details-summary-arrow-border-left) solid currentColor;
+      border-block-start: var(--gcds-details-summary-arrow-border-top-bottom)
+        solid transparent;
+      border-block-end: var(--gcds-details-summary-arrow-border-top-bottom)
+        solid transparent;
+      border-inline-start: var(--gcds-details-summary-arrow-border-left) solid
+        currentColor;
       transition: transform 0.15s ease-in-out;
     }
 
-    &[aria-expanded=false] + .details__panel {
+    &[aria-expanded='false'] + .details__panel {
       display: none;
     }
 
-    &[aria-expanded=true]::before {
+    &[aria-expanded='true']::before {
       transform: rotate(90deg);
     }
   }
@@ -58,10 +63,11 @@
   .details__panel {
     margin: var(--gcds-details-panel-margin);
     padding: var(--gcds-details-panel-padding);
-    border-inline-start: var(--gcds-details-panel-border-width) solid var(--gcds-details-panel-border-color);
+    border-inline-start: var(--gcds-details-panel-border-width) solid
+      var(--gcds-details-panel-border-color);
 
     slot {
-      display: inherit;
+      display: initial;
     }
 
     ::slotted(*) {

--- a/packages/web/src/components/gcds-footer/gcds-footer.css
+++ b/packages/web/src/components/gcds-footer/gcds-footer.css
@@ -3,7 +3,7 @@
   font: var(--gcds-footer-font);
 
   slot {
-    display: inherit;
+    display: initial;
   }
 
   .sub__header,
@@ -86,7 +86,8 @@
 
     nav {
       &:first-of-type::after {
-        border-bottom: var(--gcds-footer-main-nav-first-after-border-width) solid var(--gcds-footer-main-nav-first-after-border-color);
+        border-bottom: var(--gcds-footer-main-nav-first-after-border-width)
+          solid var(--gcds-footer-main-nav-first-after-border-color);
         content: '';
         display: block;
         width: var(--gcds-footer-main-nav-first-after-width);
@@ -177,7 +178,9 @@
           color: var(--gcds-footer-sub-hover-text);
           text-underline-offset: 0.2em;
           text-decoration: underline;
-          text-decoration-thickness: var(--gcds-footer-sub-hover-decoration-thickness);
+          text-decoration-thickness: var(
+            --gcds-footer-sub-hover-decoration-thickness
+          );
         }
 
         &:focus {

--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -3,7 +3,7 @@
   margin: var(--gcds-header-margin) !important;
 
   slot {
-    display: inherit;
+    display: initial;
   }
 
   .gcds-header__container {
@@ -14,7 +14,8 @@
   }
 
   .gcds-header__brand {
-    border-block-end: var(--gcds-header-brand-border-width) solid var(--gcds-header-brand-border-color);
+    border-block-end: var(--gcds-header-brand-border-width) solid
+      var(--gcds-header-brand-border-color);
     padding: var(--gcds-header-brand-padding);
     margin: var(--gcds-header-brand-margin);
 
@@ -23,29 +24,28 @@
       grid-gap: var(--gcds-header-brand-grid-gap);
       grid-template-columns: 1fr 0.1fr;
       grid-template-areas:
-        "signature toggle"
-        "search search";
+        'signature toggle'
+        'search search';
       width: 90%;
       max-width: var(--gcds-header-container-max-width);
       margin: 0 auto;
 
       &.container--simple {
-        grid-template-areas:
-          "signature toggle";
+        grid-template-areas: 'signature toggle';
       }
 
       .brand__toggle,
-      slot[name="toggle"] {
+      slot[name='toggle'] {
         grid-area: toggle;
         text-align: right;
       }
 
       .brand__signature,
-      slot[name="signature"] {
+      slot[name='signature'] {
         grid-area: signature;
 
         gcds-signature {
-          margin: var( --gcds-header-brand-signature-margin);
+          margin: var(--gcds-header-brand-signature-margin);
         }
       }
 
@@ -53,19 +53,18 @@
         grid-area: search;
         max-width: 100%;
         display: block;
-
       }
     }
 
     @media screen and (min-width: 64em) {
       .brand__container {
         grid-template-areas:
-          "toggle toggle"
-          "signature search";
+          'toggle toggle'
+          'signature search';
         grid-template-columns: 1fr 1fr;
 
         .brand__search,
-        slot[name="search"] {
+        slot[name='search'] {
           width: fit-content;
           margin-inline-start: auto;
         }

--- a/packages/web/src/components/gcds-heading/gcds-heading.css
+++ b/packages/web/src/components/gcds-heading/gcds-heading.css
@@ -18,7 +18,7 @@ variants;
     }
 
     slot {
-      display: inherit;
+      display: initial;
     }
   }
 }

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
@@ -15,7 +15,9 @@
     text-decoration: underline;
     text-underline-offset: 0.2em;
     text-decoration-color: currentColor;
-    text-decoration-thickness: var(--gcds-lang-toggle-default-decoration-thickness);
+    text-decoration-thickness: var(
+      --gcds-lang-toggle-default-decoration-thickness
+    );
 
     span {
       display: none;
@@ -28,7 +30,9 @@
 
     &:hover {
       color: var(--gcds-lang-toggle-hover-text);
-      text-decoration-thickness: var(--gcds-lang-toggle-hover-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-lang-toggle-hover-decoration-thickness
+      );
     }
 
     &:focus {
@@ -47,7 +51,7 @@
       padding: 0;
 
       span {
-        display: inherit;
+        display: initial;
       }
 
       abbr {

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
@@ -5,7 +5,7 @@
     box-sizing: border-box;
 
     slot {
-      display: inherit;
+      display: initial;
     }
   }
 }
@@ -14,7 +14,8 @@
   :host a {
     display: flex;
     font: var(---gcds-nav-link-font);
-    text-decoration: underline solid currentColor var(--gcds-nav-link-default-decoration-thickness);
+    text-decoration: underline solid currentColor
+      var(--gcds-nav-link-default-decoration-thickness);
     text-underline-offset: var(--gcds-nav-link-default-underline-offset);
     color: var(--gcds-nav-link-default-text);
     margin-block-end: var(--gcds-nav-link-margin);
@@ -68,7 +69,9 @@
 @layer state.hover {
   @media (hover: hover) {
     :host a:hover {
-      text-decoration-thickness: var(--gcds-nav-link-hover-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-nav-link-hover-decoration-thickness
+      );
       color: var(--gcds-nav-link-hover-text);
     }
 

--- a/packages/web/src/components/gcds-phase-banner/gcds-phase-banner.css
+++ b/packages/web/src/components/gcds-phase-banner/gcds-phase-banner.css
@@ -3,7 +3,7 @@
   line-height: var(--gcds-phase-banner-line-height);
 
   slot {
-    display: inherit;
+    display: initial;
   }
 
   /* Is Fixed */

--- a/packages/web/src/components/gcds-select/gcds-select.css
+++ b/packages/web/src/components/gcds-select/gcds-select.css
@@ -5,10 +5,10 @@
   margin: 0;
   padding: 0;
   border: 0;
-  transition: color ease-in-out .15s;
-  
+  transition: color ease-in-out 0.15s;
+
   slot {
-    display: inherit;
+    display: initial;
   }
 
   &:focus-within {
@@ -38,7 +38,7 @@
   border: var(--gcds-select-border-width) solid currentColor;
   border-radius: var(--gcds-select-border-radius);
   box-sizing: border-box;
-  transition: all ease-in-out .15s;
+  transition: all ease-in-out 0.15s;
 
   /* Select arrow */
   -webkit-appearance: none;
@@ -50,7 +50,8 @@
 
   &:focus {
     border-color: var(--gcds-select-focus-text);
-    outline: var(--gcds-select-outline-width) solid var(--gcds-select-focus-text);
+    outline: var(--gcds-select-outline-width) solid
+      var(--gcds-select-focus-text);
     outline-offset: var(--gcds-select-border-width);
     box-shadow: var(--gcds-select-focus-box-shadow);
   }

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
@@ -9,7 +9,7 @@
     overflow: hidden;
 
     slot {
-      display: inherit;
+      display: initial;
     }
   }
 }

--- a/packages/web/src/components/gcds-text/gcds-text.css
+++ b/packages/web/src/components/gcds-text/gcds-text.css
@@ -19,7 +19,7 @@ variants.weight;
       margin: 0;
 
       slot {
-        display: inherit;
+        display: initial;
       }
     }
   }


### PR DESCRIPTION
# Summary | Résumé

We added slot styles a few weeks ago to fix a Chrome bug that kept the accessibility tree from populating properly. Setting the slot style to `inherit` was causing some issues with links not displaying the underline in a few places. Changing the slot styles to `initial` to prevent that issue.

The linter also added a few formatting updates :) 
