### PR TITLE
fix: Storybook events and property page accessibility

### DIFF
--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -118,22 +118,6 @@
     color: var(--gcds-text-primary) !important;
   }
 
-  .docblock-argstable-head th:nth-child(1) span:before {
-    content: 'Property | Propriété';
-  }
-
-  .docblock-argstable-head th:nth-child(2) span:before {
-    content: 'Data type | Type de donnée';
-  }
-
-  .docblock-argstable-head th:nth-child(3) span:before {
-    content: 'Default value | Valeur par défaut';
-  }
-
-  .docblock-argstable-head th:nth-child(4) span:before {
-    content: 'Values | Valeurs';
-  }
-
   /* Table Styling */
   .docblock-argstable-head tr th,
   .docblock-argstable-body tr td.css-11nj37o,

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -391,6 +391,8 @@
 	      formatTable(document.querySelector('.docblock-argstable'), url.get('lang'));
       }
     }, 200);
+
+    // Chnage language on hide/copy code buttons
     if (url.get('lang') === 'fr') {
       var buttonTimer = setInterval(function() {
         if (document.querySelector('.docblock-code-toggle')) {
@@ -398,7 +400,31 @@
           formatFrenchButtons(document.querySelector('.docblock-code-toggle'));
         }
       }, 200);
+
+      copyButtonTimer();
     }
+  }
+
+  function copyButtonTimer() {
+    var buttonTimer = setInterval(function() {
+      if (document.querySelector('.css-otxova')) {
+        clearInterval(buttonTimer);
+        formatCopyButton(document.querySelector('.css-otxova'));
+      }
+    }, 200);
+  }
+
+  function formatCopyButton(button) {
+    button.innerText = 'Copie';
+
+    button.addEventListener('click', () => {
+      setTimeout(() => {
+        button.innerText = 'Copié';
+      }, 10);
+      setTimeout(() => {
+        button.innerText = 'Copie';
+      }, 1800);
+    })
   }
 
   function formatFrenchButtons(button) {
@@ -410,6 +436,7 @@
         setTimeout(() => {
           button.innerText = "Masquer le code";
         }, 10);
+        copyButtonTimer();
       } else {
         setTimeout(() => {
           button.innerText = "Voir le code";

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -392,7 +392,7 @@
       }
     }, 200);
 
