### PR TITLE
feat: set allowed values for grid tag property to limit misuse

### DIFF
--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -485,7 +485,15 @@ export namespace Components {
         /**
           * Set tag for grid container
          */
-        "tag"?: string;
+        "tag"?: | 'article'
+    | 'aside'
+    | 'div'
+    | 'dl'
+    | 'main'
+    | 'nav'
+    | 'ol'
+    | 'section'
+    | 'ul';
     }
     interface GcdsGridCol {
         /**
@@ -2293,7 +2301,15 @@ declare namespace LocalJSX {
         /**
           * Set tag for grid container
          */
-        "tag"?: string;
+        "tag"?: | 'article'
+    | 'aside'
+    | 'div'
+    | 'dl'
+    | 'main'
+    | 'nav'
+    | 'ol'
+    | 'section'
+    | 'ul';
     }
     interface GcdsGridCol {
         /**

--- a/packages/web/src/components/gcds-grid/gcds-grid.tsx
+++ b/packages/web/src/components/gcds-grid/gcds-grid.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
+import { Component, Element, Host, Watch, Prop, h } from '@stencil/core';
 
 type ContentValues =
   | 'center'
@@ -53,7 +53,35 @@ export class GcdsGrid {
   /**
    * Set tag for grid container
    */
-  @Prop() tag?: string = 'div';
+  @Prop({ mutable: true }) tag?:
+    | 'article'
+    | 'aside'
+    | 'div'
+    | 'dl'
+    | 'main'
+    | 'nav'
+    | 'ol'
+    | 'section'
+    | 'ul' = 'div';
+
+  @Watch('tag')
+  validateTag(newValue: string) {
+    const values = [
+      'article',
+      'aside',
+      'div',
+      'dl',
+      'main',
+      'nav',
+      'ol',
+      'section',
+      'ul',
+    ];
+
+    if (!values.includes(newValue)) {
+      this.tag = 'div';
+    }
+  }
 
   /**
    * If total grid size is less than the size of its grid container,
@@ -86,6 +114,11 @@ export class GcdsGrid {
    * Sets both the align-items + justify-items properties
    */
   @Prop() placeItems?: 'center' | 'end' | 'start' | 'stretch';
+
+  componentWillLoad() {
+    // Validate attributes and set defaults
+    this.validateTag(this.tag);
+  }
 
   render() {
     const {

--- a/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
+++ b/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
@@ -52,7 +52,18 @@ export default {
       },
     },
     tag: {
-      control: 'text',
+      control: { type: 'select' },
+      options: [
+        'article',
+        'aside',
+        'div',
+        'dl',
+        'main',
+        'nav',
+        'ol',
+        'section',
+        'ul',
+      ],
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: 'div' },
@@ -321,6 +332,20 @@ Individual.args = {
   container: 'full',
   tag: 'div',
   default: 'This is some example content to display the grid component.',
+};
+
+// ------ Grid tag ------
+
+export const Tag = Template.bind({});
+Tag.args = {
+  columns: 'repeat(auto-fit, minmax(100px, 250px))',
+  columnsDesktop: '',
+  columnsTablet: '',
+  container: 'full',
+  tag: 'article',
+  default: `<p>This is some example content to display the grid component.</p>
+  <p>This is some example content to display the grid component.</p>
+  <p>This is some example content to display the grid component.</p>`,
 };
 
 // ------ Grid events & props ------

--- a/packages/web/src/components/gcds-grid/stories/overview.mdx
+++ b/packages/web/src/components/gcds-grid/stories/overview.mdx
@@ -61,6 +61,12 @@ Use the `columns-desktop` property to define your layout for larger screens **(6
 
 <Canvas of={Grid.ColumnsDesktop} story={{ inline: true }} />
 
+### Tag
+
+Always use the tag in a standard way to maintain accessibility.
+
+<Canvas of={Grid.Tag} story={{ inline: true }} />
+
 ## Resources
 
 {/* prettier-ignore */}

--- a/packages/web/src/components/gcds-grid/test/gcds-grid.spec.ts
+++ b/packages/web/src/components/gcds-grid/test/gcds-grid.spec.ts
@@ -55,4 +55,22 @@ describe('gcds-grid', () => {
       </gcds-grid>
     `);
   });
+
+  it('renders - div when passed an invalid tag value', async () => {
+    const { root } = await newSpecPage({
+      components: [GcdsGrid],
+      html: `
+        <gcds-grid columns="1fr" tag="p" />
+      `,
+    });
+    expect(root).toEqualHtml(`
+      <gcds-grid columns="1fr" tag="p">
+        <mock:shadow-root>
+          <div class="display-grid gcds-grid" style="--gcds-grid-columns: 1fr;">
+            <slot></slot>
+          </div>
+        </mock:shadow-root>
+      </gcds-grid>
+    `);
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

Limiting the allowed values for the grid tag property after some feedback we received from the OCADU report.

Linked to
- https://github.com/cds-snc/design-gc-conception/issues/757