### PR TITLE
ci: repurpose build action

### DIFF
--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -57,7 +57,6 @@ jobs:
 
   build-storybook:
     name: Build storybook
-    if: contains(github.event.pull_request.labels.*.name, 'Renovate')
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -1,18 +1,12 @@
-name: Renovate pull request
+name: Build components
 on:
   pull_request:
       branches:
         - main
-      types:
-        - labeled
-        - opened
-        - synchronize
-        - reopened
 
 jobs:
   build-packages:
     name: Build all packages
-    if: contains(github.event.pull_request.labels.*.name, 'Renovate')
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout


### PR DESCRIPTION
# Summary | Résumé

Repurpose our old action to check failing builds on renovate PRs and make them available for all new PRs

Resolves https://github.com/cds-snc/design-gc-conception/issues/656
- https://github.com/cds-snc/design-gc-conception/issues/656