### PR TITLE
refactor: integrate gcds-heading into existing components

### DIFF
--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.tsx
@@ -22,7 +22,7 @@ export class GcdsBreadcrumbsItem {
 
     return (
       <Host role="listitem" class="gcds-breadcrumbs-item">
-        <gcds-link href={href}>
+        <gcds-link size="regular" href={href}>
           <slot></slot>
         </gcds-link>
       </Host>

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs.css
@@ -13,7 +13,6 @@
 
 @layer default {
   :host .gcds-breadcrumbs ol {
-    font: var(--gcds-breadcrumbs-font);
     margin: var(--gcds-breadcrumbs-margin);
     padding: var(--gcds-breadcrumbs-padding);
 

--- a/packages/web/src/components/gcds-button/readme.md
+++ b/packages/web/src/components/gcds-button/readme.md
@@ -47,7 +47,6 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [gcds-header](../gcds-header)
  - [gcds-search](../gcds-search)
 
 ### Depends on
@@ -58,7 +57,6 @@ Type: `Promise<void>`
 ```mermaid
 graph TD;
   gcds-button --> gcds-icon
-  gcds-header --> gcds-button
   gcds-search --> gcds-button
   style gcds-button fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -2,6 +2,7 @@
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property                 | Attribute       | Description                                                                                            | Type                                  | Default     |
@@ -15,25 +16,25 @@
 | `titleElement`           | `title-element` | The title element attribute specifies HTML element the title renders as                                | `"a" \| "h3" \| "h4" \| "h5" \| "h6"` | `'a'`       |
 | `type`                   | `type`          | The type attribute specifies how the card renders as a link                                            | `"action" \| "link"`                  | `'link'`    |
 
+
 ## Dependencies
 
 ### Depends on
 
-- [gcds-sr-only](../gcds-sr-only)
 - [gcds-text](../gcds-text)
+- [gcds-sr-only](../gcds-sr-only)
 - [gcds-link](../gcds-link)
 
 ### Graph
-
 ```mermaid
 graph TD;
-  gcds-card --> gcds-sr-only
   gcds-card --> gcds-text
+  gcds-card --> gcds-sr-only
   gcds-card --> gcds-link
   gcds-link --> gcds-icon
   style gcds-card fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
----
+----------------------------------------------
 
-_Built with [StencilJS](https://stenciljs.com/)_
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -89,7 +89,7 @@ describe('gcds-card', () => {
             <gcds-sr-only>Tagged:</gcds-sr-only>
             Tag
           </gcds-text>
-          <gcds-link class="gcds-card__title" href="#card">
+          <gcds-link aria-describedby="gcds-card__tag" class="gcds-card__title" href="#card">
             Card
           </gcds-link>
         </div>

--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
@@ -26,12 +26,6 @@
         display: block;
       }
 
-      .summary__heading {
-        font: var(--gcds-error-summary-heading-font);
-        margin: 0;
-        padding-block-end: var(--gcds-error-summary-heading-padding-bottom);
-      }
-
       .summary__errorlist {
         padding: 0;
         margin: var(--gcds-error-summary-list-margin);
@@ -52,7 +46,7 @@
   :host .gcds-error-summary:is(:focus, :has(:focus-within)) {
     border-color: var(--gcds-error-summary-focus-color);
 
-    .summary__heading {
+    gcds-heading {
       color: var(--gcds-error-summary-focus-color);
     }
   }

--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.tsx
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.tsx
@@ -199,7 +199,9 @@ export class GcdsErrorSummary {
               : ''
           }`}
         >
-          <h2 class="summary__heading">{heading ?? i18n[lang].heading}</h2>
+          <gcds-heading tag="h2" margin-top="0" margin-bottom="300">
+            {heading ?? i18n[lang].heading}
+          </gcds-heading>
           <ol class="summary__errorlist">
             {(hasSubmitted || errorLinks) &&
               Object.keys(errorQueue).length > 0 &&

--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.tsx
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.tsx
@@ -209,6 +209,7 @@ export class GcdsErrorSummary {
                 return (
                   <li class="summary__listitem">
                     <gcds-link
+                      size="regular"
                       href={errorLinks ? key : '#'}
                       onClick={e => {
                         e.preventDefault();

--- a/packages/web/src/components/gcds-error-summary/readme.md
+++ b/packages/web/src/components/gcds-error-summary/readme.md
@@ -18,11 +18,13 @@
 
 ### Depends on
 
+- [gcds-heading](../gcds-heading)
 - [gcds-link](../gcds-link)
 
 ### Graph
 ```mermaid
 graph TD;
+  gcds-error-summary --> gcds-heading
   gcds-error-summary --> gcds-link
   gcds-link --> gcds-icon
   style gcds-error-summary fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/web/src/components/gcds-error-summary/test/gcds-error-summary.spec.tsx
+++ b/packages/web/src/components/gcds-error-summary/test/gcds-error-summary.spec.tsx
@@ -20,6 +20,7 @@ describe('gcds-error-summary', () => {
       </gcds-error-summary>
     `);
   });
+
   it('renders - fr', async () => {
     const page = await newSpecPage({
       components: [GcdsErrorSummary],
@@ -38,6 +39,7 @@ describe('gcds-error-summary', () => {
       </gcds-error-summary>
     `);
   });
+
   it('renders - custom heading', async () => {
     const page = await newSpecPage({
       components: [GcdsErrorSummary],
@@ -56,6 +58,7 @@ describe('gcds-error-summary', () => {
       </gcds-error-summary>
     `);
   });
+
   it('renders - error-links', async () => {
     const page = await newSpecPage({
       components: [GcdsErrorSummary],
@@ -72,12 +75,12 @@ describe('gcds-error-summary', () => {
             </gcds-heading>
             <ol class="summary__errorlist">
               <li class="summary__listitem">
-                <gcds-link href="#link1">
+                <gcds-link size="regular" href="#link1">
                   This is the first error
                 </gcds-link>
               </li>
               <li class="summary__listitem">
-                <gcds-link href="#link2">
+                <gcds-link size="regular" href="#link2">
                   This is the second error
                 </gcds-link>
               </li>
@@ -87,6 +90,7 @@ describe('gcds-error-summary', () => {
       </gcds-error-summary>
     `);
   });
+
   it('renders - listen', async () => {
     const page = await newSpecPage({
       components: [GcdsErrorSummary],

--- a/packages/web/src/components/gcds-error-summary/test/gcds-error-summary.spec.tsx
+++ b/packages/web/src/components/gcds-error-summary/test/gcds-error-summary.spec.tsx
@@ -11,9 +11,9 @@ describe('gcds-error-summary', () => {
       <gcds-error-summary>
         <mock:shadow-root>
           <div class="gcds-error-summary" role="alert" tabindex="-1">
-            <h2 class="summary__heading">
+            <gcds-heading tag="h2" margin-top="0" margin-bottom="300">
               There was a problem
-            </h2>
+            </gcds-heading>
             <ol class="summary__errorlist"></ol>
           </div>
         </mock:shadow-root>
@@ -29,9 +29,9 @@ describe('gcds-error-summary', () => {
       <gcds-error-summary>
         <mock:shadow-root>
           <div class="gcds-error-summary" role="alert" tabindex="-1">
-            <h2 class="summary__heading">
+            <gcds-heading tag="h2" margin-top="0" margin-bottom="300">
               There was a problem
-            </h2>
+            </gcds-heading>
             <ol class="summary__errorlist"></ol>
           </div>
         </mock:shadow-root>
@@ -47,9 +47,9 @@ describe('gcds-error-summary', () => {
       <gcds-error-summary heading="This is a heading">
         <mock:shadow-root>
           <div class="gcds-error-summary" role="alert" tabindex="-1">
-            <h2 class="summary__heading">
+            <gcds-heading tag="h2" margin-top="0" margin-bottom="300">
               This is a heading
-            </h2>
+            </gcds-heading>
             <ol class="summary__errorlist"></ol>
           </div>
         </mock:shadow-root>
@@ -67,9 +67,9 @@ describe('gcds-error-summary', () => {
       <gcds-error-summary error-links='{"#link1":"This is the first error","#link2":"This is the second error"}'>
         <mock:shadow-root>
           <div class="gcds-error-summary gcds-show" role="alert" tabindex="-1">
-            <h2 class="summary__heading">
+            <gcds-heading tag="h2" margin-top="0" margin-bottom="300">
               There was a problem
-            </h2>
+            </gcds-heading>
             <ol class="summary__errorlist">
               <li class="summary__listitem">
                 <gcds-link href="#link1">
@@ -96,9 +96,9 @@ describe('gcds-error-summary', () => {
       <gcds-error-summary listen>
         <mock:shadow-root>
           <div class="gcds-error-summary" role="alert" tabindex="-1">
-            <h2 class="summary__heading">
+            <gcds-heading tag="h2" margin-top="0" margin-bottom="300">
               There was a problem
-            </h2>
+            </gcds-heading>
             <ol class="summary__errorlist"></ol>
           </div>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-footer/gcds-footer.tsx
+++ b/packages/web/src/components/gcds-footer/gcds-footer.tsx
@@ -159,7 +159,10 @@ export class GcdsFooter {
 
                       return (
                         <li>
-                          <gcds-link href={contextualLinksObject[key]}>
+                          <gcds-link
+                            size="small"
+                            href={contextualLinksObject[key]}
+                          >
                             {key}
                           </gcds-link>
                         </li>
@@ -179,22 +182,21 @@ export class GcdsFooter {
                 <ul class="govnav__list">
                   {Object.keys(govNav).map(value => (
                     <li>
-                      <gcds-link href={govNav[value].link}>
+                      <gcds-link size="small" href={govNav[value].link}>
                         {govNav[value].text}
                       </gcds-link>
                     </li>
                   ))}
                 </ul>
               </nav>
-              <nav
-                class="main__themenav"
-                aria-labelledby="themenav__header"
-              >
-                <h4 id="themenav__header" class="themenav__header">{I18N[lang].themes.heading}</h4>
+              <nav class="main__themenav" aria-labelledby="themenav__header">
+                <h4 id="themenav__header" class="themenav__header">
+                  {I18N[lang].themes.heading}
+                </h4>
                 <ul class="themenav__list">
                   {Object.keys(themeNav).map(value => (
                     <li>
-                      <gcds-link href={themeNav[value].link}>
+                      <gcds-link size="small" href={themeNav[value].link}>
                         {themeNav[value].text}
                       </gcds-link>
                     </li>
@@ -208,7 +210,9 @@ export class GcdsFooter {
         <div class="gcds-footer__sub">
           <div class="sub__container">
             <nav aria-labelledby="sub__header">
-              <h3 id="sub__header" class="sub__header">{I18N[lang].site.heading}</h3>
+              <h3 id="sub__header" class="sub__header">
+                {I18N[lang].site.heading}
+              </h3>
               <ul>
                 {subLinks
                   ? Object.keys(subLinksObject).map(key => {
@@ -217,7 +221,7 @@ export class GcdsFooter {
 
                         return (
                           <li>
-                            <gcds-link href={subLinksObject[key]}>
+                            <gcds-link size="small" href={subLinksObject[key]}>
                               {key}
                             </gcds-link>
                           </li>
@@ -227,7 +231,7 @@ export class GcdsFooter {
                   : Object.keys(siteNav).map(value => {
                       return (
                         <li>
-                          <gcds-link href={siteNav[value].link}>
+                          <gcds-link size="small" href={siteNav[value].link}>
                             {siteNav[value].text}
                           </gcds-link>
                         </li>

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
@@ -19,27 +19,27 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/social.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/social.html">
                       Social media
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/mobile.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/mobile.html">
                       Mobile applications
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/government/about.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/government/about.html">
                       About Canada.ca
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/transparency/terms.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/transparency/terms.html">
                       Terms and conditions
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/transparency/privacy.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/transparency/privacy.html">
                       Privacy
                     </gcds-link>
                   </li>
@@ -72,17 +72,17 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="govnav__list">
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/contact.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/contact.html">
                       All Contacts
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/government/dept.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/government/dept.html">
                       Departments and agencies
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/government/system.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/government/system.html">
                       About government
                     </gcds-link>
                   </li>
@@ -94,92 +94,92 @@ describe('gcds-footer', () => {
                 </h4>
                 <ul class="themenav__list">
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/jobs.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/jobs.html">
                       Jobs
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/immigration-citizenship.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/immigration-citizenship.html">
                       Immigration and citizenship
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://travel.gc.ca/">
+                    <gcds-link size="small" href="https://travel.gc.ca/">
                       Travel and tourism
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/business.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/business.html">
                       Business
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/benefits.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/benefits.html">
                       Benefits
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/health.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/health.html">
                       Health
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/taxes.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/taxes.html">
                       Taxes
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/environment.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/environment.html">
                       Environment and natural resources
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/defence.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/defence.html">
                       National security and defence
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/culture.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/culture.html">
                       Culture, history and sport
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/policing.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/policing.html">
                       Policing, justice and emergencies
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/transport.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/transport.html">
                       Transport and infrastructure
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
+                    <gcds-link size="small" href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
                       Canada and the world
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/finance.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/finance.html">
                       Money and finance
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/science.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/science.html">
                       Science and innovation
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/indigenous-peoples.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/indigenous-peoples.html">
                       Indigenous peoples
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/veterans.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/veterans.html">
                       Veterans and military
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/youth.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/youth.html">
                       Youth
                     </gcds-link>
                   </li>
@@ -195,27 +195,27 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/social.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/social.html">
                       Social media
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/mobile.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/mobile.html">
                       Mobile applications
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/government/about.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/government/about.html">
                       About Canada.ca
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/transparency/terms.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/transparency/terms.html">
                       Terms and conditions
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/transparency/privacy.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/transparency/privacy.html">
                       Privacy
                     </gcds-link>
                   </li>
@@ -248,27 +248,27 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/sociaux.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/sociaux.html">
                       Médias sociaux
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/mobile.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/mobile.html">
                       Applications mobiles
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/gouvernement/a-propos.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/gouvernement/a-propos.html">
                       À propos de Canada.ca
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/transparence/avis.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/transparence/avis.html">
                       Avis
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/transparence/confidentialite.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/transparence/confidentialite.html">
                       Confidentialité
                     </gcds-link>
                   </li>
@@ -301,17 +301,17 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="govnav__list">
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/contact.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/contact.html">
                       Toutes les coordonnées
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/gouvernement/min.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/gouvernement/min.html">
                       Ministères et organismes
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/gouvernement/systeme.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/gouvernement/systeme.html">
                       À propos du gouvernement
                     </gcds-link>
                   </li>
@@ -323,92 +323,92 @@ describe('gcds-footer', () => {
                 </h4>
                 <ul class="themenav__list">
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/emplois.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/emplois.html">
                       Emplois
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/immigration-citoyennete.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/immigration-citoyennete.html">
                       Immigration et citoyenneté
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://voyage.gc.ca/">
+                    <gcds-link size="small" href="https://voyage.gc.ca/">
                       Voyage et tourisme
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/entreprises.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/entreprises.html">
                       Entreprises
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/prestations.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/prestations.html">
                       Prestations
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/sante.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/sante.html">
                       Santé
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/impots.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/impots.html">
                       Impôts
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/environnement.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/environnement.html">
                       Environnement et ressources naturelles
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/defense.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/defense.html">
                       Sécurité nationale et défense
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/culture.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/culture.html">
                       Culture, histoire et sport
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/police.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/police.html">
                       Services de police, justice et urgences
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/transport.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/transport.html">
                       Transport et infrastructure
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.international.gc.ca/world-monde/index.aspx?lang=fra">
+                    <gcds-link size="small" href="https://www.international.gc.ca/world-monde/index.aspx?lang=fra">
                       Le Canada et le monde
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/finance.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/finance.html">
                       Argent et finance
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/science.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/science.html">
                       Science et innovation
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/autochtones.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/autochtones.html">
                       Autochtones
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/veterans.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/veterans.html">
                       Vétérans et militaires
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/services/jeunesse.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/jeunesse.html">
                       Jeunesse
                     </gcds-link>
                   </li>
@@ -424,27 +424,27 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/sociaux.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/sociaux.html">
                       Médias sociaux
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/mobile.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/mobile.html">
                       Applications mobiles
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/gouvernement/a-propos.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/gouvernement/a-propos.html">
                       À propos de Canada.ca
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/transparence/avis.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/transparence/avis.html">
                       Avis
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/fr/transparence/confidentialite.html">
+                    <gcds-link size="small" href="https://www.canada.ca/fr/transparence/confidentialite.html">
                       Confidentialité
                     </gcds-link>
                   </li>
@@ -482,17 +482,17 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="contextual__list">
                   <li>
-                    <gcds-link href="#red">
+                    <gcds-link size="small" href="#red">
                       Link 1
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="#green">
+                    <gcds-link size="small" href="#green">
                       Link 2
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="#blue">
+                    <gcds-link size="small" href="#blue">
                       Link 3
                     </gcds-link>
                   </li>
@@ -508,17 +508,17 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul class="govnav__list">
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/contact.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/contact.html">
                       All Contacts
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/government/dept.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/government/dept.html">
                       Departments and agencies
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/government/system.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/government/system.html">
                       About government
                     </gcds-link>
                   </li>
@@ -530,92 +530,92 @@ describe('gcds-footer', () => {
                 </h4>
                 <ul class="themenav__list">
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/jobs.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/jobs.html">
                       Jobs
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/immigration-citizenship.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/immigration-citizenship.html">
                       Immigration and citizenship
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://travel.gc.ca/">
+                    <gcds-link size="small" href="https://travel.gc.ca/">
                       Travel and tourism
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/business.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/business.html">
                       Business
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/benefits.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/benefits.html">
                       Benefits
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/health.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/health.html">
                       Health
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/taxes.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/taxes.html">
                       Taxes
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/environment.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/environment.html">
                       Environment and natural resources
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/defence.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/defence.html">
                       National security and defence
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/culture.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/culture.html">
                       Culture, history and sport
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/policing.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/policing.html">
                       Policing, justice and emergencies
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/transport.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/transport.html">
                       Transport and infrastructure
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
+                    <gcds-link size="small" href="https://international.gc.ca/world-monde/index.aspx?lang=eng">
                       Canada and the world
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/finance.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/finance.html">
                       Money and finance
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/science.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/science.html">
                       Science and innovation
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/indigenous-peoples.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/indigenous-peoples.html">
                       Indigenous peoples
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/veterans.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/veterans.html">
                       Veterans and military
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/services/youth.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/youth.html">
                       Youth
                     </gcds-link>
                   </li>
@@ -631,27 +631,27 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/social.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/social.html">
                       Social media
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/mobile.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/mobile.html">
                       Mobile applications
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/government/about.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/government/about.html">
                       About Canada.ca
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/transparency/terms.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/transparency/terms.html">
                       Terms and conditions
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="https://www.canada.ca/en/transparency/privacy.html">
+                    <gcds-link size="small" href="https://www.canada.ca/en/transparency/privacy.html">
                       Privacy
                     </gcds-link>
                   </li>
@@ -688,17 +688,17 @@ describe('gcds-footer', () => {
                 </h3>
                 <ul>
                   <li>
-                    <gcds-link href="#red">
+                    <gcds-link size="small" href="#red">
                       Link 1
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="#green">
+                    <gcds-link size="small" href="#green">
                       Link 2
                     </gcds-link>
                   </li>
                   <li>
-                    <gcds-link href="#blue">
+                    <gcds-link size="small" href="#blue">
                       Link 3
                     </gcds-link>
                   </li>

--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -27,14 +27,14 @@
       width: 100%;
       margin-inline: auto;
       top: var(--gcds-header-skiptonav-top);
-  
+
       gcds-link {
         z-index: 3;
         position: absolute;
         top: var(--gcds-header-skiptonav-top);
         left: 0;
         width: inherit;
-  
+
         &:not(:focus) {
           width: 0;
           height: 0;

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -65,7 +65,9 @@ export class GcdsHeader {
     } else if (this.skipToHref) {
       return (
         <nav class="gcds-header__skip-to-nav">
-          <gcds-link href={this.skipToHref}>{i18n[this.lang].skip}</gcds-link>
+          <gcds-link size="regular" href={this.skipToHref}>
+            {i18n[this.lang].skip}
+          </gcds-link>
         </nav>
       );
     } else {

--- a/packages/web/src/components/gcds-header/readme.md
+++ b/packages/web/src/components/gcds-header/readme.md
@@ -19,19 +19,18 @@
 
 ### Depends on
 
-- [gcds-button](../gcds-button)
+- [gcds-link](../gcds-link)
 - [gcds-lang-toggle](../gcds-lang-toggle)
 - [gcds-signature](../gcds-signature)
 
 ### Graph
 ```mermaid
 graph TD;
-  gcds-header --> gcds-button
+  gcds-header --> gcds-link
   gcds-header --> gcds-lang-toggle
   gcds-header --> gcds-signature
-  gcds-button --> gcds-icon
-  gcds-lang-toggle --> gcds-link
   gcds-link --> gcds-icon
+  gcds-lang-toggle --> gcds-link
   style gcds-header fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
+++ b/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
@@ -32,7 +32,7 @@ describe('gcds-header', () => {
       <gcds-header lang-href="/fr/" role="banner" signature-has-link="true" signature-variant="colour" skip-to-href="#main">
         <mock:shadow-root>
           <nav class="gcds-header__skip-to-nav">
-            <gcds-link href="#main">
+            <gcds-link size="regular" href="#main">
               Skip to main content
             </gcds-link>
           </nav>

--- a/packages/web/src/components/gcds-heading/readme.md
+++ b/packages/web/src/components/gcds-heading/readme.md
@@ -15,6 +15,19 @@
 | `tag` _(required)_ | `tag`             | Sets the appropriate HTML tag for the selected level.                                                                                      | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6"`                                                                                               | `undefined` |
 
 
+## Dependencies
+
+### Used by
+
+ - [gcds-error-summary](../gcds-error-summary)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-error-summary --> gcds-heading
+  style gcds-heading fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-heading/readme.md
+++ b/packages/web/src/components/gcds-heading/readme.md
@@ -20,11 +20,13 @@
 ### Used by
 
  - [gcds-error-summary](../gcds-error-summary)
+ - [gcds-stepper](../gcds-stepper)
 
 ### Graph
 ```mermaid
 graph TD;
   gcds-error-summary --> gcds-heading
+  gcds-stepper --> gcds-heading
   style gcds-heading fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -9,7 +9,7 @@
 
 | Property               | Attribute       | Description                                                      | Type                                                               | Default     |
 | ---------------------- | --------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------ | ----------- |
-| `autocomplete`         | `autocomplete`  | String to have autocomplete enabled                              | `string`                                                    | `undefined` |
+| `autocomplete`         | `autocomplete`  | String to have autocomplete enabled                              | `string`                                                           | `undefined` |
 | `disabled`             | `disabled`      | Specifies if an input element is disabled or not.                | `boolean`                                                          | `false`     |
 | `errorMessage`         | `error-message` | Error message for an invalid input element.                      | `string`                                                           | `undefined` |
 | `hideLabel`            | `hide-label`    | Specifies if the label is hidden or not.                         | `boolean`                                                          | `false`     |

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
@@ -15,8 +15,6 @@
 
 @layer default {
   :host .gcds-lang-toggle {
-    font: var(--gcds-lang-toggle-font);
-
     gcds-link::part(link) {
       padding: var(--gcds-lang-toggle-padding);
     }

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
@@ -50,7 +50,7 @@ export class GcdsLangToggle {
       <Host>
         <div class="gcds-lang-toggle">
           <h2>{i18n[lang].heading}</h2>
-          <gcds-link href={href} lang={i18n[lang].abbreviation}>
+          <gcds-link size="regular" href={href} lang={i18n[lang].abbreviation}>
             <span>{i18n[lang].language}</span>
             <abbr title={i18n[lang].language}>{i18n[lang].abbreviation}</abbr>
           </gcds-link>

--- a/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
@@ -12,7 +12,7 @@ describe('gcds-lang-toggle', () => {
         <mock:shadow-root>
         <div class="gcds-lang-toggle">
           <h2>Language Selection</h2>
-          <gcds-link href="/fr/" lang="fr">
+          <gcds-link size="regular" href="/fr/" lang="fr">
             <span>Français</span>
             <abbr title="Français">fr</abbr>
           </gcds-link>
@@ -32,7 +32,7 @@ describe('gcds-lang-toggle', () => {
         <mock:shadow-root>
         <div class="gcds-lang-toggle">
           <h2>Sélection de la langue</h2>
-          <gcds-link href="/en/" lang="en">
+          <gcds-link size="regular" href="/en/" lang="en">
             <span>English</span>
             <abbr title="English">en</abbr>
           </gcds-link>

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -37,6 +37,7 @@
  - [gcds-card](../gcds-card)
  - [gcds-error-summary](../gcds-error-summary)
  - [gcds-footer](../gcds-footer)
+ - [gcds-header](../gcds-header)
  - [gcds-lang-toggle](../gcds-lang-toggle)
 
 ### Depends on
@@ -51,6 +52,7 @@ graph TD;
   gcds-card --> gcds-link
   gcds-error-summary --> gcds-link
   gcds-footer --> gcds-link
+  gcds-header --> gcds-link
   gcds-lang-toggle --> gcds-link
   style gcds-link fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-sr-only/readme.md
+++ b/packages/web/src/components/gcds-sr-only/readme.md
@@ -5,6 +5,19 @@
 <!-- Auto Generated Below -->
 
 
+## Dependencies
+
+### Used by
+
+ - [gcds-card](../gcds-card)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-card --> gcds-sr-only
+  style gcds-sr-only fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-stepper/gcds-stepper.css
+++ b/packages/web/src/components/gcds-stepper/gcds-stepper.css
@@ -8,8 +8,6 @@
 
 @layer default {
   :host .gcds-stepper {
-    font: var(--gcds-stepper-font);
-    margin: var(--gcds-stepper-margin);
     color: var(--gcds-stepper-text);
   }
 }

--- a/packages/web/src/components/gcds-stepper/gcds-stepper.tsx
+++ b/packages/web/src/components/gcds-stepper/gcds-stepper.tsx
@@ -53,7 +53,14 @@ export class GcdsStepper {
 
     return (
       <Host>
-        <h6 class="gcds-stepper">{`${i18n[lang].step} ${currentStep} ${i18n[lang].of} ${totalSteps}`}</h6>
+        <gcds-heading
+          tag="h6"
+          class="gcds-stepper"
+          margin-top="0"
+          margin-bottom="300"
+        >
+          {`${i18n[lang].step} ${currentStep} ${i18n[lang].of} ${totalSteps}`}
+        </gcds-heading>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-stepper/readme.md
+++ b/packages/web/src/components/gcds-stepper/readme.md
@@ -13,6 +13,19 @@
 | `totalSteps` _(required)_  | `total-steps`  | Defines the total amount of steps. | `number` | `undefined` |
 
 
+## Dependencies
+
+### Depends on
+
+- [gcds-heading](../gcds-heading)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-stepper --> gcds-heading
+  style gcds-stepper fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-stepper/test/gcds-stepper.spec.tsx
+++ b/packages/web/src/components/gcds-stepper/test/gcds-stepper.spec.tsx
@@ -10,7 +10,7 @@ describe('gcds-stepper', () => {
     expect(page.root).toEqualHtml(`
       <gcds-stepper current-step="2" total-steps="6">
         <mock:shadow-root>
-          <h6 class="gcds-stepper">Step 2 of 6</h6>
+          <gcds-heading tag="h6" class="gcds-stepper" margin-top="0" margin-bottom="300">Step 2 of 6</h6>
         </mock:shadow-root>
       </gcds-stepper>
     `);
@@ -27,7 +27,7 @@ describe('gcds-stepper', () => {
     expect(page.root).toEqualHtml(`
       <gcds-stepper current-step="2" total-steps="6">
         <mock:shadow-root>
-          <h6 class="gcds-stepper">Step 2 of 6</h6>
+          <gcds-heading tag="h6" class="gcds-stepper" margin-top="0" margin-bottom="300">Step 2 of 6</h6>
         </mock:shadow-root>
       </gcds-stepper>
     `);
@@ -44,7 +44,7 @@ describe('gcds-stepper', () => {
     expect(page.root).toEqualHtml(`
       <gcds-stepper current-step="2" total-steps="6" lang="fr">
         <mock:shadow-root>
-          <h6 class="gcds-stepper">Étape 2 sur 6</h6>
+          <gcds-heading tag="h6" class="gcds-stepper" margin-top="0" margin-bottom="300">Étape 2 sur 6</h6>
         </mock:shadow-root>
       </gcds-stepper>
     `);


### PR DESCRIPTION
# Summary | Résumé

Integrate `gcds-heading` component into existing components to reduce code duplication created through repeated heading styles.

`gcds-heading` was integrated into:

- gcds-error-summary
- gcds-stepper

Also added the correct size prop to the `gcds-link` component in our existing components to ensure proper font-sizes and reduce the used font tokens.

[Tokens PR](https://github.com/cds-snc/gcds-tokens/pull/235)
