### PR TITLE
feat: add light link-variant to link component

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -623,14 +623,14 @@ export declare interface GcdsLangToggle extends Components.GcdsLangToggle {}
 
 
 @ProxyCmp({
-  inputs: ['display', 'download', 'external', 'href', 'rel', 'size', 'target', 'type']
+  inputs: ['display', 'download', 'external', 'href', 'linkRole', 'rel', 'size', 'target', 'type']
 })
 @Component({
   selector: 'gcds-link',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['display', 'download', 'external', 'href', 'rel', 'size', 'target', 'type'],
+  inputs: ['display', 'download', 'external', 'href', 'linkRole', 'rel', 'size', 'target', 'type'],
 })
 export class GcdsLink {
   protected el: HTMLElement;

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -623,14 +623,14 @@ export declare interface GcdsLangToggle extends Components.GcdsLangToggle {}
 
 
 @ProxyCmp({
-  inputs: ['display', 'download', 'external', 'href', 'linkRole', 'rel', 'size', 'target', 'type']
+  inputs: ['display', 'download', 'external', 'href', 'linkVariant', 'rel', 'size', 'target', 'type']
 })
 @Component({
   selector: 'gcds-link',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['display', 'download', 'external', 'href', 'linkRole', 'rel', 'size', 'target', 'type'],
+  inputs: ['display', 'download', 'external', 'href', 'linkVariant', 'rel', 'size', 'target', 'type'],
 })
 export class GcdsLink {
   protected el: HTMLElement;

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -352,7 +352,7 @@
   }
 
   /* gcds-link */
-  .sbdocs-preview .docs-story #story--components-link--role-light {
+  .sbdocs-preview .docs-story #story--components-link--variant-light {
     background: var(--gcds-color-grayscale-900);
     padding: var(--gcds-spacing-450);
   }

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -351,6 +351,12 @@
     border: var(--gcds-border-width-sm) solid var(--gcds-border-default);
   }
 
