### PR TITLE
fix: update renovate base branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,5 @@
       "before 6am on the first day of the month"
     ]
   },
-  "baseBranches": ["develop"]
+  "baseBranches": ["main"]
 }


### PR DESCRIPTION
Switching Renovate to use `main` as the base branch instead of `develop` since we will be removing the `develop` branch very soon.