### PR TITLE
fix: Declarative shadow-dom error in Chrome

### DIFF
--- a/packages/ssr/lib/client/index.ts
+++ b/packages/ssr/lib/client/index.ts
@@ -1,13 +1,6 @@
 // Original code from https://github.com/luwes/wesc
 
-import React, { FC, Fragment, PropsWithChildren, ReactNode, useEffect, useState } from 'react';
-
-export const WithRSCFallback: FC<PropsWithChildren<{ rsc: ReactNode }>> = ({ rsc, children }) => {
-  const [isClient, setIsClient] = useState(false);
-  useEffect(() => setIsClient(true), []);
-
-  return React.createElement(Fragment, null, isClient ? children : rsc);
-};
+import { PropsWithChildren } from 'react';
 
 // Must go in a client component
 // > Otherwise will error:

--- a/packages/ssr/lib/client/render.ts
+++ b/packages/ssr/lib/client/render.ts
@@ -9,6 +9,7 @@ declare global {
   }
 }
 
+// TODO: find some way to automate this
 const delFocusElements = [
   'gcds-button',
   'gcds-checkbox',

--- a/packages/ssr/lib/client/render.ts
+++ b/packages/ssr/lib/client/render.ts
@@ -43,42 +43,44 @@ function renderChildren(children, parent: HTMLElement) {
           element.connectedCallback = function () {
             originalConnected?.call(element);
 
-            if (element.shadowRoot) {
-              // Some web components defer updates. Add a timeout larger than micro task.
-              setTimeout(() => {
-                const styles = Array.from(element.shadowRoot.querySelectorAll('style'));
-                for (const style of styles) {
-                  style.textContent = minimizeCss(style.textContent);
-                }
+            // Some web components defer updates. Add a timeout larger than micro task.
+            setTimeout(() => {
+              if (!element.shadowRoot) {
+                return;
+              }
 
-                renderCustomElements(element.shadowRoot);
+              const styles = Array.from(element.shadowRoot.querySelectorAll('style') ?? []);
+              for (const style of styles) {
+                style.textContent = minimizeCss(style.textContent ?? '');
+              }
 
-                const templateProps = {
-                  shadowrootmode: element.shadowRoot.mode ?? 'open',
-                  dangerouslySetInnerHTML: {
-                    __html: element.shadowRoot.innerHTML,
-                  },
-                };
+              renderCustomElements(element.shadowRoot);
 
-                if (delFocusElements.includes(node.type)) {
-                  templateProps['shadowrootdelegatesfocus'] = 'true';
-                }
+              const templateProps = {
+                shadowrootmode: element.shadowRoot.mode ?? 'open',
+                dangerouslySetInnerHTML: {
+                  __html: element.shadowRoot.innerHTML,
+                },
+              };
 
-                const templateShadowRoot = React.createElement('template', templateProps);
+              if (delFocusElements.includes(node.type)) {
+                templateProps['shadowrootdelegatesfocus'] = 'true';
+              }
 
-                if (node.props.children) {
-                  node.props.children.unshift(templateShadowRoot);
-                } else {
-                  node.props.children = [templateShadowRoot];
-                }
+              const templateShadowRoot = React.createElement('template', templateProps);
 
-                Object.assign(node.props, attributesToProps(element.attributes));
+              if (node.props.children) {
+                node.props.children.unshift(templateShadowRoot);
+              } else {
+                node.props.children = [templateShadowRoot];
+              }
 
-                if (typeof node.props.style === 'string') {
-                  node.props.style = parseStyle(node.props.style);
-                }
-              }, 0);
-            }
+              Object.assign(node.props, attributesToProps(element.attributes));
+
+              if (typeof node.props.style === 'string') {
+                node.props.style = parseStyle(node.props.style);
+              }
+            }, 0);
           };
         }
       }
@@ -87,22 +89,18 @@ function renderChildren(children, parent: HTMLElement) {
 }
 
 const renderCustomElements = (shadowRoot: ShadowRoot) => {
-  const customElements = Array.from(shadowRoot.innerHTML.matchAll(/<gcds-[\w-]+/g)).map(([e]) => e);
+  // Find all custom elements in the shadow root
+  const customElements = Array.from(shadowRoot.innerHTML.matchAll(/<([a-z0-9]+-[\w-]+)/g)).map(([, e]) => e);
   for (const element of customElements) {
-    const elementShadowRoot = shadowRoot.querySelectorAll(element.replace('<', ''));
-    for (const e of elementShadowRoot) {
-      if (e?.shadowRoot) {
-        const template = document.createElement('template');
-        template.setAttribute('shadowrootmode', 'open');
-        template.innerHTML = e?.innerHTML;
-        renderCustomElements(e.shadowRoot);
-        shadowRoot.querySelector(element)?.appendChild(template);
-      }
+    const elementShadowRoot = shadowRoot.querySelector(element)?.shadowRoot;
+
+    if (elementShadowRoot) {
+      const template = document.createElement('template');
+      template.setAttribute('shadowrootmode', 'open');
+      template.innerHTML = elementShadowRoot?.innerHTML;
+      renderCustomElements(elementShadowRoot);
+      shadowRoot.querySelector(element)?.appendChild(template);
     }
-
-    // if (elementShadowRoot) {
-
-    // }
   }
 };
 

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -51,5 +51,6 @@ export const config: Config = {
   validatePrimaryPackageOutputTarget: true,
   extras: {
     enableImportInjection: true,
+    experimentalSlotFixes: true
   },
 };


### PR DESCRIPTION
# Summary | Résumé

Prevent errors from appearing in Chrome by adjusting render logic.

## Changes

- Added a list of our components that are form-associated to add `shadowrootdelegatesfocus` to template tag in DSD
- Fixed render function from attaching multiple template tags to custom elements in components