### PR TITLE
fix: Fixes identified in OCADU report (a11y and usability)

### DIFF
--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -663,7 +663,7 @@ export namespace Components {
         /**
           * String to have autocomplete enabled
          */
-        "autocomplete"?: 'on' | 'off';
+        "autocomplete"?: string;
         /**
           * Custom callback function on blur event
          */
@@ -2471,7 +2471,7 @@ declare namespace LocalJSX {
         /**
           * String to have autocomplete enabled
          */
-        "autocomplete"?: 'on' | 'off';
+        "autocomplete"?: string;
         /**
           * Custom callback function on blur event
          */

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -1,4 +1,6 @@
-import { Element, Component, Host, Prop, h, Fragment } from '@stencil/core';
+import { Element, Component, Host, Prop, h, Fragment, State } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
 
 @Component({
   tag: 'gcds-card',
@@ -48,6 +50,30 @@ export class GcdsCard {
    */
   @Prop({ reflect: true }) imgAlt: string;
 
+  /**
+   * Language of rendered component
+   */
+  @State() lang: string;
+
+  /*
+   * Observe lang attribute change
+   */
+  updateLang() {
+    const observer = new MutationObserver(mutations => {
+      if (mutations[0].oldValue != this.el.lang) {
+        this.lang = this.el.lang;
+      }
+    });
+    observer.observe(this.el, observerConfig);
+  }
+
+  async componentWillLoad() {
+    // Define lang attribute
+    this.lang = assignLanguage(this.el);
+
+    this.updateLang();
+  }
+
   private get hasCardFooter() {
     return !!this.el.querySelector('[slot="footer"]');
   }
@@ -63,9 +89,16 @@ export class GcdsCard {
       imgSrc,
       imgAlt,
       hasCardFooter,
+      lang
     } = this;
 
     const Element = titleElement;
+
+    const taggedAttr = {};
+
+    if (tag) {
+      taggedAttr['aria-describedby'] = 'gcds-card__tag';
+    }
 
     return (
       <Host>
@@ -77,13 +110,18 @@ export class GcdsCard {
               class="gcds-card__image"
             />
           )}
-          {tag && <span class="gcds-card__tag">{tag}</span>}
+          {tag && (
+            <span id="gcds-card__tag" class="gcds-card__tag">
+              <gcds-sr-only>{i18n[lang].tagged}</gcds-sr-only>
+              {tag}
+            </span>
+          )}
           {Element != 'a' ? (
-            <Element class="gcds-card__title">
+            <Element class="gcds-card__title" {...taggedAttr}>
               <a href={href}>{cardTitle}</a>
             </Element>
           ) : (
-            <a href={href} class="gcds-card__title">
+            <a href={href} class="gcds-card__title" {...taggedAttr}>
               {cardTitle}
             </a>
           )}

--- a/packages/web/src/components/gcds-card/i18n/i18n.js
+++ b/packages/web/src/components/gcds-card/i18n/i18n.js
@@ -1,0 +1,10 @@
+const I18N = {
+  en: {
+    tagged: 'Tagged:',
+  },
+  fr: {
+    tagged: 'Baliser :',
+  },
+};
+
+export default I18N;

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -19,6 +19,19 @@
 | `type`                   | `type`          | The type attribute specifies how the card renders as a link                                            | `"action" \| "link"`                  | `'link'`    |
 
 
+## Dependencies
+
+### Depends on
+
+- [gcds-sr-only](../gcds-sr-only)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-card --> gcds-sr-only
+  style gcds-card fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -85,8 +85,13 @@ describe('gcds-card', () => {
     <gcds-card card-title="Card" href="#card" tag="Tag" type="link">
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
-          <span class="gcds-card__tag">Tag</span>
-          <a class="gcds-card__title" href="#card">
+          <span class="gcds-card__tag" id="gcds-card__tag">
+            <gcds-sr-only>
+              Tagged:
+            </gcds-sr-only>
+            Tag
+          </span>
+          <a aria-describedby="gcds-card__tag" class="gcds-card__title" href="#card">
             Card
           </a>
         </div>

--- a/packages/web/src/components/gcds-footer/gcds-footer.tsx
+++ b/packages/web/src/components/gcds-footer/gcds-footer.tsx
@@ -148,8 +148,10 @@ export class GcdsFooter {
         {contextualLinksObject && contextualHeading && (
           <div class="gcds-footer__contextual">
             <div class="contextual__container">
-              <nav aria-label={contextualHeading}>
-                <h3 class="contextual__header">{contextualHeading}</h3>
+              <nav aria-labelledby="contextual__header">
+                <h3 id="contextual__header" class="contextual__header">
+                  {contextualHeading}
+                </h3>
                 <ul class="contextual__list">
                   {Object.keys(contextualLinksObject).map(key => {
                     if (contextualLinkCount < 3) {
@@ -170,8 +172,8 @@ export class GcdsFooter {
         {display === 'full' ? (
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav class="main__govnav" aria-label={I18N[lang].gov.heading}>
-                <h3>{I18N[lang].gov.heading}</h3>
+              <nav class="main__govnav" aria-labelledby="govnav__header">
+                <h3 id="govnav__header">{I18N[lang].gov.heading}</h3>
                 <ul class="govnav__list">
                   {Object.keys(govNav).map(value => (
                     <li>
@@ -182,9 +184,9 @@ export class GcdsFooter {
               </nav>
               <nav
                 class="main__themenav"
-                aria-label={I18N[lang].themes.heading}
+                aria-labelledby="themenav__header"
               >
-                <h4 class="themenav__header">{I18N[lang].themes.heading}</h4>
+                <h4 id="themenav__header" class="themenav__header">{I18N[lang].themes.heading}</h4>
                 <ul class="themenav__list">
                   {Object.keys(themeNav).map(value => (
                     <li>
@@ -199,8 +201,8 @@ export class GcdsFooter {
 
         <div class="gcds-footer__sub">
           <div class="sub__container">
-            <nav aria-label={I18N[lang].site.heading}>
-              <h3 class="sub__header">{I18N[lang].site.heading}</h3>
+            <nav aria-labelledby="sub__header">
+              <h3 id="sub__header" class="sub__header">{I18N[lang].site.heading}</h3>
               <ul>
                 {subLinks
                   ? Object.keys(subLinksObject).map(key => {

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
@@ -13,8 +13,8 @@ describe('gcds-footer', () => {
           <h2 class="gcds-footer__header">About this site</h2>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-label="Government of Canada Corporate">
-                <h3 class="sub__header">
+              <nav aria-labelledby="sub__header">
+                <h3 class="sub__header" id="sub__header">
                   Government of Canada Corporate
                 </h3>
                 <ul>
@@ -66,8 +66,8 @@ describe('gcds-footer', () => {
           <h2 class="gcds-footer__header">About this site</h2>
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav aria-label="Government of Canada" class="main__govnav">
-                <h3>
+              <nav aria-labelledby="govnav__header" class="main__govnav">
+                <h3 id="govnav__header">
                   Government of Canada
                 </h3>
                 <ul class="govnav__list">
@@ -88,8 +88,8 @@ describe('gcds-footer', () => {
                   </li>
                 </ul>
               </nav>
-              <nav aria-label="Themes and topics" class="main__themenav">
-                <h4 class="themenav__header">
+              <nav aria-labelledby="themenav__header" class="main__themenav">
+                <h4 class="themenav__header" id="themenav__header">
                   Themes and topics
                 </h4>
                 <ul class="themenav__list">
@@ -189,8 +189,8 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-label="Government of Canada Corporate">
-                <h3 class="sub__header">
+              <nav aria-labelledby="sub__header">
+                <h3 class="sub__header" id="sub__header">
                   Government of Canada Corporate
                 </h3>
                 <ul>
@@ -242,8 +242,8 @@ describe('gcds-footer', () => {
           <h2 class="gcds-footer__header">À propos de ce site</h2>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-label="Organisation du gouvernement du Canada">
-                <h3 class="sub__header">
+              <nav aria-labelledby="sub__header">
+                <h3 class="sub__header" id="sub__header">
                   Organisation du gouvernement du Canada
                 </h3>
                 <ul>
@@ -295,8 +295,8 @@ describe('gcds-footer', () => {
           <h2 class="gcds-footer__header">À propos de ce site</h2>
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav aria-label="Gouvernement du Canada" class="main__govnav">
-                <h3>
+              <nav aria-labelledby="govnav__header" class="main__govnav">
+                <h3 id="govnav__header">
                   Gouvernement du Canada
                 </h3>
                 <ul class="govnav__list">
@@ -317,8 +317,8 @@ describe('gcds-footer', () => {
                   </li>
                 </ul>
               </nav>
-              <nav aria-label="Thèmes et sujets" class="main__themenav">
-                <h4 class="themenav__header">
+              <nav aria-labelledby="themenav__header" class="main__themenav">
+                <h4 class="themenav__header" id="themenav__header">
                   Thèmes et sujets
                 </h4>
                 <ul class="themenav__list">
@@ -418,8 +418,8 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-label="Organisation du gouvernement du Canada">
-                <h3 class="sub__header">
+              <nav aria-labelledby="sub__header">
+                <h3 class="sub__header" id="sub__header">
                   Organisation du gouvernement du Canada
                 </h3>
                 <ul>
@@ -476,8 +476,8 @@ describe('gcds-footer', () => {
           <h2 class="gcds-footer__header">About this site</h2>
           <div class="gcds-footer__contextual">
             <div class="contextual__container">
-              <nav aria-label="Heading">
-                <h3 class="contextual__header">
+              <nav aria-labelledby="contextual__header">
+                <h3 class="contextual__header" id="contextual__header">
                   Heading
                 </h3>
                 <ul class="contextual__list">
@@ -502,8 +502,8 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav aria-label="Government of Canada" class="main__govnav">
-                <h3>
+              <nav aria-labelledby="govnav__header" class="main__govnav">
+                <h3 id="govnav__header">
                   Government of Canada
                 </h3>
                 <ul class="govnav__list">
@@ -524,8 +524,8 @@ describe('gcds-footer', () => {
                   </li>
                 </ul>
               </nav>
-              <nav aria-label="Themes and topics" class="main__themenav">
-                <h4 class="themenav__header">
+              <nav aria-labelledby="themenav__header" class="main__themenav">
+                <h4 class="themenav__header" id="themenav__header">
                   Themes and topics
                 </h4>
                 <ul class="themenav__list">
@@ -625,8 +625,8 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-label="Government of Canada Corporate">
-                <h3 class="sub__header">
+              <nav aria-labelledby="sub__header">
+                <h3 class="sub__header" id="sub__header">
                   Government of Canada Corporate
                 </h3>
                 <ul>
@@ -682,8 +682,8 @@ describe('gcds-footer', () => {
           <h2 class="gcds-footer__header">About this site</h2>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-label="Government of Canada Corporate">
-                <h3 class="sub__header">
+              <nav aria-labelledby="sub__header">
+                <h3 class="sub__header" id="sub__header">
                   Government of Canada Corporate
                 </h3>
                 <ul>

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -112,7 +112,7 @@ export class GcdsInput {
   /**
    * String to have autocomplete enabled
    */
-  @Prop() autocomplete?: 'on' | 'off';
+  @Prop() autocomplete?: string;
 
   /**
    * Custom callback function on change event

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -9,7 +9,7 @@
 
 | Property               | Attribute       | Description                                                      | Type                                                               | Default     |
 | ---------------------- | --------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------ | ----------- |
-| `autocomplete`         | `autocomplete`  | String to have autocomplete enabled                              | `"off" \| "on"`                                                    | `undefined` |
+| `autocomplete`         | `autocomplete`  | String to have autocomplete enabled                              | `string`                                                           | `undefined` |
 | `blurHandler`          | --              | Custom callback function on blur event                           | `Function`                                                         | `undefined` |
 | `changeHandler`        | --              | Custom callback function on change event                         | `Function`                                                         | `undefined` |
 | `disabled`             | `disabled`      | Specifies if an input element is disabled or not.                | `boolean`                                                          | `false`     |


### PR DESCRIPTION
# Summary | Résumé

Updates to the `gcds-card`, `gcds-footer` and `gcds-input` components based on the OCADU report.

## Card changes

- https://github.com/cds-snc/design-gc-conception/issues/684 Add hidden "Tagged:" text to card tag
- Use `aria-describedby` to make sure tag is not missed if tabbing between focusable elements

## Footer changes

- Remove `aria-label`'s and use existing headings in `gcds-footer` to label landmarks with `aria-labelledby`

## Input changes

- Change `autocomplete` property from `on  | off` to accept any `string`
