### PR TITLE
Add additional check for href property in gcds-link

### DIFF
--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -210,7 +210,7 @@ export class GcdsLink {
               label={i18n[lang].download}
               margin-left="100"
             />
-          ) : href.toLowerCase().startsWith('mailto:') ? (
+          ) : href && href.toLowerCase().startsWith('mailto:') ? (
             <gcds-icon
               icon-style="regular"
               name="envelope"
@@ -218,6 +218,7 @@ export class GcdsLink {
               margin-left="100"
             />
           ) : (
+            href &&
             href.toLowerCase().startsWith('tel:') && (
               <gcds-icon
                 name="phone"


### PR DESCRIPTION
# Summary | Résumé

Add additional check for `href` property to solve error warning in Next.js. The error would always seem to occur event when an `href` value was present.
