### PR TITLE
fix: Move use of window out of componentWillLoad and ComponentDidLoad

### DIFF
--- a/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
+++ b/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
@@ -47,6 +47,37 @@ export class GcdsSideNav {
    */
   @State() navSize: 'desktop' | 'mobile';
 
+  @Listen('focusin', { target: 'document' })
+  async focusInListener(e) {
+    if (this.el.contains(e.target) && !this.navSize) {
+      const mediaQuery = window.matchMedia('screen and (min-width: 64em)');
+      const nav = this.el as HTMLGcdsSideNavElement;
+      const mobileTrigger = this.mobile;
+
+      if (mediaQuery.matches) {
+        this.navSize = 'desktop';
+      } else {
+        this.navSize = 'mobile';
+      }
+
+      await this.updateNavItemQueue(this.el);
+
+      mediaQuery.addEventListener('change', async function (e) {
+        if (e.matches) {
+          nav.updateNavSize('desktop');
+          await nav.updateNavItemQueue(nav);
+
+          if (mobileTrigger.hasAttribute('open')) {
+            mobileTrigger.toggleNav();
+          }
+        } else {
+          nav.updateNavSize('mobile');
+          await nav.updateNavItemQueue(nav);
+        }
+      });
+    }
+  }
+
   @Listen('focusout', { target: 'document' })
   async focusOutListener(e) {
     if (!this.el.contains(e.relatedTarget)) {
@@ -132,36 +163,6 @@ export class GcdsSideNav {
     this.lang = assignLanguage(this.el);
 
     this.updateLang();
-
-    const mediaQuery = window.matchMedia('screen and (min-width: 64em)');
-
-    if (mediaQuery.matches) {
-      this.navSize = 'desktop';
-    } else {
-      this.navSize = 'mobile';
-    }
-  }
-
-  async componentDidLoad() {
-    const mediaQuery = window.matchMedia('screen and (min-width: 64em)');
-    const nav = this.el as HTMLGcdsSideNavElement;
-    const mobileTrigger = this.mobile;
-
-    await this.updateNavItemQueue(this.el);
-
-    mediaQuery.addEventListener('change', async function (e) {
-      if (e.matches) {
-        nav.updateNavSize('desktop');
-        await nav.updateNavItemQueue(nav);
-
-        if (mobileTrigger.hasAttribute('open')) {
-          mobileTrigger.toggleNav();
-        }
-      } else {
-        nav.updateNavSize('mobile');
-        await nav.updateNavItemQueue(nav);
-      }
-    });
   }
 
   render() {

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
@@ -52,6 +52,37 @@ export class GcdsTopNav {
    */
   @State() navSize: 'desktop' | 'mobile';
 
+  @Listen('focusin', { target: 'document' })
+  async focusInListener(e) {
+    if (this.el.contains(e.target) && !this.navSize) {
+      const mediaQuery = window.matchMedia('screen and (min-width: 64em)');
+      const nav = this.el as HTMLGcdsTopNavElement;
+      const mobileTrigger = this.mobile;
+
+      if (mediaQuery.matches) {
+        this.navSize = 'desktop';
+      } else {
+        this.navSize = 'mobile';
+      }
+
+      await this.updateNavItemQueue(this.el);
+
+      mediaQuery.addEventListener('change', async function (e) {
+        if (e.matches) {
+          nav.updateNavSize('desktop');
+          await nav.updateNavItemQueue(nav);
+
+          if (mobileTrigger.hasAttribute('open')) {
+            mobileTrigger.toggleNav();
+          }
+        } else {
+          nav.updateNavSize('mobile');
+          await nav.updateNavItemQueue(nav);
+        }
+      });
+    }
+  }
+
   @Listen('focusout', { target: 'document' })
   async focusOutListener(e) {
     if (!this.el.contains(e.relatedTarget)) {
@@ -148,36 +179,6 @@ export class GcdsTopNav {
     this.lang = assignLanguage(this.el);
 
     this.updateLang();
-
-    const mediaQuery = window.matchMedia('screen and (min-width: 64em)');
-
-    if (mediaQuery.matches) {
-      this.navSize = 'desktop';
-    } else {
-      this.navSize = 'mobile';
-    }
-  }
-
-  async componentDidLoad() {
-    const mediaQuery = window.matchMedia('screen and (min-width: 64em)');
-    const nav = this.el as HTMLGcdsTopNavElement;
-    const mobileTrigger = this.mobile;
-
-    await this.updateNavItemQueue(this.el);
-
-    mediaQuery.addEventListener('change', async function (e) {
-      if (e.matches) {
-        nav.updateNavSize('desktop');
-        await nav.updateNavItemQueue(nav);
-
-        if (mobileTrigger.hasAttribute('open')) {
-          mobileTrigger.toggleNav();
-        }
-      } else {
-        nav.updateNavSize('mobile');
-        await nav.updateNavItemQueue(nav);
-      }
-    });
   }
 
   render() {

--- a/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.tsx
+++ b/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.tsx
@@ -60,16 +60,6 @@ export class GcdsTopicMenu {
   @State() navSize: 'desktop' | 'mobile';
 
   /**
-   * Listen for focusout of theme and topic menu to close menu
-   */
-  @Listen('focusout', { target: 'document' })
-  async focusOutListener(e) {
-    if (!this.el.contains(e.relatedTarget) && this.open) {
-      this.toggleNav();
-    }
-  }
-
-  /**
    * Keyboard controls of theme and topic menu
    */
   @Listen('keydown', { target: 'document' })
@@ -234,6 +224,36 @@ export class GcdsTopicMenu {
     this.open = !this.open;
 
     if (this.open) {
+      // Check window size to set the state
+      const mediaQuery = window.matchMedia('screen and (max-width: 991px)');
+      const nav = this.el as HTMLGcdsTopicMenuElement;
+
+      if (mediaQuery.matches) {
+        this.navSize = 'mobile';
+      } else {
+        this.navSize = 'desktop';
+      }
+
+      // Add change event listener to keep track of window changing size
+      mediaQuery.addEventListener('change', async e => {
+        if (e.matches) {
+          nav.updateNavSize('mobile');
+
+          nav.shadowRoot
+            .querySelectorAll('[data-keep-expanded]')
+            .forEach(el => {
+              el.setAttribute('aria-expanded', 'false');
+            });
+        } else {
+          nav.updateNavSize('desktop');
+          nav.shadowRoot
+            .querySelectorAll('[data-keep-expanded]')
+            .forEach(el => {
+              el.setAttribute('aria-expanded', 'true');
+            });
+        }
+      });
+
       if (this.navSize == 'desktop') {
         this.themeList.children[0].children[0].setAttribute(
           'aria-expanded',
@@ -351,14 +371,6 @@ export class GcdsTopicMenu {
 
     this.updateLang();
 
-    const mediaQuery = window.matchMedia('screen and (max-width: 991px)');
-
-    if (mediaQuery.matches) {
-      this.navSize = 'mobile';
-    } else {
-      this.navSize = 'desktop';
-    }
-
     try {
       const response = await fetch(
         `https://www.canada.ca/content/dam/canada/sitemenu/sitemenu-v2-${this.lang}.html`,
@@ -440,25 +452,6 @@ export class GcdsTopicMenu {
         }
       });
     }
-
-    // Mobile responsiveness
-    const mediaQuery = window.matchMedia('screen and (max-width: 991px)');
-    const nav = this.el as HTMLGcdsTopicMenuElement;
-
-    mediaQuery.addEventListener('change', async e => {
-      if (e.matches) {
-        nav.updateNavSize('mobile');
-
-        nav.shadowRoot.querySelectorAll('[data-keep-expanded]').forEach(el => {
-          el.setAttribute('aria-expanded', 'false');
-        });
-      } else {
-        nav.updateNavSize('desktop');
-        nav.shadowRoot.querySelectorAll('[data-keep-expanded]').forEach(el => {
-          el.setAttribute('aria-expanded', 'true');
-        });
-      }
-    });
   }
 
   render() {


### PR DESCRIPTION
# Summary | Résumé

For better integration in SSR environments, defer using `window` to first interaction with navigation components.
