### PR TITLE
ci: workflow fixes

### DIFF
--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -27,4 +27,3 @@ jobs:
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
           release-type: node
-          include-component-in-tag: true

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
           skip-github-release: true
+          target-branch: ci/gh-workflow-fix

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -19,12 +19,12 @@ jobs:
       - uses: actions/create-github-app-token@86576b355dd19da0519e0bdb63d8edb5bcf76a25 # v1.7.0
         id: sre_app_token
         with:
-          app_id: ${{ secrets.SRE_APP_ID }}
-          private_key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SRE_APP_ID }}
+          private-key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
 
       - uses: google-github-actions/release-please-action@cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e # v4.0.2
+        id: release
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
           release-type: node
           skip-github-release: true
-          skip-github-pull-request: true

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -23,4 +23,3 @@ jobs:
         id: release
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
-          target-branch: ci/gh-workflow-fix

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -1,6 +1,9 @@
 name: Release Generator
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -21,7 +24,7 @@ jobs:
 
       - uses: google-github-actions/release-please-action@cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e # v4.0.2
         with:
-          command: manifest
           token: ${{ steps.sre_app_token.outputs.token }}
           release-type: node
-          default-branch: main
+          skip-github-release: true
+          skip-github-pull-request: true

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -1,9 +1,6 @@
 name: Release Generator
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
@@ -26,5 +23,4 @@ jobs:
         id: release
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
-          skip-github-release: true
           target-branch: ci/gh-workflow-fix

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -26,4 +26,4 @@ jobs:
         id: release
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
-          release-type: node
+          skip-github-release: true

--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           token: ${{ steps.sre_app_token.outputs.token }}
           release-type: node
-          skip-github-release: true
+          include-component-in-tag: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -40,6 +40,10 @@
   "release-type": "node",
   "plugins": [
     {
+      "type": "node-workspace",
+      "updatePeerDependencies": true
+    },
+    {
       "type": "linked-versions",
       "groupName": "GCDS Components",
       "components": [


### PR DESCRIPTION
# Summary | Résumé
GH Action for release please behaves differently from testing on local environment. I'll test the workflow on this PR instead to get a better view of what it's trying to do.

Things changed:
- The Release Please GH Action changed a few things (which we want!), the biggest thing is that we had the setting `release-type: node` set which seemed innocuous but [it actually now stops release please from using the manifest file](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#upgrading-from-v3-to-v4)
- Release please config for `node-workspaces` plugin is needed to update the peer dependencies. I thought about taking it out because it shows up as additional lines in the generated CHANGELOG, but without it, the PR fails due to the peer dependencies not being updated to the new version.

This [PR](https://github.com/cds-snc/gcds-components/pull/440) is an example of the release pr created by these changes. Once this is merged, I expect it to simply update https://github.com/cds-snc/gcds-components/pull/439