### PR TITLE
ci: add workflow dispatch to release generator gh action

### DIFF
--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -1,5 +1,6 @@
 name: Release Generator
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
# Summary | Résumé
I had the release please workflow paused and it didn't run, and realized it can't be manually dispatched.

This PR adds the `workflow_dispath` trigger to release please so we can choose to run it manually if we need to.