### PR TITLE
refactor: integrate gcds-link into existing components

### DIFF
--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -4,9 +4,8 @@
   :host(.gcds-breadcrumbs-item) {
     display: inline-block;
 
-    a {
+    gcds-link::part(link) {
       display: inline-block;
-      outline: 0;
       white-space: normal;
     }
 
@@ -28,41 +27,9 @@
       content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' height='12px' viewBox='0 0 8 14'><path fill='26374a' d='M7.7,6.3c0.4,0.4,0.4,1,0,1.4l-6,6c-0.4,0.4-1,0.4-1.4,0s-0.4-1,0-1.4L5.6,7L0.3,1.7c-0.4-0.4-0.4-1,0-1.4s1-0.4,1.4,0 L7.7,6.3L7.7,6.3z'/></svg>");
     }
 
-    a {
-      color: var(--gcds-breadcrumbs-default-text);
+    gcds-link::part(link) {
       margin: var(--gcds-breadcrumbs-item-margin);
       padding: var(--gcds-breadcrumbs-item-link-padding);
-      text-underline-offset: 0.2em;
-      text-decoration-color: currentColor;
-      text-decoration-thickness: var(
-        --gcds-breadcrumbs-default-decoration-thickness
-      );
-      transition:
-        background 0.15s ease-in-out,
-        color 0.15s ease-in-out;
     }
-  }
-}
-
-@layer hover {
-  @media (hover: hover) {
-    :host(.gcds-breadcrumbs-item) a:hover {
-      color: var(--gcds-breadcrumbs-hover-text);
-      text-decoration-thickness: var(
-        --gcds-breadcrumbs-hover-decoration-thickness
-      );
-    }
-  }
-}
-
-@layer focus {
-  :host(.gcds-breadcrumbs-item) a:focus {
-    border-radius: var(--gcds-breadcrumbs-focus-border-radius);
-    background-color: var(--gcds-breadcrumbs-focus-background);
-    color: var(--gcds-breadcrumbs-focus-text);
-    text-decoration: none;
-    box-shadow: var(--gcds-breadcrumbs-focus-box-shadow);
-    outline-offset: var(--gcds-breadcrumbs-focus-outline-offset);
-    outline: var(--gcds-breadcrumbs-focus-outline);
   }
 }

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
@@ -22,9 +22,9 @@ export class GcdsBreadcrumbsItem {
 
     return (
       <Host role="listitem" class="gcds-breadcrumbs-item">
-        <a href={href}>
+        <gcds-link href={href}>
           <slot></slot>
-        </a>
+        </gcds-link>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-breadcrumbs/readme.md
+++ b/packages/web/src/components/gcds-breadcrumbs/readme.md
@@ -18,9 +18,15 @@
 
  - [gcds-breadcrumbs](.)
 
+### Depends on
+
+- [gcds-link](../gcds-link)
+
 ### Graph
 ```mermaid
 graph TD;
+  gcds-breadcrumbs-item --> gcds-link
+  gcds-link --> gcds-icon
   gcds-breadcrumbs --> gcds-breadcrumbs-item
   style gcds-breadcrumbs-item fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -1,4 +1,4 @@
-@layer reset, default, slot, link, hover, focus;
+@layer reset, default, slot, link, hover;
 
 @layer reset {
   :host {
@@ -41,14 +41,8 @@
       color: var(--gcds-card-tag-color);
     }
 
-    :is(.gcds-card__title, .gcds-card__title > a) {
-      color: var(--gcds-card-title-color);
+    .gcds-card__title {
       font: var(--gcds-card-title-font);
-      text-underline-offset: var(--gcds-card-title-text-underline-offset);
-      text-decoration-color: currentColor;
-      text-decoration-thickness: var(
-        --gcds-card-title-text-decoration-thickness
-      );
       width: fit-content;
     }
 
@@ -76,18 +70,15 @@
 }
 
 @layer link {
-  :host .gcds-card.gcds-card--link {
-    .gcds-card__title > a::after,
-    a.gcds-card__title::after {
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      z-index: 1;
-      pointer-events: auto;
-      content: '';
-    }
+  :host .gcds-card.gcds-card--link gcds-link::part(link):after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    pointer-events: auto;
+    content: '';
   }
 }
 
@@ -100,29 +91,12 @@
         box-shadow: var(--gcds-card-hover-box-shadow);
       }
 
-      :is(
-          &.gcds-card--link:hover .gcds-card__title > a,
-          &.gcds-card--link:hover a.gcds-card__title,
-          .gcds-card__title > a:hover,
-          a.gcds-card__title:hover
-        ) {
+      &.gcds-card--link:hover gcds-link::part(link) {
         color: var(--gcds-card-hover-title-color);
         text-decoration-thickness: var(
           --gcds-card-hover-title-text-decoration-thickness
         );
       }
     }
-  }
-}
-
-@layer focus {
-  :host .gcds-card :is(.gcds-card__title > a:focus, a.gcds-card__title:focus) {
-    background-color: var(--gcds-card-focus-background);
-    border-radius: var(--gcds-card-focus-border-radius);
-    box-shadow: var(--gcds-card-focus-box-shadow);
-    color: var(--gcds-card-focus-color);
-    outline: var(--gcds-card-focus-outline);
-    outline-offset: var(--gcds-card-focus-outline-offset);
-    text-decoration: none;
   }
 }

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -80,12 +80,12 @@ export class GcdsCard {
           {tag && <span class="gcds-card__tag">{tag}</span>}
           {Element != 'a' ? (
             <Element class="gcds-card__title">
-              <a href={href}>{cardTitle}</a>
+              <gcds-link href={href}>{cardTitle}</gcds-link>
             </Element>
           ) : (
-            <a href={href} class="gcds-card__title">
+            <gcds-link href={href} class="gcds-card__title">
               {cardTitle}
-            </a>
+            </gcds-link>
           )}
 
           {description && <p class="gcds-card__description">{description}</p>}

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -19,6 +19,20 @@
 | `type`                   | `type`          | The type attribute specifies how the card renders as a link                                            | `"action" \| "link"`                  | `'link'`    |
 
 
+## Dependencies
+
+### Depends on
+
+- [gcds-link](../gcds-link)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-card --> gcds-link
+  gcds-link --> gcds-icon
+  style gcds-card fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -15,9 +15,9 @@ describe('gcds-card', () => {
     <gcds-card card-title="Card" href="#card" type="link">
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
-          <a class="gcds-card__title" href="#card">
+          <gcds-link class="gcds-card__title" href="#card">
             Card
-          </a>
+          </gcds-link>
         </div>
       </mock:shadow-root>
     </gcds-card
@@ -37,9 +37,9 @@ describe('gcds-card', () => {
     <gcds-card card-title="Card" href="#card" type="action">
       <mock:shadow-root>
         <div class="gcds-card gcds-card--action">
-          <a class="gcds-card__title" href="#card">
+          <gcds-link class="gcds-card__title" href="#card">
             Card
-          </a>
+          </gcds-link>
         </div>
       </mock:shadow-root>
     </gcds-card
@@ -61,9 +61,9 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
           <h3 class="gcds-card__title">
-            <a href="#card">
+            <gcds-link href="#card">
                 Card
-            </a>
+            </gcds-link>
           </h3>
         </div>
       </mock:shadow-root>
@@ -86,9 +86,9 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
           <span class="gcds-card__tag">Tag</span>
-          <a class="gcds-card__title" href="#card">
+          <gcds-link class="gcds-card__title" href="#card">
             Card
-          </a>
+          </gcds-link>
         </div>
       </mock:shadow-root>
     </gcds-card
@@ -109,9 +109,9 @@ describe('gcds-card', () => {
     <gcds-card card-title="Card" href="#card" description="This is the card description" type="link">
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
-          <a class="gcds-card__title" href="#card">
+          <gcds-link class="gcds-card__title" href="#card">
             Card
-          </a>
+          </gcds-link>
           <p class="gcds-card__description">
             This is the card description
           </p>
@@ -135,9 +135,9 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
           <img alt="" class="gcds-card__image" src="https://picsum.photos/480/270">
-          <a class="gcds-card__title" href="#card">
+          <gcds-link class="gcds-card__title" href="#card">
             Card
-          </a>
+          </gcds-link>
         </div>
       </mock:shadow-root>
     </gcds-card>
@@ -159,9 +159,9 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
           <img alt="Alt text for image from picsum" class="gcds-card__image" src="https://picsum.photos/480/270">
-          <a class="gcds-card__title" href="#card">
+          <gcds-link class="gcds-card__title" href="#card">
             Card
-          </a>
+          </gcds-link>
         </div>
       </mock:shadow-root>
     </gcds-card>
@@ -183,9 +183,9 @@ describe('gcds-card', () => {
     <gcds-card card-title="Card" href="#card" type="link">
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
-          <a class="gcds-card__title" href="#card">
+          <gcds-link class="gcds-card__title" href="#card">
             Card
-          </a>
+          </gcds-link>
           <div class="gcds-card__spacer"></div>
           <slot name="footer"></slot>
         </div>

--- a/packages/web/src/components/gcds-footer/gcds-footer.css
+++ b/packages/web/src/components/gcds-footer/gcds-footer.css
@@ -1,4 +1,4 @@
-@layer reset, default, contextual, main, sub, hover, focus, small, compact, medium, wide;
+@layer reset, default, contextual, main, sub, small, compact, medium, wide;
 
 @layer reset {
   :host {
@@ -8,7 +8,7 @@
       display: initial;
     }
 
-    a:not(:hover) {
+    gcds-link::part(link):not(:hover) {
       text-decoration: none;
     }
 
@@ -61,9 +61,8 @@
       grid-template-columns: 1fr;
       grid-gap: var(--gcds-footer-list-grid-gap);
 
-      li a {
+      li gcds-link::part(link) {
         color: var(--gcds-footer-main-text);
-        text-underline-position: under;
       }
     }
   }
@@ -144,37 +143,7 @@
           width: var(--gcds-footer-sub-signature-md-width);
         }
       }
-
-      a {
-        color: var(--gcds-footer-sub-text);
-        transition: color 0.15s;
-      }
     }
-  }
-}
-
-@layer hover {
-  @media (hover: hover) {
-    :host .gcds-footer__sub .sub__container a:hover {
-      color: var(--gcds-footer-sub-hover-text);
-      text-underline-offset: 0.2em;
-      text-decoration: underline;
-      text-decoration-thickness: var(
-        --gcds-footer-sub-hover-decoration-thickness
-      );
-    }
-  }
-}
-
-@layer focus {
-  :host ul li a:focus {
-    color: var(--gcds-footer-link-focus-text);
-    background-color: var(--gcds-footer-link-focus-background);
-    border-radius: var(--gcds-footer-link-focus-radius);
-    text-decoration: none;
-    box-shadow: var(--gcds-footer-link-focus-box-shadow);
-    outline-offset: var(--gcds-footer-link-focus-outline-offset);
-    outline: var(--gcds-footer-link-focus-outline);
   }
 }
 

--- a/packages/web/src/components/gcds-footer/gcds-footer.tsx
+++ b/packages/web/src/components/gcds-footer/gcds-footer.tsx
@@ -82,7 +82,6 @@ export class GcdsFooter {
         this.lang = this.el.lang;
       }
     });
-
     observer.observe(this.el, observerConfig);
   }
 

--- a/packages/web/src/components/gcds-footer/gcds-footer.tsx
+++ b/packages/web/src/components/gcds-footer/gcds-footer.tsx
@@ -82,6 +82,7 @@ export class GcdsFooter {
         this.lang = this.el.lang;
       }
     });
+
     observer.observe(this.el, observerConfig);
   }
 
@@ -157,7 +158,9 @@ export class GcdsFooter {
 
                       return (
                         <li>
-                          <a href={contextualLinksObject[key]}>{key}</a>
+                          <gcds-link href={contextualLinksObject[key]}>
+                            {key}
+                          </gcds-link>
                         </li>
                       );
                     }
@@ -175,7 +178,9 @@ export class GcdsFooter {
                 <ul class="govnav__list">
                   {Object.keys(govNav).map(value => (
                     <li>
-                      <a href={govNav[value].link}>{govNav[value].text}</a>
+                      <gcds-link href={govNav[value].link}>
+                        {govNav[value].text}
+                      </gcds-link>
                     </li>
                   ))}
                 </ul>
@@ -188,7 +193,9 @@ export class GcdsFooter {
                 <ul class="themenav__list">
                   {Object.keys(themeNav).map(value => (
                     <li>
-                      <a href={themeNav[value].link}>{themeNav[value].text}</a>
+                      <gcds-link href={themeNav[value].link}>
+                        {themeNav[value].text}
+                      </gcds-link>
                     </li>
                   ))}
                 </ul>
@@ -209,7 +216,9 @@ export class GcdsFooter {
 
                         return (
                           <li>
-                            <a href={subLinksObject[key]}>{key}</a>
+                            <gcds-link href={subLinksObject[key]}>
+                              {key}
+                            </gcds-link>
                           </li>
                         );
                       }
@@ -217,9 +226,9 @@ export class GcdsFooter {
                   : Object.keys(siteNav).map(value => {
                       return (
                         <li>
-                          <a href={siteNav[value].link}>
+                          <gcds-link href={siteNav[value].link}>
                             {siteNav[value].text}
-                          </a>
+                          </gcds-link>
                         </li>
                       );
                     })}

--- a/packages/web/src/components/gcds-footer/readme.md
+++ b/packages/web/src/components/gcds-footer/readme.md
@@ -21,11 +21,14 @@
 ### Depends on
 
 - [gcds-signature](../gcds-signature)
+- [gcds-link](../gcds-link)
 
 ### Graph
 ```mermaid
 graph TD;
   gcds-footer --> gcds-signature
+  gcds-footer --> gcds-link
+  gcds-link --> gcds-icon
   style gcds-footer fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
@@ -19,29 +19,29 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <a href="https://www.canada.ca/en/social.html">
+                    <gcds-link href="https://www.canada.ca/en/social.html">
                       Social media
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/mobile.html">
+                    <gcds-link href="https://www.canada.ca/en/mobile.html">
                       Mobile applications
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/government/about.html">
+                    <gcds-link href="https://www.canada.ca/en/government/about.html">
                       About Canada.ca
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/transparency/terms.html">
+                    <gcds-link href="https://www.canada.ca/en/transparency/terms.html">
                       Terms and conditions
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/transparency/privacy.html">
+                    <gcds-link href="https://www.canada.ca/en/transparency/privacy.html">
                       Privacy
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -72,19 +72,19 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="govnav__list">
                   <li>
-                    <a href="https://www.canada.ca/en/contact.html">
+                    <gcds-link href="https://www.canada.ca/en/contact.html">
                       All Contacts
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/government/dept.html">
+                    <gcds-link href="https://www.canada.ca/en/government/dept.html">
                       Departments and agencies
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/government/system.html">
+                    <gcds-link href="https://www.canada.ca/en/government/system.html">
                       About government
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -94,94 +94,94 @@ describe('gcds-footer', () => {
                 </h4>
                 <ul class="themenav__list">
                   <li>
-                    <a href="https://www.canada.ca/en/services/jobs.html">
+                    <gcds-link href="https://www.canada.ca/en/services/jobs.html">
                       Jobs
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/immigration-citizenship.html">
+                    <gcds-link href="https://www.canada.ca/en/services/immigration-citizenship.html">
                       Immigration and citizenship
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://travel.gc.ca/">
+                    <gcds-link href="https://travel.gc.ca/">
                       Travel and tourism
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/business.html">
+                    <gcds-link href="https://www.canada.ca/en/services/business.html">
                       Business
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/benefits.html">
+                    <gcds-link href="https://www.canada.ca/en/services/benefits.html">
                       Benefits
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/health.html">
+                    <gcds-link href="https://www.canada.ca/en/services/health.html">
                       Health
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/taxes.html">
+                    <gcds-link href="https://www.canada.ca/en/services/taxes.html">
                       Taxes
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/environment.html">
+                    <gcds-link href="https://www.canada.ca/en/services/environment.html">
                       Environment and natural resources
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/defence.html">
+                    <gcds-link href="https://www.canada.ca/en/services/defence.html">
                       National security and defence
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/culture.html">
+                    <gcds-link href="https://www.canada.ca/en/services/culture.html">
                       Culture, history and sport
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/policing.html">
+                    <gcds-link href="https://www.canada.ca/en/services/policing.html">
                       Policing, justice and emergencies
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/transport.html">
+                    <gcds-link href="https://www.canada.ca/en/services/transport.html">
                       Transport and infrastructure
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
+                    <gcds-link href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
                       Canada and the world
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/finance.html">
+                    <gcds-link href="https://www.canada.ca/en/services/finance.html">
                       Money and finance
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/science.html">
+                    <gcds-link href="https://www.canada.ca/en/services/science.html">
                       Science and innovation
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/indigenous-peoples.html">
+                    <gcds-link href="https://www.canada.ca/en/services/indigenous-peoples.html">
                       Indigenous peoples
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/veterans.html">
+                    <gcds-link href="https://www.canada.ca/en/services/veterans.html">
                       Veterans and military
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/youth.html">
+                    <gcds-link href="https://www.canada.ca/en/services/youth.html">
                       Youth
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -195,29 +195,29 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <a href="https://www.canada.ca/en/social.html">
+                    <gcds-link href="https://www.canada.ca/en/social.html">
                       Social media
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/mobile.html">
+                    <gcds-link href="https://www.canada.ca/en/mobile.html">
                       Mobile applications
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/government/about.html">
+                    <gcds-link href="https://www.canada.ca/en/government/about.html">
                       About Canada.ca
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/transparency/terms.html">
+                    <gcds-link href="https://www.canada.ca/en/transparency/terms.html">
                       Terms and conditions
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/transparency/privacy.html">
+                    <gcds-link href="https://www.canada.ca/en/transparency/privacy.html">
                       Privacy
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -248,29 +248,29 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <a href="https://www.canada.ca/fr/sociaux.html">
+                    <gcds-link href="https://www.canada.ca/fr/sociaux.html">
                       Médias sociaux
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/mobile.html">
+                    <gcds-link href="https://www.canada.ca/fr/mobile.html">
                       Applications mobiles
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/gouvernement/a-propos.html">
+                    <gcds-link href="https://www.canada.ca/fr/gouvernement/a-propos.html">
                       À propos de Canada.ca
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/transparence/avis.html">
+                    <gcds-link href="https://www.canada.ca/fr/transparence/avis.html">
                       Avis
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/transparence/confidentialite.html">
+                    <gcds-link href="https://www.canada.ca/fr/transparence/confidentialite.html">
                       Confidentialité
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -301,19 +301,19 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="govnav__list">
                   <li>
-                    <a href="https://www.canada.ca/fr/contact.html">
+                    <gcds-link href="https://www.canada.ca/fr/contact.html">
                       Toutes les coordonnées
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/gouvernement/min.html">
+                    <gcds-link href="https://www.canada.ca/fr/gouvernement/min.html">
                       Ministères et organismes
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/gouvernement/systeme.html">
+                    <gcds-link href="https://www.canada.ca/fr/gouvernement/systeme.html">
                       À propos du gouvernement
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -323,94 +323,94 @@ describe('gcds-footer', () => {
                 </h4>
                 <ul class="themenav__list">
                   <li>
-                    <a href="https://www.canada.ca/fr/services/emplois.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/emplois.html">
                       Emplois
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/immigration-citoyennete.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/immigration-citoyennete.html">
                       Immigration et citoyenneté
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://voyage.gc.ca/">
+                    <gcds-link href="https://voyage.gc.ca/">
                       Voyage et tourisme
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/entreprises.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/entreprises.html">
                       Entreprises
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/prestations.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/prestations.html">
                       Prestations
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/sante.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/sante.html">
                       Santé
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/impots.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/impots.html">
                       Impôts
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/environnement.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/environnement.html">
                       Environnement et ressources naturelles
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/defense.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/defense.html">
                       Sécurité nationale et défense
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/culture.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/culture.html">
                       Culture, histoire et sport
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/police.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/police.html">
                       Services de police, justice et urgences
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/transport.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/transport.html">
                       Transport et infrastructure
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.international.gc.ca/world-monde/index.aspx?lang=fra">
+                    <gcds-link href="https://www.international.gc.ca/world-monde/index.aspx?lang=fra">
                       Le Canada et le monde
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/finance.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/finance.html">
                       Argent et finance
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/science.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/science.html">
                       Science et innovation
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/autochtones.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/autochtones.html">
                       Autochtones
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/veterans.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/veterans.html">
                       Vétérans et militaires
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/services/jeunesse.html">
+                    <gcds-link href="https://www.canada.ca/fr/services/jeunesse.html">
                       Jeunesse
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -424,29 +424,29 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <a href="https://www.canada.ca/fr/sociaux.html">
+                    <gcds-link href="https://www.canada.ca/fr/sociaux.html">
                       Médias sociaux
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/mobile.html">
+                    <gcds-link href="https://www.canada.ca/fr/mobile.html">
                       Applications mobiles
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/gouvernement/a-propos.html">
+                    <gcds-link href="https://www.canada.ca/fr/gouvernement/a-propos.html">
                       À propos de Canada.ca
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/transparence/avis.html">
+                    <gcds-link href="https://www.canada.ca/fr/transparence/avis.html">
                       Avis
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/fr/transparence/confidentialite.html">
+                    <gcds-link href="https://www.canada.ca/fr/transparence/confidentialite.html">
                       Confidentialité
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -482,19 +482,19 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="contextual__list">
                   <li>
-                    <a href="#red">
+                    <gcds-link href="#red">
                       Link 1
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="#green">
+                    <gcds-link href="#green">
                       Link 2
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="#blue">
+                    <gcds-link href="#blue">
                       Link 3
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -508,19 +508,19 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="govnav__list">
                   <li>
-                    <a href="https://www.canada.ca/en/contact.html">
+                    <gcds-link href="https://www.canada.ca/en/contact.html">
                       All Contacts
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/government/dept.html">
+                    <gcds-link href="https://www.canada.ca/en/government/dept.html">
                       Departments and agencies
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/government/system.html">
+                    <gcds-link href="https://www.canada.ca/en/government/system.html">
                       About government
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -530,94 +530,94 @@ describe('gcds-footer', () => {
                 </h4>
                 <ul class="themenav__list">
                   <li>
-                    <a href="https://www.canada.ca/en/services/jobs.html">
+                    <gcds-link href="https://www.canada.ca/en/services/jobs.html">
                       Jobs
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/immigration-citizenship.html">
+                    <gcds-link href="https://www.canada.ca/en/services/immigration-citizenship.html">
                       Immigration and citizenship
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://travel.gc.ca/">
+                    <gcds-link href="https://travel.gc.ca/">
                       Travel and tourism
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/business.html">
+                    <gcds-link href="https://www.canada.ca/en/services/business.html">
                       Business
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/benefits.html">
+                    <gcds-link href="https://www.canada.ca/en/services/benefits.html">
                       Benefits
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/health.html">
+                    <gcds-link href="https://www.canada.ca/en/services/health.html">
                       Health
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/taxes.html">
+                    <gcds-link href="https://www.canada.ca/en/services/taxes.html">
                       Taxes
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/environment.html">
+                    <gcds-link href="https://www.canada.ca/en/services/environment.html">
                       Environment and natural resources
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/defence.html">
+                    <gcds-link href="https://www.canada.ca/en/services/defence.html">
                       National security and defence
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/culture.html">
+                    <gcds-link href="https://www.canada.ca/en/services/culture.html">
                       Culture, history and sport
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/policing.html">
+                    <gcds-link href="https://www.canada.ca/en/services/policing.html">
                       Policing, justice and emergencies
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/transport.html">
+                    <gcds-link href="https://www.canada.ca/en/services/transport.html">
                       Transport and infrastructure
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
+                    <gcds-link href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
                       Canada and the world
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/finance.html">
+                    <gcds-link href="https://www.canada.ca/en/services/finance.html">
                       Money and finance
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/science.html">
+                    <gcds-link href="https://www.canada.ca/en/services/science.html">
                       Science and innovation
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/indigenous-peoples.html">
+                    <gcds-link href="https://www.canada.ca/en/services/indigenous-peoples.html">
                       Indigenous peoples
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/veterans.html">
+                    <gcds-link href="https://www.canada.ca/en/services/veterans.html">
                       Veterans and military
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/services/youth.html">
+                    <gcds-link href="https://www.canada.ca/en/services/youth.html">
                       Youth
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -631,29 +631,29 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <a href="https://www.canada.ca/en/social.html">
+                    <gcds-link href="https://www.canada.ca/en/social.html">
                       Social media
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/mobile.html">
+                    <gcds-link href="https://www.canada.ca/en/mobile.html">
                       Mobile applications
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/government/about.html">
+                    <gcds-link href="https://www.canada.ca/en/government/about.html">
                       About Canada.ca
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/transparency/terms.html">
+                    <gcds-link href="https://www.canada.ca/en/transparency/terms.html">
                       Terms and conditions
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="https://www.canada.ca/en/transparency/privacy.html">
+                    <gcds-link href="https://www.canada.ca/en/transparency/privacy.html">
                       Privacy
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>
@@ -688,19 +688,19 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <a href="#red">
+                    <gcds-link href="#red">
                       Link 1
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="#green">
+                    <gcds-link href="#green">
                       Link 2
-                    </a>
+                    </gcds-link>
                   </li>
                   <li>
-                    <a href="#blue">
+                    <gcds-link href="#blue">
                       Link 3
-                    </a>
+                    </gcds-link>
                   </li>
                 </ul>
               </nav>

--- a/packages/web/src/components/gcds-header/readme.md
+++ b/packages/web/src/components/gcds-header/readme.md
@@ -30,6 +30,8 @@ graph TD;
   gcds-header --> gcds-lang-toggle
   gcds-header --> gcds-signature
   gcds-button --> gcds-icon
+  gcds-lang-toggle --> gcds-link
+  gcds-link --> gcds-icon
   style gcds-header fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
@@ -1,4 +1,4 @@
-@layer reset, default, hover, focus, desktop;
+@layer reset, default, desktop;
 
 @layer reset {
   :host {
@@ -17,53 +17,28 @@
   :host .gcds-lang-toggle {
     font: var(--gcds-lang-toggle-font);
 
-    a {
-      color: var(--gcds-lang-toggle-default-text);
+    gcds-link::part(link) {
       padding: var(--gcds-lang-toggle-padding);
-      text-decoration: underline currentColor
-        var(--gcds-lang-toggle-default-decoration-thickness);
-      text-underline-offset: 0.2em;
-
-      span {
-        display: none;
-      }
-
-      abbr {
-        text-transform: uppercase;
-        text-decoration: none;
-      }
     }
-  }
-}
 
-@layer hover {
-  @media (hover: hover) {
-    :host .gcds-lang-toggle a:hover {
-      color: var(--gcds-lang-toggle-hover-text);
-      text-decoration-thickness: var(
-        --gcds-lang-toggle-hover-decoration-thickness
-      );
+    span {
+      display: none;
     }
-  }
-}
 
-@layer focus {
-  :host .gcds-lang-toggle a:focus {
-    color: var(--gcds-lang-toggle-focus-text);
-    background-color: var(--gcds-lang-toggle-focus-background);
-    border-radius: var(--gcds-lang-toggle-focus-border-radius);
-    text-decoration: none;
-    box-shadow: var(--gcds-lang-toggle-focus-box-shadow);
-    outline-offset: var(--gcds-lang-toggle-focus-outline-offset);
-    outline: var(--gcds-lang-toggle-focus-outline);
+    abbr {
+      text-transform: uppercase;
+      text-decoration: none;
+    }
   }
 }
 
 /* Note: viewport specific style decision */
 @layer desktop {
   @media screen and (width >= 64em) {
-    :host .gcds-lang-toggle a {
-      padding: 0;
+    :host .gcds-lang-toggle {
+      gcds-link::part(link) {
+        padding: 0;
+      }
 
       span {
         display: initial;

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
@@ -50,10 +50,10 @@ export class GcdsLangToggle {
       <Host>
         <div class="gcds-lang-toggle">
           <h2>{i18n[lang].heading}</h2>
-          <a href={href} lang={i18n[lang].abbreviation}>
+          <gcds-link href={href} lang={i18n[lang].abbreviation}>
             <span>{i18n[lang].language}</span>
             <abbr title={i18n[lang].language}>{i18n[lang].abbreviation}</abbr>
-          </a>
+          </gcds-link>
         </div>
       </Host>
     );

--- a/packages/web/src/components/gcds-lang-toggle/readme.md
+++ b/packages/web/src/components/gcds-lang-toggle/readme.md
@@ -18,9 +18,15 @@
 
  - [gcds-header](../gcds-header)
 
+### Depends on
+
+- [gcds-link](../gcds-link)
+
 ### Graph
 ```mermaid
 graph TD;
+  gcds-lang-toggle --> gcds-link
+  gcds-link --> gcds-icon
   gcds-header --> gcds-lang-toggle
   style gcds-lang-toggle fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
@@ -12,10 +12,10 @@ describe('gcds-lang-toggle', () => {
         <mock:shadow-root>
         <div class="gcds-lang-toggle">
           <h2>Language Selection</h2>
-          <a href="/fr/" lang="fr">
+          <gcds-link href="/fr/" lang="fr">
             <span>Français</span>
             <abbr title="Français">fr</abbr>
-          </a>
+          </gcds-link>
         </div>
         </mock:shadow-root>
       </gcds-lang-toggle>
@@ -32,10 +32,10 @@ describe('gcds-lang-toggle', () => {
         <mock:shadow-root>
         <div class="gcds-lang-toggle">
           <h2>Sélection de la langue</h2>
-          <a href="/en/" lang="en">
+          <gcds-link href="/en/" lang="en">
             <span>English</span>
             <abbr title="English">en</abbr>
-          </a>
+          </gcds-link>
         </div>
         </mock:shadow-root>
       </gcds-lang-toggle>

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -34,6 +34,7 @@
 ### Used by
 
  - [gcds-error-summary](../gcds-error-summary)
+ - [gcds-lang-toggle](../gcds-lang-toggle)
 
 ### Depends on
 
@@ -44,6 +45,7 @@
 graph TD;
   gcds-link --> gcds-icon
   gcds-error-summary --> gcds-link
+  gcds-lang-toggle --> gcds-link
   style gcds-link fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -33,6 +33,7 @@
 
 ### Used by
 
+ - [gcds-card](../gcds-card)
  - [gcds-error-summary](../gcds-error-summary)
  - [gcds-lang-toggle](../gcds-lang-toggle)
 
@@ -44,6 +45,7 @@
 ```mermaid
 graph TD;
   gcds-link --> gcds-icon
+  gcds-card --> gcds-link
   gcds-error-summary --> gcds-link
   gcds-lang-toggle --> gcds-link
   style gcds-link fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -33,6 +33,7 @@
 
 ### Used by
 
+ - [gcds-breadcrumbs-item](../gcds-breadcrumbs)
  - [gcds-card](../gcds-card)
  - [gcds-error-summary](../gcds-error-summary)
  - [gcds-lang-toggle](../gcds-lang-toggle)
@@ -45,6 +46,7 @@
 ```mermaid
 graph TD;
   gcds-link --> gcds-icon
+  gcds-breadcrumbs-item --> gcds-link
   gcds-card --> gcds-link
   gcds-error-summary --> gcds-link
   gcds-lang-toggle --> gcds-link

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -36,6 +36,7 @@
  - [gcds-breadcrumbs-item](../gcds-breadcrumbs)
  - [gcds-card](../gcds-card)
  - [gcds-error-summary](../gcds-error-summary)
+ - [gcds-footer](../gcds-footer)
  - [gcds-lang-toggle](../gcds-lang-toggle)
 
 ### Depends on
@@ -49,6 +50,7 @@ graph TD;
   gcds-breadcrumbs-item --> gcds-link
   gcds-card --> gcds-link
   gcds-error-summary --> gcds-link
+  gcds-footer --> gcds-link
   gcds-lang-toggle --> gcds-link
   style gcds-link fill:#f9f,stroke:#333,stroke-width:4px
 ```


### PR DESCRIPTION
# Summary | Résumé

Integrate `gcds-link` component into existing components to reduce code duplication created through repeated link styles.

`gcds-link` was integrated into:

- gcds-lang-toggle
- gcds-card
- gcds-breadcrumbs
- gcds-footer

The `gcds-link` component will not be integrated into the following components:

- Details - the link should remain a button for better accessibility.
- Nav link - nav-link has lots of additional functionality as well as custom styles, it makes more sense to not add `gcds-link` here
- Theme and topic menu - the links are populated by a fetch call from [canada.ca](https://www.google.com/url?q=http://canada.ca&sa=D&source=docs&ust=1708633836466739&usg=AOvVaw3UdzPPjd_0Fw66MqTmSMGi) so we aren't able to directly modify them

[Token PR](https://github.com/cds-snc/gcds-tokens/pull/231)