### PR TITLE
fix: File-uploader not validating properly

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -213,7 +213,9 @@ export class GcdsFileUploader {
 
       // Validate since the input loses focus when dialog opens
       if (this.validateOn == 'blur') {
-        this.validate();
+        setTimeout(() => {
+          this.validate();
+        }, 100);
       }
     }
 


### PR DESCRIPTION
# Summary | Résumé

Fix issue where the `gcds-file-uploader` would prevent form submission and display an error after choosing a file when validating `onBlur`. Added a small timeout to the validation in `handleChange` function to allow the file-uploader component to re-render with the submitted file.
