### PR TITLE
refactor: convert final components to use shadow-dom (gcds-search, gcds-signature)

### DIFF
--- a/packages/web/src/components/gcds-search/gcds-search.tsx
+++ b/packages/web/src/components/gcds-search/gcds-search.tsx
@@ -14,8 +14,7 @@ import I18N from './i18n/I18N';
 @Component({
   tag: 'gcds-search',
   styleUrl: 'gcds-search.css',
-  shadow: false,
-  scoped: true,
+  shadow: true
 })
 export class GcdsSearch {
   @Element() el: HTMLElement;

--- a/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
+++ b/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
@@ -9,18 +9,20 @@ describe('gcds-search', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-search>
-        <div class="gcds-search">
-          <h2 class="gcds-search__header">
-            Search
-          </h2>
-          <form action="https://www.canada.ca/en/sr/srb.html" class="gcds-search__form" method="get" role="search">
-            <gcds-label hide-label="" label="Search Canada.ca" label-for="search"></gcds-label>
-            <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Search Canada.ca" size="34" type="search">
-            <gcds-button class="gcds-search__button" exportparts="button" type="submit">
-              <gcds-icon fixed-width="" label="Search" name="search"></gcds-icon>
-            </gcds-button>
-          </form>
-        </div>
+        <mock:shadow-root>
+          <div class="gcds-search">
+            <h2 class="gcds-search__header">
+              Search
+            </h2>
+            <form action="https://www.canada.ca/en/sr/srb.html" class="gcds-search__form" method="get" role="search">
+              <gcds-label hide-label="" label="Search Canada.ca" label-for="search"></gcds-label>
+              <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Search Canada.ca" size="34" type="search">
+              <gcds-button class="gcds-search__button" exportparts="button" type="submit">
+                <gcds-icon fixed-width="" label="Search" name="search"></gcds-icon>
+              </gcds-button>
+            </form>
+          </div>
+        </mock:shadowroot>
       </gcds-search>
     `);
   });
@@ -31,18 +33,20 @@ describe('gcds-search', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-search lang="fr">
-      <div class="gcds-search">
-          <h2 class="gcds-search__header">
-            Recherche
-          </h2>
-          <form action="https://www.canada.ca/fr/sr/srb.html" class="gcds-search__form" method="get" role="search">
-            <gcds-label hide-label="" label="Rechercher dans Canada.ca" label-for="search"></gcds-label>
-            <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Rechercher dans Canada.ca" size="34" type="search">
-            <gcds-button class="gcds-search__button" exportparts="button" type="submit">
-              <gcds-icon fixed-width="" label="Recherche" name="search"></gcds-icon>
-            </gcds-button>
-          </form>
-        </div>
+        <mock:shadow-root>
+          <div class="gcds-search">
+            <h2 class="gcds-search__header">
+              Recherche
+            </h2>
+            <form action="https://www.canada.ca/fr/sr/srb.html" class="gcds-search__form" method="get" role="search">
+              <gcds-label hide-label="" label="Rechercher dans Canada.ca" label-for="search"></gcds-label>
+              <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Rechercher dans Canada.ca" size="34" type="search">
+              <gcds-button class="gcds-search__button" exportparts="button" type="submit">
+                <gcds-icon fixed-width="" label="Recherche" name="search"></gcds-icon>
+              </gcds-button>
+            </form>
+          </div>
+        </mock:shadowroot>
       </gcds-search>
     `);
   });
