### PR TITLE
fix: storybook spacing in component preview

### DIFF
--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -45,9 +45,9 @@
     border: none !important;
   }
 
-  /* Copy & hide code btns */
-  .docs-story > .css-1wjen9k {
-    padding-block-end: var(--gcds-spacing-700);
+  /* Add space between component preview + copy & hide code btns */
+  .docs-story .sb-story {
+    padding-block-end: var(--gcds-spacing-500);
   }
 
   .docs-story .css-25bv1u,


### PR DESCRIPTION
# Summary | Résumé

A recent Storybook update changed the class name for one of our styles. I updated it to add the styling to a different (semantic) class in the preview code which Storybook normally doesn't update. If they change it again, I will change it to use the tag, but normally they do stick to their semantic class names.

Before:
<img width="1061" alt="Screenshot 2024-02-08 at 11 48 02 AM" src="https://github.com/cds-snc/gcds-components/assets/8675814/d13110f2-bd7f-4537-a75f-04aee6f92dd7">

After:
<img width="1079" alt="Screenshot 2024-02-08 at 11 47 54 AM" src="https://github.com/cds-snc/gcds-components/assets/8675814/b5cc5be9-7c57-4107-bcac-17bf3eafa71d">