+  /* gcds-link */
+  .sbdocs-preview .docs-story #story--components-link--role-light {
+    background: var(--gcds-color-grayscale-900);
+    padding: var(--gcds-spacing-450);
+  }
+
   /* gcds-signature */
   .sbdocs-preview .docs-story #story--components-signature--signature-white,
   .sbdocs-preview .docs-story #story--components-signature--wordmark-white {

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -771,6 +771,10 @@ export namespace Components {
          */
         "href": string;
         /**
+          * Sets the main style of the link.
+         */
+        "linkRole"?: 'default' | 'light';
+        /**
           * The rel attribute specifies the relationship between the current document and the linked document
          */
         "rel"?: string | undefined;
@@ -2590,6 +2594,10 @@ declare namespace LocalJSX {
           * The href attribute specifies the URL of the page the link goes to
          */
         "href": string;
+        /**
+          * Sets the main style of the link.
+         */
+        "linkRole"?: 'default' | 'light';
         /**
           * Emitted when the link loses focus.
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -773,7 +773,7 @@ export namespace Components {
         /**
           * Sets the main style of the link.
          */
-        "linkRole"?: 'default' | 'light';
+        "linkVariant"?: 'default' | 'light';
         /**
           * The rel attribute specifies the relationship between the current document and the linked document
          */
@@ -2597,7 +2597,7 @@ declare namespace LocalJSX {
         /**
           * Sets the main style of the link.
          */
-        "linkRole"?: 'default' | 'light';
+        "linkVariant"?: 'default' | 'light';
         /**
           * Emitted when the link loses focus.
          */

--- a/packages/web/src/components/gcds-link/gcds-link.css
+++ b/packages/web/src/components/gcds-link/gcds-link.css
@@ -35,7 +35,7 @@
     font: inherit;
   }
 
-  &.role-light {
+  &.variant-light {
     color: var(--gcds-link-light);
   }
 

--- a/packages/web/src/components/gcds-link/gcds-link.css
+++ b/packages/web/src/components/gcds-link/gcds-link.css
@@ -16,7 +16,8 @@
     background-color: var(--gcds-link-focus-background);
     color: var(--gcds-link-focus-text);
     box-shadow: var(--gcds-link-focus-box-shadow);
-    outline: var(--gcds-link-focus-outline-width) solid var(--gcds-link-focus-background);
+    outline: var(--gcds-link-focus-outline-width) solid
+      var(--gcds-link-focus-background);
     outline-offset: var(--gcds-link-focus-outline-offset);
     border-color: var(--gcds-link-focus-background);
     text-decoration: none;
@@ -32,6 +33,10 @@
 
   &.link--inherit {
     font: inherit;
+  }
+
+  &.role-light {
+    color: var(--gcds-link-light);
   }
 
   &.d-block {

--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -30,14 +30,14 @@ export class GcdsLink {
   /**
    * Sets the main style of the link.
    */
-  @Prop({ mutable: true }) linkRole?: 'default' | 'light' = 'default';
+  @Prop({ mutable: true }) linkVariant?: 'default' | 'light' = 'default';
 
-  @Watch('linkRole')
-  validateLinkRole(newValue: string) {
+  @Watch('linkVariant')
+  validateLinkVariant(newValue: string) {
     const values = ['default', 'light'];
 
     if (!values.includes(newValue)) {
-      this.linkRole = 'default';
+      this.linkVariant = 'default';
     }
   }
 
@@ -139,7 +139,7 @@ export class GcdsLink {
 
   componentWillLoad() {
     // Validate attributes and set defaults
-    this.validateLinkRole(this.linkRole);
+    this.validateLinkVariant(this.linkVariant);
     this.validateSize(this.size);
     this.validateDisplay(this.display);
 
@@ -159,7 +159,7 @@ export class GcdsLink {
       lang,
       display,
       href,
-      linkRole,
+      linkVariant,
       rel,
       target,
       external,
@@ -186,7 +186,7 @@ export class GcdsLink {
           tabIndex={0}
           {...attrs}
           class={`link--${size} ${display != 'inline' ? `d-${display}` : ''} ${
-            linkRole != 'default' ? `role-${linkRole}` : ''
+            linkVariant != 'default' ? `variant-${linkVariant}` : ''
           }`}
           ref={element => (this.shadowElement = element as HTMLElement)}
           target={isExternal ? '_blank' : target}

--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -57,7 +57,7 @@ export class GcdsLink {
   /**
    * Sets the display behavior of the link
    */
-  @Prop() display?: 'block' | 'inline' = 'inline';
+  @Prop({ mutable: true }) display?: 'block' | 'inline' = 'inline';
   @Watch('display')
   validateDisplay(newValue: string) {
     const values = ['block', 'inline'];

--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -28,6 +28,20 @@ export class GcdsLink {
    */
 
   /**
+   * Sets the main style of the link.
+   */
+  @Prop({ mutable: true }) linkRole?: 'default' | 'light' = 'default';
+
+  @Watch('linkRole')
+  validateLinkRole(newValue: string) {
+    const values = ['default', 'light'];
+
+    if (!values.includes(newValue)) {
+      this.linkRole = 'default';
+    }
+  }
+
+  /**
    * Set the link size
    */
   @Prop({ mutable: true }) size?: 'regular' | 'small' | 'inherit' = 'inherit';
@@ -125,6 +139,7 @@ export class GcdsLink {
 
   componentWillLoad() {
     // Validate attributes and set defaults
+    this.validateLinkRole(this.linkRole);
     this.validateSize(this.size);
     this.validateDisplay(this.display);
 
@@ -144,6 +159,7 @@ export class GcdsLink {
       lang,
       display,
       href,
+      linkRole,
       rel,
       target,
       external,
@@ -169,7 +185,9 @@ export class GcdsLink {
           role="link"
           tabIndex={0}
           {...attrs}
-          class={`link--${size} ${display != 'inline' ? `d-${display}` : ''}`}
+          class={`link--${size} ${display != 'inline' ? `d-${display}` : ''} ${
+            linkRole != 'default' ? `role-${linkRole}` : ''
+          }`}
           ref={element => (this.shadowElement = element as HTMLElement)}
           target={isExternal ? '_blank' : target}
           rel={isExternal ? 'noopener noreferrer' : rel}

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -7,16 +7,17 @@
 
 ## Properties
 
-| Property            | Attribute  | Description                                                                                                                                        | Type                                | Default     |
-| ------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
-| `display`           | `display`  | Sets the display behavior of the link                                                                                                              | `"block" \| "inline"`               | `'inline'`  |
-| `download`          | `download` | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                            | `undefined` |
-| `external`          | `external` | Whether the link is external or not                                                                                                                | `boolean`                           | `false`     |
-| `href` _(required)_ | `href`     | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                            | `undefined` |
-| `rel`               | `rel`      | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                            | `undefined` |
-| `size`              | `size`     | Set the link size                                                                                                                                  | `"inherit" \| "regular" \| "small"` | `'inherit'` |
-| `target`            | `target`   | The target attribute specifies where to open the linked document                                                                                   | `string`                            | `'_self'`   |
-| `type`              | `type`     | The type specifies the media type of the linked document                                                                                           | `string`                            | `undefined` |
+| Property            | Attribute   | Description                                                                                                                                        | Type                                | Default     |
+| ------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
+| `display`           | `display`   | Sets the display behavior of the link                                                                                                              | `"block" \| "inline"`               | `'inline'`  |
+| `download`          | `download`  | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                            | `undefined` |
+| `external`          | `external`  | Whether the link is external or not                                                                                                                | `boolean`                           | `false`     |
+| `href` _(required)_ | `href`      | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                            | `undefined` |
+| `linkRole`          | `link-role` | Sets the main style of the link.                                                                                                                   | `"default" \| "light"`              | `'default'` |
+| `rel`               | `rel`       | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                            | `undefined` |
+| `size`              | `size`      | Set the link size                                                                                                                                  | `"inherit" \| "regular" \| "small"` | `'inherit'` |
+| `target`            | `target`    | The target attribute specifies where to open the linked document                                                                                   | `string`                            | `'_self'`   |
+| `type`              | `type`      | The type specifies the media type of the linked document                                                                                           | `string`                            | `undefined` |
 
 
 ## Events

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -7,17 +7,17 @@
 
 ## Properties
 
-| Property            | Attribute   | Description                                                                                                                                        | Type                                | Default     |
-| ------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
-| `display`           | `display`   | Sets the display behavior of the link                                                                                                              | `"block" \| "inline"`               | `'inline'`  |
-| `download`          | `download`  | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                            | `undefined` |
-| `external`          | `external`  | Whether the link is external or not                                                                                                                | `boolean`                           | `false`     |
-| `href` _(required)_ | `href`      | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                            | `undefined` |
-| `linkRole`          | `link-role` | Sets the main style of the link.                                                                                                                   | `"default" \| "light"`              | `'default'` |
-| `rel`               | `rel`       | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                            | `undefined` |
-| `size`              | `size`      | Set the link size                                                                                                                                  | `"inherit" \| "regular" \| "small"` | `'inherit'` |
-| `target`            | `target`    | The target attribute specifies where to open the linked document                                                                                   | `string`                            | `'_self'`   |
-| `type`              | `type`      | The type specifies the media type of the linked document                                                                                           | `string`                            | `undefined` |
+| Property            | Attribute      | Description                                                                                                                                        | Type                                | Default     |
+| ------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
+| `display`           | `display`      | Sets the display behavior of the link                                                                                                              | `"block" \| "inline"`               | `'inline'`  |
+| `download`          | `download`     | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                            | `undefined` |
+| `external`          | `external`     | Whether the link is external or not                                                                                                                | `boolean`                           | `false`     |
+| `href` _(required)_ | `href`         | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                            | `undefined` |
+| `linkVariant`       | `link-variant` | Sets the main style of the link.                                                                                                                   | `"default" \| "light"`              | `'default'` |
+| `rel`               | `rel`          | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                            | `undefined` |
+| `size`              | `size`         | Set the link size                                                                                                                                  | `"inherit" \| "regular" \| "small"` | `'inherit'` |
+| `target`            | `target`       | The target attribute specifies where to open the linked document                                                                                   | `string`                            | `'_self'`   |
+| `type`              | `type`         | The type specifies the media type of the linked document                                                                                           | `string`                            | `undefined` |
 
 
 ## Events

--- a/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
+++ b/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
@@ -33,8 +33,8 @@ export default {
         defaultValue: { summary: '-' },
       },
     },
-    linkRole: {
-      name: 'link-role',
+    linkVariant: {
+      name: 'link-variant',
       control: { type: 'select' },
       options: ['default', 'light'],
       table: {
@@ -97,24 +97,28 @@ This is an example of
 <!-- Web component code (Angular, Vue) -->
 <gcds-link ${args.display != 'inline' ? `display="${args.display}"` : null} ${
     args.href ? `href="${args.href}"` : null
-  } ${args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null} ${
-    args.rel ? `rel="${args.rel}"` : null
-  } ${args.target != '_self' ? `target="${args.target}"` : null} ${
-    args.size != 'inherit' && args.size ? `size="${args.size}"` : null
-  } ${args.external ? `external` : null} ${
-    args.download ? `download="${args.download}"` : null
-  } ${args.type ? `type="${args.type}"` : null}>${args.default}</gcds-link>
+  } ${
+    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
+  } ${args.rel ? `rel="${args.rel}"` : null} ${
+    args.target != '_self' ? `target="${args.target}"` : null
+  } ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
+    args.external ? `external` : null
+  } ${args.download ? `download="${args.download}"` : null} ${
+    args.type ? `type="${args.type}"` : null
+  }>${args.default}</gcds-link>
 
 <!-- React code -->
 <GcdsLink ${args.display != 'inline' ? `display="${args.display}"` : null} ${
     args.href ? `href="${args.href}"` : null
-  } ${args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null} ${
-    args.rel ? `rel="${args.rel}"` : null
-  } ${args.target != '_self' ? `target="${args.target}"` : null} ${
-    args.size != 'inherit' && args.size ? `size="${args.size}"` : null
-  } ${args.external ? `external` : null} ${
-    args.download ? `download="${args.download}"` : null
-  } ${args.type ? `type="${args.type}"` : null}>${args.default}</GcdsLink>
+  } ${
+    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
+  } ${args.rel ? `rel="${args.rel}"` : null} ${
+    args.target != '_self' ? `target="${args.target}"` : null
+  } ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
+    args.external ? `external` : null
+  } ${args.download ? `download="${args.download}"` : null} ${
+    args.type ? `type="${args.type}"` : null
+  }>${args.default}</GcdsLink>
 link.
 `.replace(/ null/g, '');
 
@@ -127,29 +131,31 @@ const TemplateSizeInherit = args =>
 <GcdsHeading tag="h4">This is an example of <GcdsLink href="#">${args.default}</GcdsLink> link</GcdsHeading>
 `;
 
-const TemplateRole = args =>
+const TemplateVariant = args =>
   `
 <!-- Web component code (Angular, Vue) -->
 <gcds-link href="#" ${
-    args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null
+    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
   }>${args.default}</gcds-link>
 
 <!-- React code -->
 <GcdsLink href="#" ${
-    args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null
+    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
   }>${args.default}</GcdsLink>
 `.replace(/ null/g, '');
 
 const TemplatePlayground = args => `
 <gcds-link ${args.display != 'inline' ? `display="${args.display}"` : null} ${
   args.href ? `href="${args.href}"` : null
-} ${args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null} ${
-  args.rel ? `rel="${args.rel}"` : null
-} ${args.target && args.target != '_self' ? `target="${args.target}"` : null} ${
-  args.size != 'inherit' && args.size ? `size="${args.size}"` : null
-} ${args.external ? `external` : null} ${
-  args.download ? `download="${args.download}"` : null
-} ${args.type ? `type="${args.type}"` : null}>  ${args.default}
+} ${
+  args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
+} ${args.rel ? `rel="${args.rel}"` : null} ${
+  args.target && args.target != '_self' ? `target="${args.target}"` : null
+} ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
+  args.external ? `external` : null
+} ${args.download ? `download="${args.download}"` : null} ${
+  args.type ? `type="${args.type}"` : null
+}>  ${args.default}
 </gcds-link>
 `;
 
@@ -159,7 +165,7 @@ export const Default = Template.bind({});
 Default.args = {
   display: 'inline',
   href: '#',
-  linkRole: 'default',
+  linkVariant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -175,7 +181,7 @@ export const Props = Template.bind({});
 Props.args = {
   display: 'inline',
   href: '#',
-  linkRole: 'default',
+  linkVariant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -191,7 +197,7 @@ export const External = Template.bind({});
 External.args = {
   display: 'inline',
   href: 'http://design-system.alpha.canada.ca',
-  linkRole: 'default',
+  linkVariant: 'default',
   rel: '',
   target: '_blank',
   size: 'inherit',
@@ -205,7 +211,7 @@ export const Download = Template.bind({});
 Download.args = {
   href: 'long-filename.pdf',
   display: 'inline',
-  linkRole: 'default',
+  linkVariant: 'default',
   target: '_self',
   size: 'inherit',
   download: 'file.pdf',
@@ -216,7 +222,7 @@ Download.args = {
 export const Email = Template.bind({});
 Email.args = {
   display: 'inline',
-  linkRole: 'default',
+  linkVariant: 'default',
   target: '_self',
   size: 'inherit',
   href: 'mailto:test@test.com?subject=Test%20Email',
@@ -226,7 +232,7 @@ Email.args = {
 export const Phone = Template.bind({});
 Phone.args = {
   display: 'inline',
-  linkRole: 'default',
+  linkVariant: 'default',
   target: '_self',
   size: 'inherit',
   href: 'tel:1234567890',
@@ -239,7 +245,7 @@ export const SizesSmall = Template.bind({});
 SizesSmall.args = {
   display: 'inline',
   href: '#',
-  linkRole: 'default',
+  linkVariant: 'default',
   rel: '',
   target: '_self',
   size: 'small',
@@ -253,7 +259,7 @@ export const SizesRegular = Template.bind({});
 SizesRegular.args = {
   display: 'inline',
   href: '#',
-  linkRole: 'default',
+  linkVariant: 'default',
   rel: '',
   target: '_self',
   size: 'regular',
@@ -267,7 +273,7 @@ export const SizesInherit = TemplateSizeInherit.bind({});
 SizesInherit.args = {
   display: 'inline',
   href: '#',
-  linkRole: 'default',
+  linkVariant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -279,16 +285,16 @@ SizesInherit.args = {
 
 // ------ Link roles ------
 
-export const RoleDefault = TemplateRole.bind({});
-RoleDefault.args = {
-  default: 'This is a link using the default link role.',
-  linkRole: 'default',
+export const VariantDefault = TemplateVariant.bind({});
+VariantDefault.args = {
+  default: 'This is a link using the default link variant.',
+  linkVariant: 'default',
 };
 
-export const RoleLight = TemplateRole.bind({});
-RoleLight.args = {
-  default: 'This is a link using the light link role.',
-  linkRole: 'light',
+export const VariantLight = TemplateVariant.bind({});
+VariantLight.args = {
+  default: 'This is a link using the light link variant.',
+  linkVariant: 'light',
 };
 
 // ------ Link playground ------
@@ -297,7 +303,7 @@ export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   display: 'inline',
   href: '#',
-  linkRole: 'default',
+  linkVariant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',

--- a/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
+++ b/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
@@ -33,6 +33,15 @@ export default {
         defaultValue: { summary: '-' },
       },
     },
+    linkRole: {
+      name: 'link-role',
+      control: { type: 'select' },
+      options: ['default', 'light'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'default' },
+      },
+    },
     rel: {
       control: 'text',
       table: {
@@ -88,24 +97,24 @@ This is an example of
 <!-- Web component code (Angular, Vue) -->
 <gcds-link ${args.display != 'inline' ? `display="${args.display}"` : null} ${
     args.href ? `href="${args.href}"` : null
-  } ${args.rel ? `rel="${args.rel}"` : null} ${
-    args.target != '_self' ? `target="${args.target}"` : null
-  } ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
-    args.external ? `external` : null
-  } ${args.download ? `download="${args.download}"` : null} ${
-    args.type ? `type="${args.type}"` : null
-  }>${args.default}</gcds-link>
+  } ${args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null} ${
+    args.rel ? `rel="${args.rel}"` : null
+  } ${args.target != '_self' ? `target="${args.target}"` : null} ${
+    args.size != 'inherit' && args.size ? `size="${args.size}"` : null
+  } ${args.external ? `external` : null} ${
+    args.download ? `download="${args.download}"` : null
+  } ${args.type ? `type="${args.type}"` : null}>${args.default}</gcds-link>
 
 <!-- React code -->
 <GcdsLink ${args.display != 'inline' ? `display="${args.display}"` : null} ${
     args.href ? `href="${args.href}"` : null
-  } ${args.rel ? `rel="${args.rel}"` : null} ${
-    args.target != '_self' ? `target="${args.target}"` : null
-  } ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
-    args.external ? `external` : null
-  } ${args.download ? `download="${args.download}"` : null} ${
-    args.type ? `type="${args.type}"` : null
-  }>${args.default}</GcdsLink>
+  } ${args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null} ${
+    args.rel ? `rel="${args.rel}"` : null
+  } ${args.target != '_self' ? `target="${args.target}"` : null} ${
+    args.size != 'inherit' && args.size ? `size="${args.size}"` : null
+  } ${args.external ? `external` : null} ${
+    args.download ? `download="${args.download}"` : null
+  } ${args.type ? `type="${args.type}"` : null}>${args.default}</GcdsLink>
 link.
 `.replace(/ null/g, '');
 
@@ -113,28 +122,44 @@ const TemplateSizeInherit = args =>
   `
 <!-- Web component code (Angular, Vue) -->
 <gcds-heading tag="h4">This is an example of <gcds-link href="#">${args.default}</gcds-link> link</gcds-heading>
+
 <!-- React code -->
 <GcdsHeading tag="h4">This is an example of <GcdsLink href="#">${args.default}</GcdsLink> link</GcdsHeading>
 `;
 
+const TemplateRole = args =>
+  `
+<!-- Web component code (Angular, Vue) -->
+<gcds-link href="#" ${
+    args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null
+  }>${args.default}</gcds-link>
+
+<!-- React code -->
+<GcdsLink href="#" ${
+    args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null
+  }>${args.default}</GcdsLink>
+`.replace(/ null/g, '');
+
 const TemplatePlayground = args => `
 <gcds-link ${args.display != 'inline' ? `display="${args.display}"` : null} ${
   args.href ? `href="${args.href}"` : null
-} ${args.rel ? `rel="${args.rel}"` : null} ${
-  args.target && args.target != '_self' ? `target="${args.target}"` : null
-} ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
-  args.external ? `external` : null
-} ${args.download ? `download="${args.download}"` : null} ${
-  args.type ? `type="${args.type}"` : null
-}>  ${args.default}
+} ${args.linkRole != 'default' ? `link-role="${args.linkRole}"` : null} ${
+  args.rel ? `rel="${args.rel}"` : null
+} ${args.target && args.target != '_self' ? `target="${args.target}"` : null} ${
+  args.size != 'inherit' && args.size ? `size="${args.size}"` : null
+} ${args.external ? `external` : null} ${
+  args.download ? `download="${args.download}"` : null
+} ${args.type ? `type="${args.type}"` : null}>  ${args.default}
 </gcds-link>
 `;
 
 // ------ Link Default ------
+
 export const Default = Template.bind({});
 Default.args = {
   display: 'inline',
   href: '#',
+  linkRole: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -145,10 +170,12 @@ Default.args = {
 };
 
 // ------ Link events & props ------
+
 export const Props = Template.bind({});
 Props.args = {
   display: 'inline',
   href: '#',
+  linkRole: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -158,10 +185,13 @@ Props.args = {
   default: 'a GCDS Link component',
 };
 
+// ------ Link with icon ------
+
 export const External = Template.bind({});
 External.args = {
   display: 'inline',
   href: 'http://design-system.alpha.canada.ca',
+  linkRole: 'default',
   rel: '',
   target: '_blank',
   size: 'inherit',
@@ -175,6 +205,7 @@ export const Download = Template.bind({});
 Download.args = {
   href: 'long-filename.pdf',
   display: 'inline',
+  linkRole: 'default',
   target: '_self',
   size: 'inherit',
   download: 'file.pdf',
@@ -185,6 +216,7 @@ Download.args = {
 export const Email = Template.bind({});
 Email.args = {
   display: 'inline',
+  linkRole: 'default',
   target: '_self',
   size: 'inherit',
   href: 'mailto:test@test.com?subject=Test%20Email',
@@ -194,16 +226,20 @@ Email.args = {
 export const Phone = Template.bind({});
 Phone.args = {
   display: 'inline',
+  linkRole: 'default',
   target: '_self',
   size: 'inherit',
   href: 'tel:1234567890',
   default: 'a phone number',
 };
 
+// ------ Link sizes ------
+
 export const SizesSmall = Template.bind({});
 SizesSmall.args = {
   display: 'inline',
   href: '#',
+  linkRole: 'default',
   rel: '',
   target: '_self',
   size: 'small',
@@ -217,6 +253,7 @@ export const SizesRegular = Template.bind({});
 SizesRegular.args = {
   display: 'inline',
   href: '#',
+  linkRole: 'default',
   rel: '',
   target: '_self',
   size: 'regular',
@@ -230,6 +267,7 @@ export const SizesInherit = TemplateSizeInherit.bind({});
 SizesInherit.args = {
   display: 'inline',
   href: '#',
+  linkRole: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -239,12 +277,27 @@ SizesInherit.args = {
   default: 'a size inherit',
 };
 
+// ------ Link roles ------
+
+export const RoleDefault = TemplateRole.bind({});
+RoleDefault.args = {
+  default: 'This is a link using the default link role.',
+  linkRole: 'default',
+};
+
+export const RoleLight = TemplateRole.bind({});
+RoleLight.args = {
+  default: 'This is a link using the light link role.',
+  linkRole: 'light',
+};
+
 // ------ Link playground ------
 
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   display: 'inline',
   href: '#',
+  linkRole: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',

--- a/packages/web/src/components/gcds-link/stories/overview.mdx
+++ b/packages/web/src/components/gcds-link/stories/overview.mdx
@@ -45,15 +45,15 @@ A navigational element that allows users to navigate to a new page, website or s
 
 <Canvas of={Link.SizesSmall} story={{ inline: true }} />
 
-### Roles
+### Variants
 
 #### Default
 
-<Canvas of={Link.RoleDefault} story={{ inline: true }} />
+<Canvas of={Link.VariantDefault} story={{ inline: true }} />
 
 #### Light
 
-<Canvas of={Link.RoleLight} story={{ inline: true }} />
+<Canvas of={Link.VariantLight} story={{ inline: true }} />
 
 ## Resources
 

--- a/packages/web/src/components/gcds-link/stories/overview.mdx
+++ b/packages/web/src/components/gcds-link/stories/overview.mdx
@@ -45,6 +45,16 @@ A navigational element that allows users to navigate to a new page, website or s
 
 <Canvas of={Link.SizesSmall} story={{ inline: true }} />
 
+### Roles
+
+#### Default
+
+<Canvas of={Link.RoleDefault} story={{ inline: true }} />
+
+#### Light
+
+<Canvas of={Link.RoleLight} story={{ inline: true }} />
+
 ## Resources
 
 {/* prettier-ignore */}

--- a/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
+++ b/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
@@ -255,15 +255,15 @@ describe('gcds-link', () => {
     `);
   });
 
-  it('renders a light link role', async () => {
+  it('renders a light link variant', async () => {
     const { root } = await newSpecPage({
       components: [GcdsLink],
-      html: '<gcds-link href="#" link-role="light">Link text</gcds-link>',
+      html: '<gcds-link href="#" link-variant="light">Link text</gcds-link>',
     });
     expect(root).toEqualHtml(`
-      <gcds-link href="#" link-role="light">
+      <gcds-link href="#" link-variant="light">
         <mock:shadow-root>
-          <a class="link--inherit role-light" part="link" href="#" role="link" tabindex="0" target="_self">
+          <a class="link--inherit variant-light" part="link" href="#" role="link" tabindex="0" target="_self">
             <slot></slot>
           </a>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
+++ b/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
@@ -254,4 +254,21 @@ describe('gcds-link', () => {
       </gcds-link>
     `);
   });
+
+  it('renders a light link role', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsLink],
+      html: '<gcds-link href="#" link-role="light">Link text</gcds-link>',
+    });
+    expect(root).toEqualHtml(`
+      <gcds-link href="#" link-role="light">
+        <mock:shadow-root>
+          <a class="link--inherit role-light" part="link" href="#" role="link" tabindex="0" target="_self">
+            <slot></slot>
+          </a>
+        </mock:shadow-root>
+        Link text
+      </gcds-link>
+    `);
+  });
 });

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -641,7 +641,7 @@
         </gcds-link>
       </p>
       <div class="bg-dark mb-400 p-200">
-        <gcds-link link-role="light" href="/">
+        <gcds-link link-variant="light" href="/">
           This is a link using the light link role.
         </gcds-link>
       </div>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -596,9 +596,13 @@
         compare it to regular text.
       </p>
       <p class="mb-400">
-        <gcds-link href="https://picsum.photos/480/270" external display="block"
-          >This is an external link.</gcds-link
+        <gcds-link
+          href="https://picsum.photos/480/270"
+          external
+          display="block"
         >
+          This is an external link.
+        </gcds-link>
       </p>
       <p class="mb-400">
         This is a
@@ -612,9 +616,9 @@
       </p>
       <p class="mb-400">
         Contact us
-        <gcds-link href="mailto:test@test.com?subject=Test%20email"
-          >via email</gcds-link
-        >
+        <gcds-link href="mailto:test@test.com?subject=Test%20email">
+          via email
+        </gcds-link>
         or by phone.
       </p>
       <p class="mb-400">
@@ -627,15 +631,20 @@
         after this link.
       </p>
       <p class="mb-400">
-        <gcds-link href="/" referrerpolicy="no-referrer" external
-          >This is a sample link with a referrerpolicy.</gcds-link
-        >
+        <gcds-link href="/" referrerpolicy="no-referrer" external>
+          This is a sample link with a referrerpolicy.
+        </gcds-link>
       </p>
       <p class="mb-400">
-        <gcds-link href="" onClick='window.alert("Thank you!")'
-          >Click me!</gcds-link
-        >
+        <gcds-link href="" onClick='window.alert("Thank you!")'>
+          Click me!
+        </gcds-link>
       </p>
+      <div class="bg-dark mb-400 p-200">
+        <gcds-link link-role="light" href="/">
+          This is a link using the light link role.
+        </gcds-link>
+      </div>
 
       <hr class="my-550" />
 


### PR DESCRIPTION
# Summary | Résumé

As discussed in dev-design-sync recently, adding a new `link-variant` prop that allows users to use `light` links.