### PR TITLE
refactor: css rewrite breadcrumbs

### DIFF
--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -1,7 +1,24 @@
-:host {
-  &(.gcds-breadcrumbs-item) {
-    position: relative;
+@layer reset, default, hover, focus;
+
+@layer reset {
+  :host(.gcds-breadcrumbs-item) {
     display: inline-block;
+
+    a {
+      display: inline-block;
+      outline: 0;
+      white-space: normal;
+    }
+
+    slot {
+      display: block;
+    }
+  }
+}
+
+@layer default {
+  :host(.gcds-breadcrumbs-item) {
+    position: relative;
     padding: var(--gcds-breadcrumbs-item-padding) !important;
 
     &:before {
@@ -12,39 +29,40 @@
     }
 
     a {
-      display: inline-block;
       color: var(--gcds-breadcrumbs-default-text);
-      outline: 0;
       margin: var(--gcds-breadcrumbs-item-margin);
       padding: var(--gcds-breadcrumbs-item-link-padding);
       text-underline-offset: 0.2em;
       text-decoration-color: currentColor;
-      text-decoration-thickness: var(--gcds-breadcrumbs-default-decoration-thickness);
-      transition: background 0.15s ease-in-out, color 0.15s ease-in-out;
-      white-space: normal;
-
-      slot {
-        display: block;
-      }
+      text-decoration-thickness: var(
+        --gcds-breadcrumbs-default-decoration-thickness
+      );
+      transition:
+        background 0.15s ease-in-out,
+        color 0.15s ease-in-out;
     }
   }
+}
 
-  &(:focus) {
-    a {
-      border-radius: var(--gcds-breadcrumbs-focus-border-radius);
-      background-color: var(--gcds-breadcrumbs-focus-background);
-      color: var(--gcds-breadcrumbs-focus-text);
-      text-decoration: none;
-      box-shadow: var(--gcds-breadcrumbs-focus-box-shadow);
-      outline-offset: var(--gcds-breadcrumbs-focus-outline-offset);
-      outline: var(--gcds-breadcrumbs-focus-outline);
-    }
-  }
-
-  &(:not(:focus)) {
-    a:hover {
+@layer hover {
+  @media (hover: hover) {
+    :host(.gcds-breadcrumbs-item) a:hover {
       color: var(--gcds-breadcrumbs-hover-text);
-      text-decoration-thickness: var(--gcds-breadcrumbs-hover-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-breadcrumbs-hover-decoration-thickness
+      );
     }
+  }
+}
+
+@layer focus {
+  :host(.gcds-breadcrumbs-item) a:focus {
+    border-radius: var(--gcds-breadcrumbs-focus-border-radius);
+    background-color: var(--gcds-breadcrumbs-focus-background);
+    color: var(--gcds-breadcrumbs-focus-text);
+    text-decoration: none;
+    box-shadow: var(--gcds-breadcrumbs-focus-box-shadow);
+    outline-offset: var(--gcds-breadcrumbs-focus-outline-offset);
+    outline: var(--gcds-breadcrumbs-focus-outline);
   }
 }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
@@ -1,8 +1,19 @@
-:host .gcds-breadcrumbs {
-  ol {
+@layer reset, default;
+
+@layer reset {
+  :host {
+    display: block;
+
+    .gcds-breadcrumbs ol {
+      list-style: none;
+      overflow-x: hidden;
+    }
+  }
+}
+
+@layer default {
+  :host .gcds-breadcrumbs ol {
     font: var(--gcds-breadcrumbs-font);
-    list-style: none;
-    overflow-x: hidden;
     margin: var(--gcds-breadcrumbs-margin);
     padding: var(--gcds-breadcrumbs-padding);
 
@@ -11,10 +22,8 @@
       margin: var(--gcds-breadcrumbs-item-first-child-margin) !important;
     }
 
-    &.has-canada-link gcds-breadcrumbs-item:first-child {
-      &:before {
-        display: none;
-      }
+    &.has-canada-link gcds-breadcrumbs-item:first-child:before {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

CSS rewrite for the breadcrumbs component to add new CSS features like layers, etc.

Part of fix for https://github.com/cds-snc/design-gc-conception/issues/627.