### PR TITLE
refactor: css rewrite error message

### DIFF
--- a/packages/web/src/components/gcds-error-message/gcds-error-message.css
+++ b/packages/web/src/components/gcds-error-message/gcds-error-message.css
@@ -1,12 +1,19 @@
-:host {
-  display: inline-block;
+@layer reset, default;
+
+@layer reset {
+  :host {
+    display: inline-block;
+  }
 }
 
-:host .error-message {
-  font: var(--gcds-error-message-font);
-  margin: var(--gcds-error-message-margin);
-  padding: var(--gcds-error-message-padding);
-  background: var(--gcds-error-message-background);
-  color: var(--gcds-error-message-text);
-  border-inline-start: var(--gcds-error-message-border-width) solid var(--gcds-error-message-border-color);
+@layer default {
+  :host .error-message {
+    font: var(--gcds-error-message-font);
+    margin: var(--gcds-error-message-margin);
+    padding: var(--gcds-error-message-padding);
+    background: var(--gcds-error-message-background);
+    color: var(--gcds-error-message-text);
+    border-inline-start: var(--gcds-error-message-border-width) solid
+      var(--gcds-error-message-border-color);
+  }
 }


### PR DESCRIPTION
# Summary | Résumé

CSS rewrite for the error message component to add new CSS features like layers, etc.

Part of fix for https://github.com/cds-snc/design-gc-conception/issues/627