### PR TITLE
fix: link variant prop name

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -623,14 +623,14 @@ export declare interface GcdsLangToggle extends Components.GcdsLangToggle {}
 
 
 @ProxyCmp({
-  inputs: ['display', 'download', 'external', 'href', 'linkVariant', 'rel', 'size', 'target', 'type']
+  inputs: ['display', 'download', 'external', 'href', 'rel', 'size', 'target', 'type', 'variant']
 })
 @Component({
   selector: 'gcds-link',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['display', 'download', 'external', 'href', 'linkVariant', 'rel', 'size', 'target', 'type'],
+  inputs: ['display', 'download', 'external', 'href', 'rel', 'size', 'target', 'type', 'variant'],
 })
 export class GcdsLink {
   protected el: HTMLElement;

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -771,10 +771,6 @@ export namespace Components {
          */
         "href": string;
         /**
-          * Sets the main style of the link.
-         */
-        "linkVariant"?: 'default' | 'light';
-        /**
           * The rel attribute specifies the relationship between the current document and the linked document
          */
         "rel"?: string | undefined;
@@ -790,6 +786,10 @@ export namespace Components {
           * The type specifies the media type of the linked document
          */
         "type"?: string | undefined;
+        /**
+          * Sets the main style of the link.
+         */
+        "variant"?: 'default' | 'light';
     }
     interface GcdsNavGroup {
         /**
@@ -2595,10 +2595,6 @@ declare namespace LocalJSX {
          */
         "href": string;
         /**
-          * Sets the main style of the link.
-         */
-        "linkVariant"?: 'default' | 'light';
-        /**
           * Emitted when the link loses focus.
          */
         "onGcdsBlur"?: (event: GcdsLinkCustomEvent<void>) => void;
@@ -2626,6 +2622,10 @@ declare namespace LocalJSX {
           * The type specifies the media type of the linked document
          */
         "type"?: string | undefined;
+        /**
+          * Sets the main style of the link.
+         */
+        "variant"?: 'default' | 'light';
     }
     interface GcdsNavGroup {
         /**

--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -30,14 +30,14 @@ export class GcdsLink {
   /**
    * Sets the main style of the link.
    */
-  @Prop({ mutable: true }) linkVariant?: 'default' | 'light' = 'default';
+  @Prop({ mutable: true }) variant?: 'default' | 'light' = 'default';
 
-  @Watch('linkVariant')
-  validateLinkVariant(newValue: string) {
+  @Watch('variant')
+  validateVariant(newValue: string) {
     const values = ['default', 'light'];
 
     if (!values.includes(newValue)) {
-      this.linkVariant = 'default';
+      this.variant = 'default';
     }
   }
 
@@ -139,7 +139,7 @@ export class GcdsLink {
 
   componentWillLoad() {
     // Validate attributes and set defaults
-    this.validateLinkVariant(this.linkVariant);
+    this.validateVariant(this.variant);
     this.validateSize(this.size);
     this.validateDisplay(this.display);
 
@@ -159,13 +159,13 @@ export class GcdsLink {
       lang,
       display,
       href,
-      linkVariant,
       rel,
       target,
       external,
       download,
       type,
       inheritedAttributes,
+      variant,
     } = this;
 
     const attrs = {
@@ -186,7 +186,7 @@ export class GcdsLink {
           tabIndex={0}
           {...attrs}
           class={`link--${size} ${display != 'inline' ? `d-${display}` : ''} ${
-            linkVariant != 'default' ? `variant-${linkVariant}` : ''
+            variant != 'default' ? `variant-${variant}` : ''
           }`}
           ref={element => (this.shadowElement = element as HTMLElement)}
           target={isExternal ? '_blank' : target}

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -7,17 +7,17 @@
 
 ## Properties
 
-| Property            | Attribute      | Description                                                                                                                                        | Type                                | Default     |
-| ------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
-| `display`           | `display`      | Sets the display behavior of the link                                                                                                              | `"block" \| "inline"`               | `'inline'`  |
-| `download`          | `download`     | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                            | `undefined` |
-| `external`          | `external`     | Whether the link is external or not                                                                                                                | `boolean`                           | `false`     |
-| `href` _(required)_ | `href`         | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                            | `undefined` |
-| `linkVariant`       | `link-variant` | Sets the main style of the link.                                                                                                                   | `"default" \| "light"`              | `'default'` |
-| `rel`               | `rel`          | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                            | `undefined` |
-| `size`              | `size`         | Set the link size                                                                                                                                  | `"inherit" \| "regular" \| "small"` | `'inherit'` |
-| `target`            | `target`       | The target attribute specifies where to open the linked document                                                                                   | `string`                            | `'_self'`   |
-| `type`              | `type`         | The type specifies the media type of the linked document                                                                                           | `string`                            | `undefined` |
+| Property            | Attribute  | Description                                                                                                                                        | Type                                | Default     |
+| ------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
+| `display`           | `display`  | Sets the display behavior of the link                                                                                                              | `"block" \| "inline"`               | `'inline'`  |
+| `download`          | `download` | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                            | `undefined` |
+| `external`          | `external` | Whether the link is external or not                                                                                                                | `boolean`                           | `false`     |
+| `href` _(required)_ | `href`     | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                            | `undefined` |
+| `rel`               | `rel`      | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                            | `undefined` |
+| `size`              | `size`     | Set the link size                                                                                                                                  | `"inherit" \| "regular" \| "small"` | `'inherit'` |
+| `target`            | `target`   | The target attribute specifies where to open the linked document                                                                                   | `string`                            | `'_self'`   |
+| `type`              | `type`     | The type specifies the media type of the linked document                                                                                           | `string`                            | `undefined` |
+| `variant`           | `variant`  | Sets the main style of the link.                                                                                                                   | `"default" \| "light"`              | `'default'` |
 
 
 ## Events

--- a/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
+++ b/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
@@ -33,8 +33,7 @@ export default {
         defaultValue: { summary: '-' },
       },
     },
-    linkVariant: {
-      name: 'link-variant',
+    variant: {
       control: { type: 'select' },
       options: ['default', 'light'],
       table: {
@@ -97,28 +96,24 @@ This is an example of
 <!-- Web component code (Angular, Vue) -->
 <gcds-link ${args.display != 'inline' ? `display="${args.display}"` : null} ${
     args.href ? `href="${args.href}"` : null
-  } ${
-    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
-  } ${args.rel ? `rel="${args.rel}"` : null} ${
-    args.target != '_self' ? `target="${args.target}"` : null
-  } ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
-    args.external ? `external` : null
-  } ${args.download ? `download="${args.download}"` : null} ${
-    args.type ? `type="${args.type}"` : null
-  }>${args.default}</gcds-link>
+  } ${args.variant != 'default' ? `variant="${args.variant}"` : null} ${
+    args.rel ? `rel="${args.rel}"` : null
+  } ${args.target != '_self' ? `target="${args.target}"` : null} ${
+    args.size != 'inherit' && args.size ? `size="${args.size}"` : null
+  } ${args.external ? `external` : null} ${
+    args.download ? `download="${args.download}"` : null
+  } ${args.type ? `type="${args.type}"` : null}>${args.default}</gcds-link>
 
 <!-- React code -->
 <GcdsLink ${args.display != 'inline' ? `display="${args.display}"` : null} ${
     args.href ? `href="${args.href}"` : null
-  } ${
-    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
-  } ${args.rel ? `rel="${args.rel}"` : null} ${
-    args.target != '_self' ? `target="${args.target}"` : null
-  } ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
-    args.external ? `external` : null
-  } ${args.download ? `download="${args.download}"` : null} ${
-    args.type ? `type="${args.type}"` : null
-  }>${args.default}</GcdsLink>
+  } ${args.variant != 'default' ? `variant="${args.variant}"` : null} ${
+    args.rel ? `rel="${args.rel}"` : null
+  } ${args.target != '_self' ? `target="${args.target}"` : null} ${
+    args.size != 'inherit' && args.size ? `size="${args.size}"` : null
+  } ${args.external ? `external` : null} ${
+    args.download ? `download="${args.download}"` : null
+  } ${args.type ? `type="${args.type}"` : null}>${args.default}</GcdsLink>
 link.
 `.replace(/ null/g, '');
 
@@ -135,27 +130,25 @@ const TemplateVariant = args =>
   `
 <!-- Web component code (Angular, Vue) -->
 <gcds-link href="#" ${
-    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
+    args.variant != 'default' ? `variant="${args.variant}"` : null
   }>${args.default}</gcds-link>
 
 <!-- React code -->
 <GcdsLink href="#" ${
-    args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
+    args.variant != 'default' ? `variant="${args.variant}"` : null
   }>${args.default}</GcdsLink>
 `.replace(/ null/g, '');
 
 const TemplatePlayground = args => `
 <gcds-link ${args.display != 'inline' ? `display="${args.display}"` : null} ${
   args.href ? `href="${args.href}"` : null
-} ${
-  args.linkVariant != 'default' ? `link-variant="${args.linkVariant}"` : null
-} ${args.rel ? `rel="${args.rel}"` : null} ${
-  args.target && args.target != '_self' ? `target="${args.target}"` : null
-} ${args.size != 'inherit' && args.size ? `size="${args.size}"` : null} ${
-  args.external ? `external` : null
-} ${args.download ? `download="${args.download}"` : null} ${
-  args.type ? `type="${args.type}"` : null
-}>  ${args.default}
+} ${args.variant != 'default' ? `variant="${args.variant}"` : null} ${
+  args.rel ? `rel="${args.rel}"` : null
+} ${args.target && args.target != '_self' ? `target="${args.target}"` : null} ${
+  args.size != 'inherit' && args.size ? `size="${args.size}"` : null
+} ${args.external ? `external` : null} ${
+  args.download ? `download="${args.download}"` : null
+} ${args.type ? `type="${args.type}"` : null}>  ${args.default}
 </gcds-link>
 `;
 
@@ -165,7 +158,7 @@ export const Default = Template.bind({});
 Default.args = {
   display: 'inline',
   href: '#',
-  linkVariant: 'default',
+  variant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -181,7 +174,7 @@ export const Props = Template.bind({});
 Props.args = {
   display: 'inline',
   href: '#',
-  linkVariant: 'default',
+  variant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -197,7 +190,7 @@ export const External = Template.bind({});
 External.args = {
   display: 'inline',
   href: 'http://design-system.alpha.canada.ca',
-  linkVariant: 'default',
+  variant: 'default',
   rel: '',
   target: '_blank',
   size: 'inherit',
@@ -211,7 +204,7 @@ export const Download = Template.bind({});
 Download.args = {
   href: 'long-filename.pdf',
   display: 'inline',
-  linkVariant: 'default',
+  variant: 'default',
   target: '_self',
   size: 'inherit',
   download: 'file.pdf',
@@ -222,7 +215,7 @@ Download.args = {
 export const Email = Template.bind({});
 Email.args = {
   display: 'inline',
-  linkVariant: 'default',
+  variant: 'default',
   target: '_self',
   size: 'inherit',
   href: 'mailto:test@test.com?subject=Test%20Email',
@@ -232,7 +225,7 @@ Email.args = {
 export const Phone = Template.bind({});
 Phone.args = {
   display: 'inline',
-  linkVariant: 'default',
+  variant: 'default',
   target: '_self',
   size: 'inherit',
   href: 'tel:1234567890',
@@ -245,7 +238,7 @@ export const SizesSmall = Template.bind({});
 SizesSmall.args = {
   display: 'inline',
   href: '#',
-  linkVariant: 'default',
+  variant: 'default',
   rel: '',
   target: '_self',
   size: 'small',
@@ -259,7 +252,7 @@ export const SizesRegular = Template.bind({});
 SizesRegular.args = {
   display: 'inline',
   href: '#',
-  linkVariant: 'default',
+  variant: 'default',
   rel: '',
   target: '_self',
   size: 'regular',
@@ -273,7 +266,7 @@ export const SizesInherit = TemplateSizeInherit.bind({});
 SizesInherit.args = {
   display: 'inline',
   href: '#',
-  linkVariant: 'default',
+  variant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',
@@ -288,13 +281,13 @@ SizesInherit.args = {
 export const VariantDefault = TemplateVariant.bind({});
 VariantDefault.args = {
   default: 'This is a link using the default link variant.',
-  linkVariant: 'default',
+  variant: 'default',
 };
 
 export const VariantLight = TemplateVariant.bind({});
 VariantLight.args = {
   default: 'This is a link using the light link variant.',
-  linkVariant: 'light',
+  variant: 'light',
 };
 
 // ------ Link playground ------
@@ -303,7 +296,7 @@ export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   display: 'inline',
   href: '#',
-  linkVariant: 'default',
+  variant: 'default',
   rel: '',
   target: '_self',
   size: 'inherit',

--- a/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
+++ b/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
@@ -258,10 +258,10 @@ describe('gcds-link', () => {
   it('renders a light link variant', async () => {
     const { root } = await newSpecPage({
       components: [GcdsLink],
-      html: '<gcds-link href="#" link-variant="light">Link text</gcds-link>',
+      html: '<gcds-link href="#" variant="light">Link text</gcds-link>',
     });
     expect(root).toEqualHtml(`
-      <gcds-link href="#" link-variant="light">
+      <gcds-link href="#" variant="light">
         <mock:shadow-root>
           <a class="link--inherit variant-light" part="link" href="#" role="link" tabindex="0" target="_self">
             <slot></slot>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -641,7 +641,7 @@
         </gcds-link>
       </p>
       <div class="bg-dark mb-400 p-200">
-        <gcds-link link-variant="light" href="/">
+        <gcds-link variant="light" href="/">
           This is a link using the light link role.
         </gcds-link>
       </div>


### PR DESCRIPTION
# Summary | Résumé

Rename `link-variant` prop to `variant` to be consistent with other components.