### PR TITLE
refactor: css rewrite textarea

### DIFF
--- a/packages/web/src/components/gcds-textarea/gcds-textarea.css
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.css
@@ -1,58 +1,89 @@
-:host .gcds-textarea-wrapper {
-  width: 100%;
-  max-width: 75ch;
-  font: var(--gcds-textarea-font);
-  color: var(--gcds-textarea-default-text);
-  margin: 0;
-  padding: 0;
-  border: 0;
-  transition: color ease-in-out .15s;
+@layer reset, default, disabled, error, focus;
 
-  &:focus-within {
-    color: var(--gcds-textarea-focus-text);
-  }
-
-  &.gcds-disabled {
-    color: var(--gcds-textarea-disabled-text);
-  }
-
-  .error-message-container {
+@layer reset {
+  :host {
     display: block;
+
+    .gcds-textarea-wrapper {
+      margin: 0;
+      padding: 0;
+      border: 0;
+
+      textarea {
+        box-sizing: border-box;
+      }
+    }
   }
 }
 
-:host textarea {
-  display: block;
-  min-width: 50%;
-  width: 100%;
-  max-width: 100%;
-  height: auto;
-  min-height: var(--gcds-textarea-min-height);
-  font: inherit;
-  margin: var(--gcds-textarea-margin);
-  padding: var(--gcds-textarea-padding);
-  background-color: var(--gcds-textarea-default-background);
-  background-image: none;
-  color: var(--gcds-textarea-default-text);
-  border: var(--gcds-textarea-border-width) solid currentColor;
-  border-radius: var(--gcds-textarea-border-radius);
-  box-sizing: border-box;
-  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s, outline ease-in-out .15s;
+@layer default {
+  :host .gcds-textarea-wrapper {
+    width: 100%;
+    max-width: 75ch;
+    font: var(--gcds-textarea-font);
+    color: var(--gcds-textarea-default-text);
+    transition: color ease-in-out 0.15s;
 
-  &:focus {
-    border-color: var(--gcds-textarea-focus-text);
-    outline: var(--gcds-textarea-outline-width) solid var(--gcds-textarea-focus-text);
-    outline-offset: var(--gcds-textarea-border-width);
-    box-shadow: var(--gcds-textarea-focus-box-shadow);
+    :is(textarea, .textarea__count) {
+      margin: var(--gcds-textarea-margin) !important;
+    }
+
+    textarea {
+      display: block;
+      min-width: 50%;
+      width: 100%;
+      max-width: 100%;
+      height: auto;
+      min-height: var(--gcds-textarea-min-height);
+      font: inherit;
+      padding: var(--gcds-textarea-padding) !important;
+      background-color: var(--gcds-textarea-default-background);
+      background-image: none;
+      color: var(--gcds-textarea-default-text);
+      border: var(--gcds-textarea-border-width) solid currentColor;
+      border-radius: var(--gcds-textarea-border-radius);
+      transition:
+        border-color ease-in-out 0.15s,
+        box-shadow ease-in-out 0.15s,
+        outline ease-in-out 0.15s;
+    }
   }
+}
 
-  &:disabled {
-    cursor: not-allowed;
-    background-color: var(--gcds-textarea-disabled-background);
-    border-color: var(--gcds-textarea-disabled-text);
+@layer disabled {
+  :host .gcds-textarea-wrapper.gcds-disabled {
+    color: var(--gcds-textarea-disabled-text);
+
+    textarea:disabled {
+      cursor: not-allowed;
+      background-color: var(--gcds-textarea-disabled-background);
+      border-color: var(--gcds-textarea-disabled-text);
+    }
   }
+}
 
-  &.gcds-error:not(:focus) {
-    border-color: var(--gcds-textarea-danger-border);
+@layer error {
+  :host .gcds-textarea-wrapper {
+    .error-message-container {
+      display: block;
+    }
+
+    textarea.gcds-error:not(:focus) {
+      border-color: var(--gcds-textarea-danger-border);
+    }
+  }
+}
+
+@layer focus {
+  :host .gcds-textarea-wrapper:focus-within {
+    color: var(--gcds-textarea-focus-text);
+
+    textarea:focus {
+      border-color: var(--gcds-textarea-focus-text);
+      outline: var(--gcds-textarea-outline-width) solid
+        var(--gcds-textarea-focus-text);
+      outline-offset: var(--gcds-textarea-border-width);
+      box-shadow: var(--gcds-textarea-focus-box-shadow);
+    }
   }
 }

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -383,7 +383,11 @@ export class GcdsTextarea {
           </textarea>
 
           {characterCount ? (
-            <p id={`textarea__count-${textareaId}`} aria-live="polite">
+            <p
+              id={`textarea__count-${textareaId}`}
+              class="textarea__count"
+              aria-live="polite"
+            >
               {value == undefined
                 ? `${characterCount} ${i18n[lang].characters.allowed}`
                 : `${characterCount - value.length} ${

--- a/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
+++ b/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
@@ -44,7 +44,7 @@ describe('gcds-textarea', () => {
             rows="5"
             maxlength="22"
           >Value Test</textarea>
-          <p id="textarea__count-character-count" aria-live="polite">12 characters left</p>
+          <p id="textarea__count-character-count" class="textarea__count" aria-live="polite">12 characters left</p>
         </div>
       </gcds-textarea>
     `);
@@ -68,7 +68,7 @@ describe('gcds-textarea', () => {
             rows="5"
             maxlength="22"
           >Value Test</textarea>
-          <p id="textarea__count-character-count" aria-live="polite">12 caractères restants</p>
+          <p id="textarea__count-character-count" class="textarea__count" aria-live="polite">12 caractères restants</p>
         </div>
       </gcds-textarea>
     `);


### PR DESCRIPTION
# Summary | Résumé

CSS rewrite for the textarea component to add new CSS features like layers, etc.

Part of fix for https://github.com/cds-snc/design-gc-conception/issues/627