### PR TITLE
Move toggle navigation focusout logic form top-nav to nav-group

### DIFF
--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -7,6 +7,7 @@ import {
   Method,
   Event,
   EventEmitter,
+  Listen,
   h,
 } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
@@ -55,6 +56,18 @@ export class GcdsNavGroup {
    * Style of nav to render based on parent
    */
   @State() navStyle: string;
+
+  @Listen('focusout', { target: 'document' })
+  async focusOutListener(e) {
+    if (
+      (e.target === this.el || this.el.contains(e.target)) &&
+      !this.el.contains(e.relatedTarget) &&
+      this.navStyle == 'dropdown' &&
+      this.open
+    ) {
+      this.toggleNav();
+    }
+  }
 
   /**
    * Focus button element

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -62,7 +62,7 @@ export class GcdsNavGroup {
     if (
       (e.target === this.el || this.el.contains(e.target)) &&
       !this.el.contains(e.relatedTarget) &&
-      this.navStyle == 'dropdown' &&
+      this.navStyle === 'dropdown' &&
       this.open
     ) {
       this.toggleNav();

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
@@ -59,16 +59,6 @@ export class GcdsTopNav {
         if (this.mobile.hasAttribute('open')) {
           await this.mobile.toggleNav();
         }
-      } else {
-        for (let i = 0; i < this.el.children.length; i++) {
-          if (
-            this.el.children[i].nodeName == 'GCDS-NAV-GROUP' &&
-            this.el.children[i].hasAttribute('open')
-          ) {
-            await (this.el.children[i] as HTMLGcdsNavGroupElement).toggleNav();
-            await this.updateNavItemQueue(this.el);
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
# Summary | Résumé

To fix issue flagged in #383, moved the logic to close a dropwdown on focusout from the `gcds-top-nav` to `gcds-nav-group` to allow closure of singular dropdowns.

Resolves #383.

## Example to test

```html
      <gcds-top-nav label="topbar" alignment="right" lang="en">
        <gcds-nav-link href="#red" slot="home">Home</gcds-nav-link>
        <gcds-nav-group
          menu-label="Contact us submenu"
          open-trigger="Contact us"
        >
          <gcds-nav-link href="#red">Form</gcds-nav-link>
          <gcds-nav-link href="#red">GitHub</gcds-nav-link>
          <gcds-nav-link href="#red">Slack</gcds-nav-link>
        </gcds-nav-group>
        <gcds-nav-link href="#red">Installation</gcds-nav-link>
        <gcds-nav-link href="#red">Foundations</gcds-nav-link>
        <gcds-nav-link href="#red" current>Components</gcds-nav-link>
        <gcds-nav-group
          menu-label="Contact us submenu"
          open-trigger="Contact us"
        >
          <gcds-nav-link href="#red">Form</gcds-nav-link>
          <gcds-nav-link href="#red">GitHub</gcds-nav-link>
          <gcds-nav-link href="#red">Slack</gcds-nav-link>
        </gcds-nav-group>
      </gcds-top-nav>
     