@@ -59,18 +63,20 @@ describe('gcds-search', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-search action="submit.html" method="post" name="s" placeholder="Text.ca" search-id="searchForm">
-        <div class="gcds-search">
-          <h2 class="gcds-search__header">
-            Search
-          </h2>
-          <form action="submit.html" class="gcds-search__form" method="post" role="search">
-          <gcds-label hide-label="" label="Search Text.ca" label-for="searchForm"></gcds-label>
-            <input class="gcds-search__input" id="searchForm" list="search-list" maxlength="170" name="s" placeholder="Search Text.ca" size="34" type="search">
-            <gcds-button class="gcds-search__button" exportparts="button" type="submit">
-              <gcds-icon fixed-width="" label="Search" name="search"></gcds-icon>
-            </gcds-button>
-          </form>
-        </div>
+        <mock:shadow-root>
+          <div class="gcds-search">
+            <h2 class="gcds-search__header">
+              Search
+            </h2>
+            <form action="submit.html" class="gcds-search__form" method="post" role="search">
+            <gcds-label hide-label="" label="Search Text.ca" label-for="searchForm"></gcds-label>
+              <input class="gcds-search__input" id="searchForm" list="search-list" maxlength="170" name="s" placeholder="Search Text.ca" size="34" type="search">
+              <gcds-button class="gcds-search__button" exportparts="button" type="submit">
+                <gcds-icon fixed-width="" label="Search" name="search"></gcds-icon>
+              </gcds-button>
+            </form>
+          </div>
+        </mock:shadowroot>
       </gcds-search>
     `);
   });

--- a/packages/web/src/components/gcds-signature/gcds-signature.css
+++ b/packages/web/src/components/gcds-signature/gcds-signature.css
@@ -1,52 +1,52 @@
 @layer reset, default, type.signature, type.wordmark, variant.colour, variant.white, desktop;
 
 @layer reset {
-  gcds-signature {
+  :host {
     display: block;
     width: fit-content;
   }
 }
 
 @layer default {
-  gcds-signature {
+  :host {
     .gcds-signature {
       display: flex;
     }
 
     svg {
       max-width: 100%;
+
+      .fip_flag {
+        fill: var(--gcds-signature-color-flag);
+      }
     }
   }
 }
 
 @layer type.signature {
-  gcds-signature:not([type='wordmark']) svg {
+  :host(:not([type='wordmark'])) svg {
     height: var(--gcds-signature-signature-height);
   }
 }
 
 @layer type.wordmark {
-  gcds-signature[type='wordmark'] svg {
+  :host([type='wordmark']) svg {
     height: var(--gcds-signature-wordmark-height);
     width: auto;
   }
 }
 
 @layer variant.colour {
-  gcds-signature:not([variant='white']) svg {
+  :host(:not([variant='white'])) svg {
     .fip_text {
       fill: var(--gcds-signature-color-text);
-    }
-
-    .fip_flag {
-      fill: var(--gcds-signature-color-flag);
     }
   }
 }
 
 @layer variant.white {
-  gcds-signature[variant='white'] svg {
-    :is(.fip_text, .fip_flag) {
+  :host([variant='white']) svg {
+    :is(.fip_text) {
       fill: var(--gcds-signature-white-default);
     }
   }
@@ -54,7 +54,7 @@
 
 /* Note: viewport specific style decision */
 @layer desktop {
-  gcds-signature:not([type='wordmark']) svg {
+  :host(:not([type='wordmark'])) svg {
     @media screen and (width >= 64em) {
       height: 2.125rem;
     }

--- a/packages/web/src/components/gcds-signature/gcds-signature.tsx
+++ b/packages/web/src/components/gcds-signature/gcds-signature.tsx
@@ -10,6 +10,7 @@ import WordmarkFr from './assets/wmms-spl-fr.svg';
 @Component({
   tag: 'gcds-signature',
   styleUrl: 'gcds-signature.css',
+  shadow: true,
 })
 export class GcdsSignature {
   @Element() el: HTMLElement;

--- a/packages/web/src/components/gcds-signature/test/gcds-signature.spec.tsx
+++ b/packages/web/src/components/gcds-signature/test/gcds-signature.spec.tsx
@@ -21,9 +21,11 @@ describe('gcds-signature', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-signature lang="en" type="signature" variant="colour">
-        <div class="gcds-signature">
-          Government of Canada
-        </div>
+        <mock:shadow-root>
+          <div class="gcds-signature">
+            Government of Canada
+          </div>
+        </mock:shadow-root>
       </gcds-signature>
     `);
   });
@@ -35,9 +37,11 @@ describe('gcds-signature', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-signature lang="en" type="signature" has-link="true" variant="colour">
-        <a class="gcds-signature" href="https://canada.ca/en.html">
-          Government of Canada
-        </a>
+        <mock:shadow-root>
+          <a class="gcds-signature" href="https://canada.ca/en.html">
+            Government of Canada
+          </a>
+        </mock:shadow-root>
       </gcds-signature>
     `);
   });
@@ -49,9 +53,11 @@ describe('gcds-signature', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-signature lang="fr" type="signature" variant="colour">
-        <div class="gcds-signature">
-          Gouvernement du Canada
-        </div>
+        <mock:shadow-root>
+          <div class="gcds-signature">
+            Gouvernement du Canada
+          </div>
+        </mock:shadow-root>
       </gcds-signature>
     `);
   });
@@ -63,9 +69,11 @@ describe('gcds-signature', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-signature lang="fr" type="signature" has-link="true" variant="colour">
-        <a class="gcds-signature" href="https://canada.ca/fr.html">
-          Gouvernement du Canada
-        </a>
+        <mock:shadow-root>
+          <a class="gcds-signature" href="https://canada.ca/fr.html">
+            Gouvernement du Canada
+          </a>
+        </mock:shadow-root>
       </gcds-signature>
     `);
   });
@@ -77,9 +85,11 @@ describe('gcds-signature', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-signature lang="en" type="wordmark" variant="colour">
-        <div class="gcds-signature">
-          Symbol of the Government of Canada
-        </div>
+        <mock:shadow-root>
+          <div class="gcds-signature">
+            Symbol of the Government of Canada
+          </div>
+        </mock:shadow-root>
       </gcds-signature>
     `);
   });
@@ -91,9 +101,11 @@ describe('gcds-signature', () => {
     });
     expect(page.root).toEqualHtml(`
       <gcds-signature lang="fr" type="wordmark" variant="colour">
-        <div class="gcds-signature">
-          Symbole du Gouvernement du Canada
-        </div>
+        <mock:shadow-root>
+          <div class="gcds-signature">
+            Symbole du Gouvernement du Canada
+          </div>
+        </mock:shadow-root>
       </gcds-signature>
     `);
   });


### PR DESCRIPTION
# Summary | Résumé

Convert `gcds-search` and `gcds-signature` to use shadow-dom to help with rendering in a SSR environment.
