### PR TITLE
refactor: integrate gcds-text into existing components 

### DIFF
--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -36,18 +36,9 @@
       width: 100%;
     }
 
-    .gcds-card__tag {
-      font: var(--gcds-card-tag-font);
-      color: var(--gcds-card-tag-color);
-    }
-
     .gcds-card__title {
       font: var(--gcds-card-title-font);
       width: fit-content;
-    }
-
-    .gcds-card__description {
-      max-width: var(--gcds-card-description-max-width);
     }
   }
 }

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -1,4 +1,12 @@
-import { Element, Component, Host, Prop, h, Fragment, State } from '@stencil/core';
+import {
+  Element,
+  Component,
+  Host,
+  Prop,
+  h,
+  Fragment,
+  State,
+} from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
 import i18n from './i18n/i18n';
 
@@ -89,7 +97,7 @@ export class GcdsCard {
       imgSrc,
       imgAlt,
       hasCardFooter,
-      lang
+      lang,
     } = this;
 
     const Element = titleElement;
@@ -111,10 +119,15 @@ export class GcdsCard {
             />
           )}
           {tag && (
-            <span id="gcds-card__tag" class="gcds-card__tag">
+            <gcds-text
+              id="gcds-card__tag"
+              class="gcds-card__tag"
+              text-role="secondary"
+              size="caption"
+            >
               <gcds-sr-only>{i18n[lang].tagged}</gcds-sr-only>
               {tag}
-            </span>
+            </gcds-text>
           )}
           {Element != 'a' ? (
             <Element class="gcds-card__title" {...taggedAttr}>
@@ -125,8 +138,9 @@ export class GcdsCard {
               {cardTitle}
             </gcds-link>
           )}
-
-          {description && <p class="gcds-card__description">{description}</p>}
+          {description && (
+            <gcds-text class="gcds-card__description">{description}</gcds-text>
+          )}
           {hasCardFooter && (
             <>
               <div class="gcds-card__spacer"></div>

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -1,9 +1,6 @@
 # gcds-card
 
-
-
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
@@ -18,23 +15,25 @@
 | `titleElement`           | `title-element` | The title element attribute specifies HTML element the title renders as                                | `"a" \| "h3" \| "h4" \| "h5" \| "h6"` | `'a'`       |
 | `type`                   | `type`          | The type attribute specifies how the card renders as a link                                            | `"action" \| "link"`                  | `'link'`    |
 
-
 ## Dependencies
 
 ### Depends on
 
 - [gcds-sr-only](../gcds-sr-only)
+- [gcds-text](../gcds-text)
 - [gcds-link](../gcds-link)
 
 ### Graph
+
 ```mermaid
 graph TD;
   gcds-card --> gcds-sr-only
+  gcds-card --> gcds-text
   gcds-card --> gcds-link
   gcds-link --> gcds-icon
   style gcds-card fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
-*Built with [StencilJS](https://stenciljs.com/)*
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -85,12 +85,10 @@ describe('gcds-card', () => {
     <gcds-card card-title="Card" href="#card" tag="Tag" type="link">
       <mock:shadow-root>
         <div class="gcds-card gcds-card--link">
-          <span class="gcds-card__tag" id="gcds-card__tag">
-            <gcds-sr-only>
-              Tagged:
-            </gcds-sr-only>
+          <gcds-text id="gcds-card__tag" class="gcds-card__tag" size="caption" text-role="secondary">
+            <gcds-sr-only>Tagged:</gcds-sr-only>
             Tag
-          </span>
+          </gcds-text>
           <gcds-link class="gcds-card__title" href="#card">
             Card
           </gcds-link>
@@ -117,9 +115,9 @@ describe('gcds-card', () => {
           <gcds-link class="gcds-card__title" href="#card">
             Card
           </gcds-link>
-          <p class="gcds-card__description">
+          <gcds-text class="gcds-card__description">
             This is the card description
-          </p>
+          </gcds-text>
         </div>
       </mock:shadow-root>
     </gcds-card

--- a/packages/web/src/components/gcds-checkbox/readme.md
+++ b/packages/web/src/components/gcds-checkbox/readme.md
@@ -60,6 +60,7 @@ graph TD;
   gcds-checkbox --> gcds-label
   gcds-checkbox --> gcds-hint
   gcds-checkbox --> gcds-error-message
+  gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   style gcds-checkbox fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-checkbox/readme.md
+++ b/packages/web/src/components/gcds-checkbox/readme.md
@@ -60,6 +60,7 @@ graph TD;
   gcds-checkbox --> gcds-label
   gcds-checkbox --> gcds-hint
   gcds-checkbox --> gcds-error-message
+  gcds-error-message --> gcds-text
   style gcds-checkbox fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.css
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.css
@@ -4,6 +4,10 @@
   :host {
     display: block;
 
+    dl {
+      margin: 0;
+    }
+
     slot {
       display: initial;
     }
@@ -11,19 +15,15 @@
 }
 
 @layer default {
-  :host {
-    font: var(--gcds-date-modified-font);
-    color: var(--gcds-date-modified-text);
+  :host .gcds-date-modified {
     margin: var(--gcds-date-modified-margin);
 
-    .gcds-date-modified {
-      :is(dt, dd) {
-        display: inline;
-      }
+    :is(dt, gcds-text, dd) {
+      display: inline;
+    }
 
-      dd {
-        margin: var(--gcds-date-modified-description-margin);
-      }
+    dd {
+      margin: var(--gcds-date-modified-description-margin);
     }
   }
 }

--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
@@ -49,15 +49,21 @@ export class GcdsDateModified {
     return (
       <Host>
         <dl class="gcds-date-modified">
-          <dt>{type === 'version' ? 'Version ' : i18n[lang].term}</dt>
+          <dt>
+            <gcds-text display="inline" margin-bottom="0">
+              {type === 'version' ? 'Version ' : i18n[lang].term}
+            </gcds-text>
+          </dt>
           <dd>
-            {type === 'version' ? (
-              <slot></slot>
-            ) : (
-              <time>
+            <gcds-text display="inline" margin-bottom="0">
+              {type === 'version' ? (
                 <slot></slot>
-              </time>
-            )}
+              ) : (
+                <time>
+                  <slot></slot>
+                </time>
+              )}
+            </gcds-text>
           </dd>
         </dl>
       </Host>

--- a/packages/web/src/components/gcds-date-modified/readme.md
+++ b/packages/web/src/components/gcds-date-modified/readme.md
@@ -12,6 +12,19 @@
 | `type`   | `type`    | Set date modified type. Default is date. | `"date" \| "version"` | `'date'` |
 
 
+## Dependencies
+
+### Depends on
+
+- [gcds-text](../gcds-text)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-date-modified --> gcds-text
+  style gcds-date-modified fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-date-modified/test/gcds-date-modified.spec.tsx
+++ b/packages/web/src/components/gcds-date-modified/test/gcds-date-modified.spec.tsx
@@ -12,12 +12,12 @@ describe('gcds-date-modified', () => {
         <mock:shadow-root>
           <dl class="gcds-date-modified">
             <dt>
-              Date modified:
+              <gcds-text display="inline" margin-bottom="0">Date modified:</gcds-text>
             </dt>
             <dd>
-              <time>
-              <slot></slot>
-              </time>
+              <gcds-text display="inline" margin-bottom="0">
+                <time><slot></slot></time>
+              </gcds-text>
             </dd>
           </dl>
         </mock:shadow-root>
@@ -36,12 +36,12 @@ describe('gcds-date-modified', () => {
         <mock:shadow-root>
           <dl class="gcds-date-modified">
             <dt>
-              Date de modification :
+              <gcds-text display="inline" margin-bottom="0">Date de modification :</gcds-text>
             </dt>
             <dd>
-              <time>
-                <slot></slot>
-              </time>
+              <gcds-text display="inline" margin-bottom="0">
+                <time><slot></slot></time>
+              </gcds-text>
             </dd>
           </dl>
         </mock:shadow-root>
@@ -60,10 +60,12 @@ describe('gcds-date-modified', () => {
         <mock:shadow-root>
           <dl class="gcds-date-modified">
             <dt>
-              Version
+              <gcds-text display="inline" margin-bottom="0">Version</gcds-text>
             </dt>
             <dd>
-              <slot></slot>
+              <gcds-text display="inline" margin-bottom="0">
+                <slot></slot>
+              </gcds-text>
             </dd>
           </dl>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-error-message/gcds-error-message.css
+++ b/packages/web/src/components/gcds-error-message/gcds-error-message.css
@@ -8,11 +8,9 @@
 
 @layer default {
   :host .error-message {
-    font: var(--gcds-error-message-font);
     margin: var(--gcds-error-message-margin);
     padding: var(--gcds-error-message-padding);
     background: var(--gcds-error-message-background);
-    color: var(--gcds-error-message-text);
     border-inline-start: var(--gcds-error-message-border-width) solid
       var(--gcds-error-message-border-color);
   }

--- a/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
+++ b/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
@@ -30,9 +30,9 @@ export class GcdsErrorMessage {
         id={`error-message-${messageId}`}
         class="gcds-error-message-wrapper"
       >
-        <p class="error-message" role="alert">
+        <gcds-text class="error-message" role="alert" margin-bottom="0">
           {message}
-        </p>
+        </gcds-text>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-error-message/readme.md
+++ b/packages/web/src/components/gcds-error-message/readme.md
@@ -24,9 +24,14 @@
  - [gcds-select](../gcds-select)
  - [gcds-textarea](../gcds-textarea)
 
+### Depends on
+
+- [gcds-text](../gcds-text)
+
 ### Graph
 ```mermaid
 graph TD;
+  gcds-error-message --> gcds-text
   gcds-checkbox --> gcds-error-message
   gcds-fieldset --> gcds-error-message
   gcds-file-uploader --> gcds-error-message

--- a/packages/web/src/components/gcds-error-message/test/gcds-error-message.spec.ts
+++ b/packages/web/src/components/gcds-error-message/test/gcds-error-message.spec.ts
@@ -10,9 +10,9 @@ describe('gcds-error-message', () => {
     expect(root).toEqualHtml(`
       <gcds-error-message message-id="input-renders" message="This field is required" id="error-message-input-renders" class="gcds-error-message-wrapper">
         <mock:shadow-root>
-          <p class="error-message" role="alert">
+          <gcds-text class="error-message" role="alert" margin-bottom="0">
             This field is required
-          </p>
+          </gcds-text>
         </mock:shadow-root>
       </gcds-error-message>
     `);

--- a/packages/web/src/components/gcds-fieldset/readme.md
+++ b/packages/web/src/components/gcds-fieldset/readme.md
@@ -54,6 +54,7 @@ Type: `Promise<void>`
 graph TD;
   gcds-fieldset --> gcds-hint
   gcds-fieldset --> gcds-error-message
+  gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   style gcds-fieldset fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-fieldset/readme.md
+++ b/packages/web/src/components/gcds-fieldset/readme.md
@@ -54,6 +54,7 @@ Type: `Promise<void>`
 graph TD;
   gcds-fieldset --> gcds-hint
   gcds-fieldset --> gcds-error-message
+  gcds-error-message --> gcds-text
   style gcds-fieldset fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
@@ -76,9 +76,6 @@
     justify-content: space-between;
     width: 100%;
     max-width: var(--gcds-file-uploader-file-max-width);
-    font: inherit;
-    font-weight: var(--gcds-file-uploader-button-font-weight);
-    color: var(--gcds-file-uploader-default-text);
     padding: var(--gcds-file-uploader-file-padding);
     border: var(--gcds-file-uploader-file-border-width) solid
       var(--gcds-file-uploader-file-border-color);
@@ -88,11 +85,18 @@
       border-block-end: 0;
     }
 
-    span {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      padding-inline-end: 0;
+    &:last-of-type {
+      margin: var(--gcds-file-uploader-button-margin);
+    }
+
+    gcds-text {
+      overflow: auto;
+
+      &::part(text) {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
 
     button {
@@ -101,6 +105,7 @@
       background: transparent;
       border: 0;
       color: var(--gcds-file-uploader-file-button-default-text);
+      font-weight: var(--gcds-file-uploader-button-font-weight);
       margin: var(--gcds-file-uploader-file-button-margin);
       padding: var(--gcds-file-uploader-file-button-padding);
 

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -446,7 +446,7 @@ export class GcdsFileUploader {
                   class="file-uploader__uploaded-file"
                   aria-label={`${i18n[lang].removeFile} ${file}.`}
                 >
-                  <span>{file}</span>
+                  <gcds-text margin-bottom="0">{file}</gcds-text>
                   <button onClick={e => this.removeFile(e)}>
                     <span>{i18n[lang].button.remove}</span>
                     <gcds-icon name="times" size="text" margin-left="200" />

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -64,6 +64,7 @@ graph TD;
   gcds-file-uploader --> gcds-hint
   gcds-file-uploader --> gcds-error-message
   gcds-file-uploader --> gcds-icon
+  gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   style gcds-file-uploader fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -64,6 +64,7 @@ graph TD;
   gcds-file-uploader --> gcds-hint
   gcds-file-uploader --> gcds-error-message
   gcds-file-uploader --> gcds-icon
+  gcds-error-message --> gcds-text
   style gcds-file-uploader fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -55,6 +55,7 @@ Type: `Promise<void>`
 - [gcds-label](../gcds-label)
 - [gcds-hint](../gcds-hint)
 - [gcds-error-message](../gcds-error-message)
+- [gcds-text](../gcds-text)
 - [gcds-icon](../gcds-icon)
 
 ### Graph
@@ -63,6 +64,7 @@ graph TD;
   gcds-file-uploader --> gcds-label
   gcds-file-uploader --> gcds-hint
   gcds-file-uploader --> gcds-error-message
+  gcds-file-uploader --> gcds-text
   gcds-file-uploader --> gcds-icon
   gcds-hint --> gcds-text
   gcds-error-message --> gcds-text

--- a/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
+++ b/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
@@ -184,7 +184,7 @@ const TemplatePlayground = args => `
 
 export const Default = Template.bind({});
 Default.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-default',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -196,7 +196,7 @@ Default.args = {
 
 export const Disabled = Template.bind({});
 Disabled.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-disabled',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -207,7 +207,7 @@ Disabled.args = {
 
 export const Error = Template.bind({});
 Error.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-error',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -219,7 +219,7 @@ Error.args = {
 
 export const Required = Template.bind({});
 Required.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-required',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -232,7 +232,7 @@ Required.args = {
 
 export const Multiple = Template.bind({});
 Multiple.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-multiple',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -245,7 +245,7 @@ Multiple.args = {
 
 export const AcceptAudio = Template.bind({});
 AcceptAudio.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-audio',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -256,7 +256,7 @@ AcceptAudio.args = {
 
 export const AcceptImages = Template.bind({});
 AcceptImages.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-images',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -267,7 +267,7 @@ AcceptImages.args = {
 
 export const AcceptJpg = Template.bind({});
 AcceptJpg.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-jpg',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -278,7 +278,7 @@ AcceptJpg.args = {
 
 export const AcceptPdf = Template.bind({});
 AcceptPdf.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-pdf',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -289,7 +289,7 @@ AcceptPdf.args = {
 
 export const AcceptPng = Template.bind({});
 AcceptPng.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-png',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -300,7 +300,7 @@ AcceptPng.args = {
 
 export const AcceptSvg = Template.bind({});
 AcceptSvg.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-svg',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -311,7 +311,7 @@ AcceptSvg.args = {
 
 export const AcceptVideos = Template.bind({});
 AcceptVideos.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-videos',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',
@@ -342,7 +342,7 @@ Props.args = {
 
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
-  uploaderId: 'uploader',
+  uploaderId: 'uploader-playground',
   name: 'file-uploader',
   label: 'Label',
   hint: 'Hint / Example message.',

--- a/packages/web/src/components/gcds-hint/gcds-hint.css
+++ b/packages/web/src/components/gcds-hint/gcds-hint.css
@@ -5,3 +5,12 @@
     display: block;
   }
 }
+
+@layer default {
+  :host {
+    .gcds-hint,
+    gcds-text::part(text) {
+      color: inherit;
+    }
+  }
+}

--- a/packages/web/src/components/gcds-hint/gcds-hint.css
+++ b/packages/web/src/components/gcds-hint/gcds-hint.css
@@ -5,10 +5,3 @@
     display: block;
   }
 }
-
-@layer default {
-  :host .gcds-hint {
-    font: var(--gcds-hint-font);
-    margin: var(--gcds-hint-margin);
-  }
-}

--- a/packages/web/src/components/gcds-hint/gcds-hint.tsx
+++ b/packages/web/src/components/gcds-hint/gcds-hint.tsx
@@ -27,7 +27,9 @@ export class GcdsHint {
 
     return (
       <Host id={`hint-${hintId}`}>
-        <p class="gcds-hint">{hint}</p>
+        <gcds-text class="gcds-hint" margin-bottom="200">
+          {hint}
+        </gcds-text>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-hint/readme.md
+++ b/packages/web/src/components/gcds-hint/readme.md
@@ -25,9 +25,14 @@
  - [gcds-select](../gcds-select)
  - [gcds-textarea](../gcds-textarea)
 
+### Depends on
+
+- [gcds-text](../gcds-text)
+
 ### Graph
 ```mermaid
 graph TD;
+  gcds-hint --> gcds-text
   gcds-checkbox --> gcds-hint
   gcds-fieldset --> gcds-hint
   gcds-file-uploader --> gcds-hint

--- a/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
+++ b/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
@@ -10,7 +10,7 @@ describe('gcds-hint', () => {
     expect(root).toEqualHtml(`
       <gcds-hint hint-id="input-renders" hint="Hint Test" id="hint-input-renders">
         <mock:shadow-root>
-          <p class="gcds-hint">Hint Test</p>
+          <gcds-text class="gcds-hint" margin-bottom="200">Hint Test</gcds-text>
         </mock:shadow-root>
       </gcds-hint>
     `);

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -63,6 +63,7 @@ graph TD;
   gcds-input --> gcds-label
   gcds-input --> gcds-hint
   gcds-input --> gcds-error-message
+  gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   style gcds-input fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -63,6 +63,7 @@ graph TD;
   gcds-input --> gcds-label
   gcds-input --> gcds-hint
   gcds-input --> gcds-error-message
+  gcds-error-message --> gcds-text
   style gcds-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-radio-group/readme.md
+++ b/packages/web/src/components/gcds-radio-group/readme.md
@@ -34,6 +34,7 @@
 graph TD;
   gcds-radio-group --> gcds-label
   gcds-radio-group --> gcds-hint
+  gcds-hint --> gcds-text
   style gcds-radio-group fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-select/readme.md
+++ b/packages/web/src/components/gcds-select/readme.md
@@ -60,6 +60,7 @@ graph TD;
   gcds-select --> gcds-label
   gcds-select --> gcds-hint
   gcds-select --> gcds-error-message
+  gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   style gcds-select fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-select/readme.md
+++ b/packages/web/src/components/gcds-select/readme.md
@@ -60,6 +60,7 @@ graph TD;
   gcds-select --> gcds-label
   gcds-select --> gcds-hint
   gcds-select --> gcds-error-message
+  gcds-error-message --> gcds-text
   style gcds-select fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.tsx
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.tsx
@@ -9,7 +9,9 @@ export class GcdsSrOnly {
   render() {
     return (
       <Host>
-        <slot></slot>
+        <p>
+          <slot></slot>
+        </p>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
+++ b/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
@@ -10,7 +10,7 @@ describe('gcds-sr-only', () => {
     expect(page.root).toEqualHtml(`
       <gcds-sr-only>
         <mock:shadow-root>
-          <slot></slot>
+          <p><slot></slot></p>
         </mock:shadow-root>
         Hidden text
       </gcds-sr-only>

--- a/packages/web/src/components/gcds-text/gcds-text.tsx
+++ b/packages/web/src/components/gcds-text/gcds-text.tsx
@@ -190,6 +190,7 @@ export class GcdsText {
             ${marginTop ? `mt-${marginTop}` : ''}
             ${marginBottom ? `mb-${marginBottom}` : ''}
           `}
+          part="text"
         >
           {size === 'caption' ? (
             <small>

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -17,6 +17,13 @@
 | `textRole`       | `text-role`       | Sets the main style of the text.                                                                                    | `"light" \| "primary" \| "secondary"`                                                                                                        | `'primary'` |
 
 
+## Shadow Parts
+
+| Part     | Description |
+| -------- | ----------- |
+| `"text"` |             |
+
+
 ## Dependencies
 
 ### Used by
@@ -24,6 +31,7 @@
  - [gcds-card](../gcds-card)
  - [gcds-date-modified](../gcds-date-modified)
  - [gcds-error-message](../gcds-error-message)
+ - [gcds-file-uploader](../gcds-file-uploader)
  - [gcds-hint](../gcds-hint)
  - [gcds-textarea](../gcds-textarea)
 
@@ -33,6 +41,7 @@ graph TD;
   gcds-card --> gcds-text
   gcds-date-modified --> gcds-text
   gcds-error-message --> gcds-text
+  gcds-file-uploader --> gcds-text
   gcds-hint --> gcds-text
   gcds-textarea --> gcds-text
   style gcds-text fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -22,6 +22,7 @@
 ### Used by
 
  - [gcds-card](../gcds-card)
+ - [gcds-date-modified](../gcds-date-modified)
  - [gcds-error-message](../gcds-error-message)
  - [gcds-hint](../gcds-hint)
 
@@ -29,6 +30,7 @@
 ```mermaid
 graph TD;
   gcds-card --> gcds-text
+  gcds-date-modified --> gcds-text
   gcds-error-message --> gcds-text
   gcds-hint --> gcds-text
   style gcds-text fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -17,6 +17,19 @@
 | `textRole`       | `text-role`       | Sets the main style of the text.                                                                                    | `"light" \| "primary" \| "secondary"`                                                                                                        | `'primary'` |
 
 
+## Dependencies
+
+### Used by
+
+ - [gcds-card](../gcds-card)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-card --> gcds-text
+  style gcds-text fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -25,6 +25,7 @@
  - [gcds-date-modified](../gcds-date-modified)
  - [gcds-error-message](../gcds-error-message)
  - [gcds-hint](../gcds-hint)
+ - [gcds-textarea](../gcds-textarea)
 
 ### Graph
 ```mermaid
@@ -33,6 +34,7 @@ graph TD;
   gcds-date-modified --> gcds-text
   gcds-error-message --> gcds-text
   gcds-hint --> gcds-text
+  gcds-textarea --> gcds-text
   style gcds-text fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -23,12 +23,14 @@
 
  - [gcds-card](../gcds-card)
  - [gcds-error-message](../gcds-error-message)
+ - [gcds-hint](../gcds-hint)
 
 ### Graph
 ```mermaid
 graph TD;
   gcds-card --> gcds-text
   gcds-error-message --> gcds-text
+  gcds-hint --> gcds-text
   style gcds-text fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-text/readme.md
+++ b/packages/web/src/components/gcds-text/readme.md
@@ -22,11 +22,13 @@
 ### Used by
 
  - [gcds-card](../gcds-card)
+ - [gcds-error-message](../gcds-error-message)
 
 ### Graph
 ```mermaid
 graph TD;
   gcds-card --> gcds-text
+  gcds-error-message --> gcds-text
   style gcds-text fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
+++ b/packages/web/src/components/gcds-text/test/gcds-text.spec.ts
@@ -12,7 +12,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text>
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-400">
+          <p class="gcds-text limit role-primary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -34,7 +34,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text text-role="primary">
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-400">
+          <p class="gcds-text limit role-primary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -53,7 +53,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text text-role="secondary">
         <mock:shadow-root>
-          <p class="gcds-text limit role-secondary mt-0 mb-400">
+          <p class="gcds-text limit role-secondary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -72,7 +72,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text text-role="light">
         <mock:shadow-root>
-          <p class="gcds-text limit role-light mt-0 mb-400">
+          <p class="gcds-text limit role-light mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -94,7 +94,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text>
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-400">
+          <p class="gcds-text limit role-primary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -113,7 +113,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text character-limit="false">
         <mock:shadow-root>
-          <p class="gcds-text role-primary mt-0 mb-400">
+          <p class="gcds-text role-primary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -135,7 +135,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text>
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-400">
+          <p class="gcds-text limit role-primary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -154,7 +154,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text class="d-flex" display="flex">
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-400">
+          <p class="gcds-text limit role-primary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -176,7 +176,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text margin-top="400">
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-400 mb-400">
+          <p class="gcds-text limit role-primary mt-400 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -195,7 +195,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text margin-bottom="600">
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-600">
+          <p class="gcds-text limit role-primary mt-0 mb-600" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -217,7 +217,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text>
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-400">
+          <p class="gcds-text limit role-primary mt-0 mb-400" part="text">
             <slot></slot>
           </p>
         </mock:shadow-root>
@@ -236,7 +236,7 @@ describe('gcds-text', () => {
     expect(root).toEqualHtml(`
       <gcds-text size="caption">
         <mock:shadow-root>
-          <p class="gcds-text limit role-primary mt-0 mb-400">
+          <p class="gcds-text limit role-primary mt-0 mb-400" part="text">
             <small><slot></slot></small>
           </p>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.css
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.css
@@ -24,10 +24,6 @@
     color: var(--gcds-textarea-default-text);
     transition: color ease-in-out 0.15s;
 
-    :is(textarea, .textarea__count) {
-      margin: var(--gcds-textarea-margin) !important;
-    }
-
     textarea {
       display: block;
       min-width: 50%;
@@ -36,6 +32,7 @@
       height: auto;
       min-height: var(--gcds-textarea-min-height);
       font: inherit;
+      margin: var(--gcds-textarea-margin) !important;
       padding: var(--gcds-textarea-padding) !important;
       background-color: var(--gcds-textarea-default-background);
       background-image: none;

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -390,17 +390,13 @@ export class GcdsTextarea {
           </textarea>
 
           {characterCount ? (
-            <p
-              id={`textarea__count-${textareaId}`}
-              class="textarea__count"
-              aria-live="polite"
-            >
+            <gcds-text id={`textarea__count-${textareaId}`} aria-live="polite">
               {value == undefined
                 ? `${characterCount} ${i18n[lang].characters.allowed}`
                 : `${characterCount - value.length} ${
                     i18n[lang].characters.left
                   }`}
-            </p>
+            </gcds-text>
           ) : null}
         </div>
       </Host>

--- a/packages/web/src/components/gcds-textarea/readme.md
+++ b/packages/web/src/components/gcds-textarea/readme.md
@@ -63,6 +63,7 @@ graph TD;
   gcds-textarea --> gcds-label
   gcds-textarea --> gcds-hint
   gcds-textarea --> gcds-error-message
+  gcds-error-message --> gcds-text
   style gcds-textarea fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-textarea/readme.md
+++ b/packages/web/src/components/gcds-textarea/readme.md
@@ -63,6 +63,7 @@ graph TD;
   gcds-textarea --> gcds-label
   gcds-textarea --> gcds-hint
   gcds-textarea --> gcds-error-message
+  gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   style gcds-textarea fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-textarea/readme.md
+++ b/packages/web/src/components/gcds-textarea/readme.md
@@ -56,6 +56,7 @@ Type: `Promise<void>`
 - [gcds-label](../gcds-label)
 - [gcds-hint](../gcds-hint)
 - [gcds-error-message](../gcds-error-message)
+- [gcds-text](../gcds-text)
 
 ### Graph
 ```mermaid
@@ -63,6 +64,7 @@ graph TD;
   gcds-textarea --> gcds-label
   gcds-textarea --> gcds-hint
   gcds-textarea --> gcds-error-message
+  gcds-textarea --> gcds-text
   gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   style gcds-textarea fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
+++ b/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
@@ -47,7 +47,7 @@ describe('gcds-textarea', () => {
               rows="5"
               maxlength="22"
             >Value Test</textarea>
-            <p id="textarea__count-character-count" class="textarea__count" aria-live="polite">12 characters left</p>
+            <gcds-text id="textarea__count-character-count" aria-live="polite">12 characters left</gcds-text>
           </div>
         </mock:shadow-root>
       </gcds-textarea>
@@ -73,7 +73,7 @@ describe('gcds-textarea', () => {
               rows="5"
               maxlength="22"
             >Value Test</textarea>
-            <p id="textarea__count-character-count" class="textarea__count" aria-live="polite">12 caractères restants</p>
+            <gcds-text id="textarea__count-character-count" aria-live="polite">12 caractères restants</gcds-text>
           </div>
         </mock:shadow-root>
       </gcds-textarea>


### PR DESCRIPTION
# Summary | Résumé

Integrate gcds-text component into existing components to reduce code duplication created through repeated text styles.

gcds-text was integrated into:

- gcds-card
- gcds-date-modified
- gcds-error-message
- gcds-file-uploader
- gcds-hint
- gcds-textarea

[Token PR](https://github.com/cds-snc/gcds-tokens/pull/232)