### PR TITLE
docs: Update installation instructions for the monorepo changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Toute la documentation sur les composants de Système de design GC est accessibl
 - Exécutez ensuite `npm install` pour installer toutes les dépendances Node.js.
 - Finalement, exécutez `npm run build` pour compiler les trois paquets (composants Web, React et Angular).
 
-Vous pouvez tester localement les paquets Angular et React puisque ce référentiel est configuré à l’aide de [lerna](https://lerna.js.org/), qui utilise [`npm workspaces`](https://docs.npmjs.com/cli/v10/using-npm/workspaces) à la base. Npm workspaces gère automatiquement la liaison de paquets dépendants à l’exécution de `npm install`, donc nul besoin d’exécuter manuellement npm link.
+Vous pouvez tester localement les paquets Angular et React puisque ce référentiel est configuré à l’aide de [lerna](https://lerna.js.org/), qui utilise [`npm workspaces`](https://docs.npmjs.com/cli/v10/using-npm/workspaces) à la base. Npm workspaces gère automatiquement la liaison de paquets dépendants à l’exécution de `npm install`, donc nul besoin d’exécuter manuellement `npm link`.
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -79,12 +79,8 @@ Toute la documentation sur les composants de Système de design GC est accessibl
 
 - Copiez le référentiel `git clone https://github.com/cds-snc/gcds-components`.
 - Exécutez ensuite `npm install` pour installer toutes les dépendances Node.js.
-- Finalement, exécutez `npm run build` pour compiler les composants Web. [FR]
 - Finalement, exécutez `npm run build` pour compiler les trois paquets (composants web, react et angular). [FR]
 
-Pour tester localement les paquets Angular/React, assurez-vous de connecter les paquets au paquet Web en utilisant `npm link`. [original, to be removed]
-
-Pour tester localement les paquets Angular et React 
 You can test the Angular and React packages locally as this repository is setup using [lerna](https://lerna.js.org/) which uses [`npm workspaces`](https://docs.npmjs.com/cli/v10/using-npm/workspaces) under the hood. Npm workspaces automatically handles the linking of dependent packages on `npm install` so there is no need to manually use `npm link`. [FR]
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Toute la documentation sur les composants de Système de design GC est accessibl
 
 - Copiez le référentiel `git clone https://github.com/cds-snc/gcds-components`.
 - Exécutez ensuite `npm install` pour installer toutes les dépendances Node.js.
-- Finalement, exécutez `npm run build` pour compiler les trois paquets (composants web, react et angular). [FR]
+- Finalement, exécutez `npm run build` pour compiler les trois paquets (composants Web, React et Angular).
 
-You can test the Angular and React packages locally as this repository is setup using [lerna](https://lerna.js.org/) which uses [`npm workspaces`](https://docs.npmjs.com/cli/v10/using-npm/workspaces) under the hood. Npm workspaces automatically handles the linking of dependent packages on `npm install` so there is no need to manually use `npm link`. [FR]
+Vous pouvez tester localement les paquets Angular et React puisque ce référentiel est configuré à l’aide de [lerna](https://lerna.js.org/), qui utilise [`npm workspaces`](https://docs.npmjs.com/cli/v10/using-npm/workspaces) à la base. Npm workspaces gère automatiquement la liaison de paquets dépendants à l’exécution de `npm install`, donc nul besoin d’exécuter manuellement npm link.
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ You can find the full documentation for GC Design System Components on [https://
 ## Local installation
 
 - Clone the repo `git clone https://github.com/cds-snc/gcds-components`.
-- Change into the `/packages/web` directory.
 - Run `npm install` to install all Node.js dependencies.
-- Run `npm run build` to compile web components.
+- Run `npm run build` to compile all three packages (web components, react and angular).
 
-To test the Angular/React packages locally make sure to link the packages to the web package using `npm link`.
+You can test the Angular and React packages locally as this repository is setup using [lerna](https://lerna.js.org/) which uses [`npm workspaces`](https://docs.npmjs.com/cli/v10/using-npm/workspaces) under the hood. Npm workspaces automatically handles the linking of dependent packages on `npm install` so there is no need to manually use `npm link`.
+
 <br/>
 <br/>
 
@@ -78,11 +78,15 @@ Toute la documentation sur les composants de Système de design GC est accessibl
 ## Installation locale
 
 - Copiez le référentiel `git clone https://github.com/cds-snc/gcds-components`.
-- Allez dans le répertoire `/packages/web`.
 - Exécutez ensuite `npm install` pour installer toutes les dépendances Node.js.
-- Finalement, exécutez `npm run build` pour compiler les composants Web.
+- Finalement, exécutez `npm run build` pour compiler les composants Web. [FR]
+- Finalement, exécutez `npm run build` pour compiler les trois paquets (composants web, react et angular). [FR]
 
-Pour tester localement les paquets Angular/React, assurez-vous de connecter les paquets au paquet Web en utilisant `npm link`.
+Pour tester localement les paquets Angular/React, assurez-vous de connecter les paquets au paquet Web en utilisant `npm link`. [original, to be removed]
+
+Pour tester localement les paquets Angular et React 
+You can test the Angular and React packages locally as this repository is setup using [lerna](https://lerna.js.org/) which uses [`npm workspaces`](https://docs.npmjs.com/cli/v10/using-npm/workspaces) under the hood. Npm workspaces automatically handles the linking of dependent packages on `npm install` so there is no need to manually use `npm link`. [FR]
+
 <br/>
 <br/>
 


### PR DESCRIPTION
# Summary | Résumé

Updating the installation instructions in the repo's main README to reflect the changes for the mono repo setup.

Translations provided by @EliseKa (big thank you!)

To preview, you can visit https://github.com/cds-snc/gcds-components/tree/docs/monorepo-instructions and scroll down to see how it looks like.