-    // Chnage language on hide/copy code buttons
+    // Change language on hide/copy code buttons
     if (url.get('lang') === 'fr') {
       var buttonTimer = setInterval(function() {
         if (document.querySelector('.docblock-code-toggle')) {

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -374,4 +374,114 @@
   #story--components-top-navigation--default {
     height: 300px;
   }
+
+  .css-8ycahn * .token.comment {
+      color: white !important;
+  }
 </style>
+
+<script>
+  const url = new URLSearchParams(window.location.search);
+
+  if (url.get('demo') && url.get('lang')) {
+    var timer = setInterval(function() {
+      if (document.querySelector('.docblock-argstable')) {
+        clearInterval(timer);
+	      formatTable(document.querySelector('.docblock-argstable'), url.get('lang'));
+      }
+    }, 200);
+  }
+
+  function formatTable(table, lang) {
+    // Format table header
+    const tableHead = [...table.querySelectorAll('th')];
+    tableHead.forEach(th => {
+      th.setAttribute('lang', lang);
+      if (lang == 'en') {
+        const thText = th.innerText;
+        if (thText == 'Name') {
+          th.innerText = 'Property';
+        } else if (thText == 'Description') {
+          th.innerText = 'Data type';
+        } else if (thText == 'Default') {
+          th.innerText = 'Default value';
+        } else if (thText == 'Control') {
+          const resetBtn = th.querySelector('button');
+          th.innerText = 'Values';
+          resetBtn.setAttribute('style', 'float: right;');
+          th.append(resetBtn);
+        }
+      } else {
+        const thText = th.innerText;
+        if (thText == 'Name') {
+          th.innerText = 'Propriété';
+        } else if (thText == 'Description') {
+          th.innerText = 'Type de donnée';
+        } else if (thText == 'Default') {
+          th.innerText = 'Valeur par défaut';
+        } else if (thText == 'Control') {
+          const resetBtn = th.querySelector('button');
+          th.innerText = 'Valeurs';
+          resetBtn.setAttribute('style', 'float: right;');
+          resetBtn.setAttribute('title', 'Réinitialiser les contrôles');
+          th.append(resetBtn);
+        }
+      }
+    });
+
+    // Table Rows
+    const tableRows = [...table.querySelectorAll('tbody > tr')];
+    tableRows.forEach(tr => {
+      // Expand collapse rows
+      if (tr.hasAttribute('class')) {
+        tr.removeAttribute('title');
+        const cellText = tr.children[1].innerText.split(' | ');
+        tr.children[1].innerText = lang === 'en' ? cellText[0] : cellText[1].replace(' items', '');
+        tr.setAttribute('class', '');
+        tr.children[1].setAttribute('class', '');
+        tr.removeChild(tr.children[0]);
+      }
+
+      // Loop through table cells
+      const propertyId = `${tr.children[0].innerText.replace('*', '')}-property`;
+      for (let x = 0; x < tr.children.length; x++) {
+        // Format first cell
+        if (x == 0) {
+          tr.children[x].setAttribute('id', propertyId);
+          if (tr.children[x].querySelector('[title=Required]') && lang == 'fr') {
+            tr.children[x].querySelector('[title=Required]').setAttribute('lang', 'fr');
+            tr.children[x].querySelector('[title=Required]').setAttribute('title', 'Obligatoire');
+          }
+        }
+        // Format third cell
+        if (tr.children[x].innerText === '-') {
+          if (lang === 'en') {
+            tr.children[x].setAttribute('title', 'No default value');
+          } else {
+            tr.children[x].setAttribute('title', 'Aucune valeur par défaut');
+            tr.children[x].setAttribute('lang', 'fr');
+          }
+        }
+        // Format last cell
+        if (x === 3) {
+          if (tr.children[x].querySelector('select')) {
+            tr.children[x].querySelector('select').setAttribute('aria-labelledby', propertyId);
+
+            if (lang === 'fr') {
+              const firstSelectOption = tr.children[x].querySelector('select').children[0];
+              firstSelectOption.setAttribute('lang', 'fr');
+              firstSelectOption.innerText = 'Choisir une option';
+            }
+          }
+
+          // Remove placeholders and assign aria-labelledby
+          if (tr.children[x].querySelector('[placeholder]')) {
+            const formElement = tr.children[x].querySelector('[placeholder]');
+            formElement.removeAttribute('placeholder');
+            formElement.setAttribute('aria-labelledby', propertyId);
+          }
+        }
+      }
+    });
+  }
+</script>

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -137,7 +137,8 @@
   /* Table Styling */
   .docblock-argstable-head tr th,
   .docblock-argstable-body tr td.css-11nj37o,
-  .docblock-argstable-body tr .css-11nj37o ~ td {
+  .docblock-argstable-body tr .css-11nj37o ~ td,
+  .sub-table-heading {
     background-color: var(--gcds-color-grayscale-0) !important;
     border-radius: 0 !important;
     color: var(--gcds-text-primary) !important;
@@ -197,7 +198,7 @@
     border: var(--gcds-border-width-sm) solid currentColor;
   }
 
-  .docblock-argstable-body td {
+  .docblock-argstable-body td:not(.sub-table-heading) {
     vertical-align: middle !important;
     background-color: #262626 !important;
     color: var(--gcds-text-light);
@@ -384,12 +385,37 @@
   const url = new URLSearchParams(window.location.search);
 
   if (url.get('demo') && url.get('lang')) {
-    var timer = setInterval(function() {
+    var tableTimer = setInterval(function() {
       if (document.querySelector('.docblock-argstable')) {
-        clearInterval(timer);
+        clearInterval(tableTimer);
 	      formatTable(document.querySelector('.docblock-argstable'), url.get('lang'));
       }
     }, 200);
+    if (url.get('lang') === 'fr') {
+      var buttonTimer = setInterval(function() {
+        if (document.querySelector('.docblock-code-toggle')) {
+          clearInterval(buttonTimer);
+          formatFrenchButtons(document.querySelector('.docblock-code-toggle'));
+        }
+      }, 200);
+    }
+  }
+
+  function formatFrenchButtons(button) {
+    setTimeout(() => {
+      button.innerText = "Masquer le code";
+    }, 10);
+    button.addEventListener('click', () => {
+      if (!button.classList.contains('docblock-code-toggle--expanded')) {
+        setTimeout(() => {
+          button.innerText = "Masquer le code";
+        }, 10);
+      } else {
+        setTimeout(() => {
+          button.innerText = "Voir le code";
+        }, 10);
+      }
+    });
   }
 
   function formatTable(table, lang) {
@@ -435,10 +461,13 @@
       // Expand collapse rows
       if (tr.hasAttribute('class')) {
         tr.removeAttribute('title');
-        const cellText = tr.children[1].innerText.split(' | ');
-        tr.children[1].innerText = lang === 'en' ? cellText[0] : cellText[1].replace(' items', '');
+        const cellText = tr.children[0].children[1].innerText.toLowerCase().split(' | ');
+        tr.children[1].innerText = lang === 'en' ? 
+          cellText[0].charAt(0).toUpperCase() + cellText[0].slice(1) : 
+          cellText[1].replace(' items', '').charAt(0).toUpperCase() + cellText[1].slice(1);
         tr.setAttribute('class', '');
-        tr.children[1].setAttribute('class', '');
+        tr.children[1].setAttribute('colspan', '4');
+        tr.children[1].setAttribute('class', 'sub-table-heading');
         tr.removeChild(tr.children[0]);
       }
 

--- a/packages/web/src/utils/storybook/component-properties.js
+++ b/packages/web/src/utils/storybook/component-properties.js
@@ -1,4 +1,4 @@
-const formProps = {
+export const formProps = {
   disabled: {
     control: 'boolean',
     table: {
@@ -47,7 +47,7 @@ const formProps = {
   },
 };
 
-const langProp = {
+export const langProp = {
   lang: {
     control: 'radio',
     options: ['en', 'fr'],
@@ -58,7 +58,7 @@ const langProp = {
   },
 };
 
-const validatorProps = {
+export const validatorProps = {
   validateOn: {
     name: 'validate-on',
     control: { type: 'select' },
@@ -68,10 +68,4 @@ const validatorProps = {
       defaultValue: { summary: 'blur' },
     },
   },
-};
-
-export default {
-  formProps,
-  validatorProps,
-  langProp,
 };


### PR DESCRIPTION
# Summary | Résumé

Add script to document head to run various fixes for storybook events and properties page. The script will only run when the query strings `demo="true"` and `lang="en | fr"` are present.

Example url: `/iframe.html?viewMode=docs&demo=true&lang=fr&singleStory=true&id=components-input--events-properties`

## Fixes

- https://github.com/cds-snc/design-gc-conception/issues/694
- https://github.com/cds-snc/design-gc-conception/issues/691
- https://github.com/cds-snc/design-gc-conception/issues/687
- https://github.com/cds-snc/design-gc-conception/issues/686
- Tagged english only content, like property names, with `lang="en"`
