### PR TITLE
Add wrapped prop for conditional render to fix slot hydration issue

### DIFF
--- a/packages/ssr/lib/client/index.ts
+++ b/packages/ssr/lib/client/index.ts
@@ -37,18 +37,18 @@ function resolve(children, result = []) {
       } else {
         // Function component
         const props = { ...node.props };
-        // Apply extra wrapped prop to GCDS components
+        // Apply extra isAlreadyWrapped prop to GCDS components
         if (node.type.toString().includes('Gcds')) {
-          props.wrapped = true;
+          props.isAlreadyWrapped = true;
         }
         resolve(node.type(props), result);
       }
     } else if (typeof node.type === 'object' && typeof node.type.render === 'function') {
       const props = { ...node.props };
       const renderedComp = node.type.render(node.props);
-      // Apply extra wrapped attribute to GCDS components
+      // Apply extra isAlreadyWrapped attribute to GCDS components
       if (renderedComp.type.includes('gcds-')) {
-        props.wrapped = true;
+        props.isAlreadyWrapped = true;
       }
       resolve(node.type.render(props), result);
     }

--- a/packages/ssr/lib/client/index.ts
+++ b/packages/ssr/lib/client/index.ts
@@ -36,10 +36,21 @@ function resolve(children, result = []) {
         resolve(vnode, result);
       } else {
         // Function component
-        resolve(node.type(node.props), result);
+        const props = { ...node.props };
+        // Apply extra wrapped prop to GCDS components
+        if (node.type.toString().includes('Gcds')) {
+          props.wrapped = true;
+        }
+        resolve(node.type(props), result);
       }
     } else if (typeof node.type === 'object' && typeof node.type.render === 'function') {
-      resolve(node.type.render(node.props), result);
+      const props = { ...node.props };
+      const renderedComp = node.type.render(node.props);
+      // Apply extra wrapped attribute to GCDS components
+      if (renderedComp.type.includes('gcds-')) {
+        props.wrapped = true;
+      }
+      resolve(node.type.render(props), result);
     }
   }
 

--- a/packages/ssr/scripts/utils.ts
+++ b/packages/ssr/scripts/utils.ts
@@ -78,8 +78,8 @@ const ${toPascalCase(elementName)}WebComponent = React.forwardRef(({ children = 
     nativeProps[p.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()] = nonEventProps[p];
   }
 
-  if (nativeProps.wrapped) {
-    delete nativeProps.wrapped;
+  if (nativeProps.isAlreadyWrapped) {
+    delete nativeProps.isAlreadyWrapped;
   }
 
   if (typeof window !== 'undefined') {
@@ -96,11 +96,11 @@ function ${toPascalCase(elementName)}(props) {
   if (!props['noSSR'] && typeof window == 'undefined') {
     let cloned = [];
 
-    // Pass wrapped prop to children GCDS components
+    // Pass isAlreadyWrapped prop to children GCDS components
     if (Array.isArray(props.children)) {
       props.children.map((child, i) => {
         if (child.type && child.type.toString().includes('Gcds')) {
-          cloned.push(React.cloneElement(child, { wrapped: true, key: i }));
+          cloned.push(React.cloneElement(child, { isAlreadyWrapped: true, key: i }));
         } else if (typeof child == 'string') {
           cloned.push(child);
         } else {
@@ -109,7 +109,7 @@ function ${toPascalCase(elementName)}(props) {
       });
     } else if (typeof props.children == 'object') {
       if (props.children.type && props.children.type.toString().includes('Gcds')) {
-        cloned.push(React.cloneElement(props.children, { wrapped: true, key: 0 }));
+        cloned.push(React.cloneElement(props.children, { isAlreadyWrapped: true, key: 0 }));
       } else {
         cloned.push(React.cloneElement(props.children, { key: 0 }));
       }
@@ -117,8 +117,7 @@ function ${toPascalCase(elementName)}(props) {
       cloned = props.children;
     }
 
-    // Render without GcdsWrapper if wrapped: true
-    if (props.wrapped) {
+    if (props.isAlreadyWrapped) {
       return(
         <${toPascalCase(elementName)}WebComponent {...props}>
           {cloned}

--- a/packages/ssr/scripts/utils.ts
+++ b/packages/ssr/scripts/utils.ts
@@ -98,15 +98,15 @@ function ${toPascalCase(elementName)}(props) {
 
     // Pass wrapped prop to children GCDS components
     if (Array.isArray(props.children)) {
-      for (let x = 0; x< props.children.length; x++) {
-        if (props.children[x].type && props.children[x].type.toString().includes('Gcds')) {
-          cloned.push(React.cloneElement(props.children[x], { wrapped: true, key: x }));
-        } else if (typeof props.children[x] == 'string') {
-          cloned.push(props.children[x]);
+      props.children.map((child, i) => {
+        if (child.type && child.type.toString().includes('Gcds')) {
+          cloned.push(React.cloneElement(child, { wrapped: true, key: i }));
+        } else if (typeof child == 'string') {
+          cloned.push(child);
         } else {
-          cloned.push(React.cloneElement(props.children[x], { key: x }));
+          cloned.push(React.cloneElement(child, { key: i }));
         }
-      }
+      });
     } else if (typeof props.children == 'object') {
       if (props.children.type && props.children.type.toString().includes('Gcds')) {
         cloned.push(React.cloneElement(props.children, { wrapped: true, key: 0 }));


### PR DESCRIPTION
# Summary | Résumé

When using the experimental SSR package, a hydration error would occur when a GCDS component was slotted into another GCDS component. This was happening since the `GcdsWrapper` wraps each  GCDS component when used causing conflicts in the render.  This can be seen with the breadcrumbs, top-nav and side-nav components using https://github.com/ethanWallace/components-ssr-test.

## Solution

Added logic to add a `wrapped` prop into the rendering to prevent a `GcdsWrapper` from being placed inside another `GcdsWrapper`. The new prop is eventually removed before final render so it doesn't display on the component. These props should only be passed to GCDS components and avoid any other component.