### PR TITLE
refactor: replace gcds-button skip-to-href with gcds-link component

### DIFF
--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -78,5 +78,20 @@
     width: 100%;
     margin-inline: auto;
     top: var(--gcds-header-skiptonav-top);
+
+    gcds-link {
+      z-index: 3;
+      position: absolute;
+      top: var(--gcds-header-skiptonav-top);
+      left: 0;
+      width: inherit;
+
+      &:not(:focus) {
+        width: 0;
+        height: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+      }
+    }
   }
 }

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -65,13 +65,7 @@ export class GcdsHeader {
     } else if (this.skipToHref) {
       return (
         <nav class="gcds-header__skip-to-nav">
-          <gcds-button
-            type="link"
-            button-role="skip-to-content"
-            href={this.skipToHref}
-          >
-            {i18n[this.lang].skip}
-          </gcds-button>
+          <gcds-link href={this.skipToHref}>{i18n[this.lang].skip}</gcds-link>
         </nav>
       );
     } else {

--- a/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
+++ b/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
@@ -32,9 +32,9 @@ describe('gcds-header', () => {
       <gcds-header lang-href="/fr/" role="banner" signature-has-link="true" signature-variant="colour" skip-to-href="#main">
         <mock:shadow-root>
           <nav class="gcds-header__skip-to-nav">
-            <gcds-button button-role="skip-to-content" type="link" href="#main">
+            <gcds-link href="#main">
               Skip to main content
-            </gcds-button>
+            </gcds-link>
           </nav>
           <div class="gcds-header__brand">
             <div class="brand__container container--simple">


### PR DESCRIPTION
# Summary | Résumé

Replacing the skip-to-href `gcds-button` in the header component with the new `gcds-link` component.