### PR TITLE
fix: invalid path for types

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -13,18 +13,20 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "outDir": "dist",
+    "outDir": "./dist",
     "removeComments": false,
     "skipLibCheck": true,
     "jsx": "react",
     "target": "es2015",
+    "declarationDir": "./dist/types"
   },
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
   ],
   "exclude": [
-    "**/__tests__/**"
+    "**/__tests__/**",
+    "node_modules",
   ],
   "compileOnSave": false,
   "buildOnSave": false


### PR DESCRIPTION
# Summary | Résumé
- Fixes #466

Tested with a small create react app with typescript. I saw the exact same message as detailed in #466, and tested this updated package on that app. This fix should resolve the issue; I don't see anymore typescript errors during testing.