### PR TITLE
Export ContentValues type in gcds-grid to fix angular build

### DIFF
--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -13,7 +13,7 @@
       "peerDependencies": {
         "@angular/common": "^16.0.0",
         "@angular/core": "^16.0.0",
-        "@cdssnc/gcds-components": "^0.16.0"
+        "@cdssnc/gcds-components": "^0.18.0"
       }
     },
     "node_modules/@angular/common": {
@@ -105,12 +105,12 @@
       }
     },
     "node_modules/@cdssnc/gcds-components": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-components/-/gcds-components-0.16.0.tgz",
-      "integrity": "sha512-kUs2xCfjPeHark8Rvarmu9ZNQap+4gOApvPbh9J+wBlLQ9NmqDKOouj7Accfcg/i3zq5Qm5y8CGl1WcsZu2DBA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-components/-/gcds-components-0.18.0.tgz",
+      "integrity": "sha512-sH8EAyDksU7sXbrr6IwnOoGb1ZaEOYyOTX3AsBuMIeva0lppxapHqAW51WZd/CX7S4YboZT2+75nBMyAcXq0Jw==",
       "peer": true,
       "dependencies": {
-        "@stencil/core": "^4.0.0",
+        "@stencil/core": "^4.7.2",
         "@stencil/react-output-target": "^0.5.3",
         "@storybook/addon-a11y": "^7.4.0",
         "@storybook/addons": "^7.4.0",
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.7.0.tgz",
-      "integrity": "sha512-hl3hD5FA8F9kZiDJSus08Kno1QRl+fXeMBzrl5DjWAzAu0JHxL1AqTph5oQSekjvkSahaa8JtsXnHRZU93eivg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.1.tgz",
+      "integrity": "sha512-FB3vQR2xbX8RkiKdvBRj6jAe2VunKgB4U5hWSbpdcg/GhZrwOhsEgkGUGa8hGm9bgEUpIu16in1zFqziPyBEFw==",
       "peer": true,
       "bin": {
         "stencil": "bin/stencil"

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -6,7 +6,9 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Validator, ValidatorEntry } from "./validators";
+import { ContentValues } from "./components/gcds-grid/gcds-grid";
 export { Validator, ValidatorEntry } from "./validators";
+export { ContentValues } from "./components/gcds-grid/gcds-grid";
 export namespace Components {
     interface GcdsAlert {
         /**

--- a/packages/web/src/components/gcds-grid/gcds-grid.tsx
+++ b/packages/web/src/components/gcds-grid/gcds-grid.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Host, Prop, h } from '@stencil/core';
 
-type ContentValues =
+export type ContentValues =
   | 'center'
   | 'end'
   | 'space-around'


### PR DESCRIPTION
# Summary | Résumé

Export `ContentValues` type in `gcds-grid` to fix angular build. Was previously saying it could not find `ContentValues`.
