### PR TITLE
refactor: css rewrite lang-toggle

### DIFF
--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
@@ -1,53 +1,67 @@
-:host {
-  display: block;
-  font: var(--gcds-lang-toggle-font);
+@layer reset, default, hover, focus, desktop;
 
-  h2 {
-    margin: 0;
-    overflow: hidden;
-    position: absolute;
-    width: 0;
+@layer reset {
+  :host {
+    display: block;
+
+    .gcds-lang-toggle h2 {
+      margin: 0;
+      overflow: hidden;
+      position: absolute;
+      width: 0;
+    }
   }
+}
 
-  a {
-    color: var(--gcds-lang-toggle-default-text);
-    padding: var(--gcds-lang-toggle-padding);
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
-    text-decoration-color: currentColor;
-    text-decoration-thickness: var(
-      --gcds-lang-toggle-default-decoration-thickness
-    );
+@layer default {
+  :host .gcds-lang-toggle {
+    font: var(--gcds-lang-toggle-font);
 
-    span {
-      display: none;
+    a {
+      color: var(--gcds-lang-toggle-default-text);
+      padding: var(--gcds-lang-toggle-padding);
+      text-decoration: underline currentColor
+        var(--gcds-lang-toggle-default-decoration-thickness);
+      text-underline-offset: 0.2em;
+
+      span {
+        display: none;
+      }
+
+      abbr {
+        text-transform: uppercase;
+        text-decoration: none;
+      }
     }
+  }
+}
 
-    abbr {
-      text-transform: uppercase;
-      text-decoration: none;
-    }
-
-    &:hover {
+@layer hover {
+  @media (hover: hover) {
+    :host .gcds-lang-toggle a:hover {
       color: var(--gcds-lang-toggle-hover-text);
       text-decoration-thickness: var(
         --gcds-lang-toggle-hover-decoration-thickness
       );
     }
-
-    &:focus {
-      color: var(--gcds-lang-toggle-focus-text);
-      background-color: var(--gcds-lang-toggle-focus-background);
-      border-radius: var(--gcds-lang-toggle-focus-border-radius);
-      text-decoration: none;
-      box-shadow: var(--gcds-lang-toggle-focus-box-shadow);
-      outline-offset: var(--gcds-lang-toggle-focus-outline-offset);
-      outline: var(--gcds-lang-toggle-focus-outline);
-    }
   }
+}
 
+@layer focus {
+  :host .gcds-lang-toggle a:focus {
+    color: var(--gcds-lang-toggle-focus-text);
+    background-color: var(--gcds-lang-toggle-focus-background);
+    border-radius: var(--gcds-lang-toggle-focus-border-radius);
+    text-decoration: none;
+    box-shadow: var(--gcds-lang-toggle-focus-box-shadow);
+    outline-offset: var(--gcds-lang-toggle-focus-outline-offset);
+    outline: var(--gcds-lang-toggle-focus-outline);
+  }
+}
+
+@layer desktop {
   @media screen and (min-width: 64em) {
-    a {
+    :host .gcds-lang-toggle a {
       padding: 0;
 
       span {

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
@@ -59,8 +59,9 @@
   }
 }
 
+/* Note: viewport specific style decision */
 @layer desktop {
-  @media screen and (min-width: 64em) {
+  @media screen and (width >= 64em) {
     :host .gcds-lang-toggle a {
       padding: 0;
 

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
@@ -48,7 +48,7 @@ export class GcdsLangToggle {
 
     return (
       <Host>
-        <div>
+        <div class="gcds-lang-toggle">
           <h2>{i18n[lang].heading}</h2>
           <a href={href} lang={i18n[lang].abbreviation}>
             <span>{i18n[lang].language}</span>

--- a/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
@@ -10,7 +10,7 @@ describe('gcds-lang-toggle', () => {
     expect(page.root).toEqualHtml(`
       <gcds-lang-toggle href="/fr/" lang="en">
         <mock:shadow-root>
-        <div>
+        <div class="gcds-lang-toggle">
           <h2>Language Selection</h2>
           <a href="/fr/" lang="fr">
             <span>Français</span>
@@ -30,7 +30,7 @@ describe('gcds-lang-toggle', () => {
     expect(page.root).toEqualHtml(`
       <gcds-lang-toggle href="/en/" lang="fr">
         <mock:shadow-root>
-        <div>
+        <div class="gcds-lang-toggle">
           <h2>Sélection de la langue</h2>
           <a href="/en/" lang="en">
             <span>English</span>


### PR DESCRIPTION
# Summary | Résumé

CSS rewrite for the lang-toggle to add new CSS features like layers, etc.

Part of fix for https://github.com/cds-snc/design-gc-conception/issues/627.