### PR TITLE
refactor: css rewrite hint

### DIFF
--- a/packages/web/src/components/gcds-hint/gcds-hint.css
+++ b/packages/web/src/components/gcds-hint/gcds-hint.css
@@ -1,4 +1,14 @@
-:host .gcds-hint {
-  font: var(--gcds-hint-font);
-  margin: var(--gcds-hint-margin);
+@layer reset, default;
+
+@layer reset {
+  :host {
+    display: block;
+  }
+}
+
+@layer default {
+  :host .gcds-hint {
+    font: var(--gcds-hint-font);
+    margin: var(--gcds-hint-margin);
+  }
 }

--- a/packages/web/src/components/gcds-hint/gcds-hint.tsx
+++ b/packages/web/src/components/gcds-hint/gcds-hint.tsx
@@ -3,8 +3,7 @@ import { Component, Element, Host, Prop, h } from '@stencil/core';
 @Component({
   tag: 'gcds-hint',
   styleUrl: 'gcds-hint.css',
-  shadow: false,
-  scoped: true,
+  shadow: true,
 })
 export class GcdsHint {
   @Element() el: HTMLElement;

--- a/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
+++ b/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
@@ -9,7 +9,9 @@ describe('gcds-hint', () => {
     });
     expect(root).toEqualHtml(`
       <gcds-hint hint-id="input-renders" hint="Hint Test" id="hint-input-renders">
-        <p class="gcds-hint">Hint Test</p>
+        <mock:shadow-root>
+          <p class="gcds-hint">Hint Test</p>
+        </mock:shadow-root>
       </gcds-hint>
     `);
   });


### PR DESCRIPTION
# Summary | Résumé

CSS rewrite for the hint component to add new CSS features like layers, etc.

Part of fix for https://github.com/cds-snc/design-gc-conception/issues/627