### PR TITLE
rework: Rework navigation components to remove menu role and hydration issues

### DIFF
--- a/packages/ssr/lib/utils.ts
+++ b/packages/ssr/lib/utils.ts
@@ -217,19 +217,12 @@ export const gcdsAttributeGenerator = (tagName: string, props: object) => {
       return props;
     }
     case 'gcds-nav-link': {
-      // props['class'] = props['class'] ? `${props['class']} gcds-nav-link--sidenav` : 'gcds-nav-link--sidenav';
-      // props['role'] = props['role'] ? props['role'] : 'presentation';
+      props['role'] = props['role'] ? props['role'] : 'listitem';
 
       return props;
     }
     case 'gcds-nav-group': {
-      const openClass = props['open'] ? 'gcds-nav-group-expanded' : '';
-      if (openClass != '') {
-        props['class'] = props['class'] ? `${props['class']} ${openClass}` : openClass;
-      } else {
-        props['class'] = props['class'] ? `${props['class']}${openClass}` : openClass;
-      }
-      props['role'] = props['role'] ? props['role'] : 'presentation';
+      props['role'] = props['role'] ? props['role'] : 'listitem';
 
       return props;
     }

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
@@ -98,7 +98,7 @@
     }
   }
 
-  :host(.gcds-mobile-nav.gcds-nav-group-expanded) {
+  :host([open].gcds-mobile-nav) {
     z-index: 100;
     position: fixed;
     top: 0;
@@ -166,7 +166,7 @@
       margin: var(--gcds-nav-group-mobile-list-margin);
     }
 
-    :host(.gcds-nav-group-expanded:not(.gcds-mobile-nav))
+    :host([open]:not(.gcds-mobile-nav))
       .gcds-nav-group__list {
       padding-inline-start: var(--gcds-nav-group-side-nav-dropdown-padding);
     }

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -137,24 +137,17 @@ export class GcdsNavGroup {
   render() {
     const { closeTrigger, menuLabel, open, openTrigger } = this;
 
-    const roleAttr = {
-      role: 'menuitem',
-    };
+    const hostAttr = {};
 
-    if (this.el.classList.contains('gcds-mobile-nav')) {
-      delete roleAttr['role'];
+    if (open) {
+      hostAttr['class'] = 'gcds-nav-group-expanded';
     }
 
     return (
-      <Host
-        role="presentation"
-        open={open}
-        class={open && 'gcds-nav-group-expanded'}
-      >
+      <Host role="listitem" open={open} {...hostAttr}>
         <button
           aria-haspopup="true"
           aria-expanded={open.toString()}
-          {...roleAttr}
           ref={element => (this.triggerElement = element as HTMLElement)}
           class={`gcds-nav-group__trigger gcds-trigger--${this.navStyle}`}
           onClick={() => {
@@ -166,7 +159,6 @@ export class GcdsNavGroup {
           {closeTrigger && open ? closeTrigger : openTrigger}
         </button>
         <ul
-          role="menu"
           aria-label={menuLabel}
           class={`gcds-nav-group__list gcds-nav--${this.navStyle}`}
         >

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -137,14 +137,8 @@ export class GcdsNavGroup {
   render() {
     const { closeTrigger, menuLabel, open, openTrigger } = this;
 
-    const hostAttr = {};
-
-    if (open) {
-      hostAttr['class'] = 'gcds-nav-group-expanded';
-    }
-
     return (
-      <Host role="listitem" open={open} {...hostAttr}>
+      <Host role="listitem" open={open}>
         <button
           aria-haspopup="true"
           aria-expanded={open.toString()}

--- a/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.spec.tsx
+++ b/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.spec.tsx
@@ -8,13 +8,13 @@ describe('gcds-nav-group', () => {
       html: `<gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group"></gcds-nav-group>`,
     });
     expect(page.root).toEqualHtml(`
-    <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" role="presentation">
+    <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" role="listitem">
       <mock:shadow-root>
-        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable" role="menuitem">
+        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable">
           <gcds-icon name="angle-down"></gcds-icon>
           Nav group
         </button>
-        <ul aria-label="Nav group submenu" class="gcds-nav--expandable gcds-nav-group__list" role="menu">
+        <ul aria-label="Nav group submenu" class="gcds-nav--expandable gcds-nav-group__list">
           <slot></slot>
         </ul>
       </mock:shadow-root>
@@ -28,13 +28,13 @@ describe('gcds-nav-group', () => {
       html: `<gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" lang="fr"></gcds-nav-group>`,
     });
     expect(page.root).toEqualHtml(`
-    <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" lang="fr" role="presentation">
+    <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" lang="fr" role="listitem">
       <mock:shadow-root>
-        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable" role="menuitem">
+        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable">
           <gcds-icon name="angle-down"></gcds-icon>
           Nav group
         </button>
-        <ul aria-label="Nav group submenu" class="gcds-nav--expandable gcds-nav-group__list" role="menu">
+        <ul aria-label="Nav group submenu" class="gcds-nav--expandable gcds-nav-group__list">
           <slot></slot>
         </ul>
       </mock:shadow-root>
@@ -48,13 +48,13 @@ describe('gcds-nav-group', () => {
       html: `<gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" open></gcds-nav-group>`,
     });
     expect(page.root).toEqualHtml(`
-    <gcds-nav-group class="gcds-nav-group-expanded" menu-label="Nav group submenu" open-trigger="Nav group" role="presentation" open>
+    <gcds-nav-group class="gcds-nav-group-expanded" menu-label="Nav group submenu" open-trigger="Nav group" role="listitem" open>
       <mock:shadow-root>
-        <button aria-expanded="true" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable" role="menuitem">
+        <button aria-expanded="true" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable">
           <gcds-icon name="angle-up"></gcds-icon>
           Nav group
         </button>
-        <ul aria-label="Nav group submenu" class="gcds-nav--expandable gcds-nav-group__list" role="menu">
+        <ul aria-label="Nav group submenu" class="gcds-nav--expandable gcds-nav-group__list">
           <slot></slot>
         </ul>
       </mock:shadow-root>

--- a/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.spec.tsx
+++ b/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.spec.tsx
@@ -48,7 +48,7 @@ describe('gcds-nav-group', () => {
       html: `<gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" open></gcds-nav-group>`,
     });
     expect(page.root).toEqualHtml(`
-    <gcds-nav-group class="gcds-nav-group-expanded" menu-label="Nav group submenu" open-trigger="Nav group" role="listitem" open>
+    <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" role="listitem" open>
       <mock:shadow-root>
         <button aria-expanded="true" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable">
           <gcds-icon name="angle-up"></gcds-icon>

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
@@ -41,7 +41,7 @@
 @layer variants {
   /* Top-nav: styles for larger screens */
   @media only screen and (width >= 64em) {
-    :host(.gcds-nav-link--topnav) > .gcds-nav-link {
+    :host > .gcds-nav-link--topnav.gcds-nav-link {
       color: var(--gcds-nav-link-top-nav-text);
       margin: var(--gcds-nav-link-top-nav-margin);
       padding: var(--gcds-nav-link-top-nav-padding);
@@ -54,14 +54,14 @@
     }
 
     /* Home link styles  */
-    :host(.gcds-nav-link--home) > .gcds-nav-link {
+    :host([slot=home]) > .gcds-nav-link {
       font: var(--gcds-nav-link-top-nav-home-font);
       padding: var(--gcds-nav-link-top-nav-home-padding);
     }
   }
 
   /* Side-nav: nav link styles */
-  :host(.gcds-nav-link--sidenav) > .gcds-nav-link {
+  :host > .gcds-nav-link--sidenav.gcds-nav-link {
     padding: var(--gcds-nav-link-side-nav-padding);
   }
 }
@@ -75,16 +75,16 @@
       color: var(--gcds-nav-link-hover-text);
     }
 
-    :host(.gcds-nav-link--sidenav) > .gcds-nav-link:hover,
-    :host(.gcds-nav-link--dropdown) > .gcds-nav-link:hover {
+    :host > .gcds-nav-link--sidenav.gcds-nav-link:hover,
+    :host > .gcds-nav-link--dropdown.gcds-nav-link:hover {
       color: var(--gcds-nav-link-hover-text);
     }
 
-    :host(.gcds-nav-link--sidenav) > .gcds-nav-link:hover {
+    :host > .gcds-nav-link--sidenav.gcds-nav-link:hover {
       background-color: var(--gcds-nav-link-side-nav-hover-background);
     }
 
-    :host(.gcds-nav-link--dropdown) > .gcds-nav-link:hover {
+    :host> .gcds-nav-link--dropdown.gcds-nav-link:hover {
       background-color: var(--gcds-nav-link-top-nav-hover-background);
     }
   }
@@ -98,7 +98,7 @@
     border-inline-start-color: var(--gcds-nav-link-active-border-color);
   }
 
-  :host(.gcds-nav-link--topnav) > .gcds-nav-link[aria-current='page'] {
+  :host > .gcds-nav-link--topnav.gcds-nav-link[aria-current='page'] {
     @media only screen and (width >= 64em) {
       font: var(--gcds-nav-link-font);
       background-color: transparent;

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
@@ -84,7 +84,7 @@
       background-color: var(--gcds-nav-link-side-nav-hover-background);
     }
 
-    :host> .gcds-nav-link--dropdown.gcds-nav-link:hover {
+    :host > .gcds-nav-link--dropdown.gcds-nav-link:hover {
       background-color: var(--gcds-nav-link-top-nav-hover-background);
     }
   }

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
@@ -116,12 +116,11 @@ export class GcdsNavLink {
     }
 
     return (
-      <Host role="presentation" class={`gcds-nav-link--${this.navStyle}`}>
+      <Host role="listitem" class={`gcds-nav-link--${this.navStyle}`}>
         <a
           class="gcds-nav-link"
           href={href}
           {...linkAttrs}
-          role="menuitem"
           onBlur={e => this.onBlur(e)}
           onFocus={e => this.onFocus(e)}
           onClick={e => this.onClick(e)}

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
@@ -96,8 +96,7 @@ export class GcdsNavLink {
 
     if (this.el.closest('gcds-top-nav')) {
       if (this.el.parentNode.nodeName == 'GCDS-TOP-NAV') {
-        this.navStyle =
-          this.el.slot == 'home' ? 'topnav gcds-nav-link--home' : 'topnav';
+        this.navStyle = 'topnav';
       } else {
         this.navStyle = 'dropdown';
       }
@@ -116,9 +115,9 @@ export class GcdsNavLink {
     }
 
     return (
-      <Host role="listitem" class={`gcds-nav-link--${this.navStyle}`}>
+      <Host role="listitem">
         <a
-          class="gcds-nav-link"
+          class={`gcds-nav-link gcds-nav-link--${this.navStyle}`}
           href={href}
           {...linkAttrs}
           onBlur={e => this.onBlur(e)}

--- a/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.spec.tsx
+++ b/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.spec.tsx
@@ -8,9 +8,9 @@ describe('gcds-nav-link', () => {
       html: `<gcds-nav-link href="#link">Nav Link</gcds-nav-link>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-nav-link href="#link" class="gcds-nav-link--sidenav" role="presentation">
+      <gcds-nav-link href="#link" class="gcds-nav-link--sidenav" role="listitem">
         <mock:shadow-root>
-          <a href="#link" class="gcds-nav-link" role="menuitem">
+          <a href="#link" class="gcds-nav-link">
             <slot></slot>
           </a>
         </mock:shadow-root>
@@ -24,9 +24,9 @@ describe('gcds-nav-link', () => {
       html: `<gcds-nav-link href="#link" current>Nav Link</gcds-nav-link>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-nav-link class="gcds-nav-link--sidenav" current="" href="#link" role="presentation">
+      <gcds-nav-link class="gcds-nav-link--sidenav" current="" href="#link" role="listitem">
         <mock:shadow-root>
-          <a aria-current="page" class="gcds-nav-link" href="#link" role="menuitem">
+          <a aria-current="page" class="gcds-nav-link" href="#link">
             <slot></slot>
           </a>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.spec.tsx
+++ b/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.spec.tsx
@@ -8,9 +8,9 @@ describe('gcds-nav-link', () => {
       html: `<gcds-nav-link href="#link">Nav Link</gcds-nav-link>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-nav-link href="#link" class="gcds-nav-link--sidenav" role="listitem">
+      <gcds-nav-link href="#link" role="listitem">
         <mock:shadow-root>
-          <a href="#link" class="gcds-nav-link">
+          <a href="#link" class="gcds-nav-link gcds-nav-link--sidenav">
             <slot></slot>
           </a>
         </mock:shadow-root>
@@ -24,9 +24,9 @@ describe('gcds-nav-link', () => {
       html: `<gcds-nav-link href="#link" current>Nav Link</gcds-nav-link>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-nav-link class="gcds-nav-link--sidenav" current="" href="#link" role="listitem">
+      <gcds-nav-link current="" href="#link" role="listitem">
         <mock:shadow-root>
-          <a aria-current="page" class="gcds-nav-link" href="#link">
+          <a aria-current="page" class="gcds-nav-link gcds-nav-link--sidenav" href="#link">
             <slot></slot>
           </a>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-side-nav/gcds-side-nav.css
+++ b/packages/web/src/components/gcds-side-nav/gcds-side-nav.css
@@ -6,6 +6,7 @@
 
     * {
       margin: 0;
+      padding: 0;
       box-sizing: border-box;
     }
   }

--- a/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
+++ b/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
@@ -175,17 +175,20 @@ export class GcdsSideNav {
           class="gcds-side-nav"
         >
           <h2 class="gcds-side-nav__heading">{label}</h2>
-          <gcds-nav-group
-            menuLabel="Menu"
-            closeTrigger={lang == 'fr' ? 'Fermer' : 'Close'}
-            openTrigger="Menu"
-            class="gcds-mobile-nav"
-            role="menu"
-            ref={element => (this.mobile = element as HTMLGcdsNavGroupElement)}
-            lang={lang}
-          >
-            <slot></slot>
-          </gcds-nav-group>
+          <ul>
+            <gcds-nav-group
+              menuLabel="Menu"
+              closeTrigger={lang == 'fr' ? 'Fermer' : 'Close'}
+              openTrigger="Menu"
+              class="gcds-mobile-nav"
+              ref={element =>
+                (this.mobile = element as HTMLGcdsNavGroupElement)
+              }
+              lang={lang}
+            >
+              <slot></slot>
+            </gcds-nav-group>
+          </ul>
         </nav>
       </Host>
     );

--- a/packages/web/src/components/gcds-side-nav/test/gcds-side-nav.spec.tsx
+++ b/packages/web/src/components/gcds-side-nav/test/gcds-side-nav.spec.tsx
@@ -16,9 +16,11 @@ describe('gcds-side-nav', () => {
             <h2 class="gcds-side-nav__heading">
               Side-nav
             </h2>
-            <gcds-nav-group class="gcds-mobile-nav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en" role="menu">
-              <slot></slot>
-            </gcds-nav-group>
+            <ul>
+              <gcds-nav-group class="gcds-mobile-nav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en">
+                <slot></slot>
+              </gcds-nav-group>
+            </ul>
           </nav>
         </mock:shadow-root>
       </gcds-side-nav>
@@ -36,9 +38,11 @@ describe('gcds-side-nav', () => {
             <h2 class="gcds-side-nav__heading">
               Side-nav
             </h2>
-            <gcds-nav-group class="gcds-mobile-nav" menuLabel="Menu" closeTrigger="Fermer" openTrigger="Menu" lang="fr" role="menu">
-              <slot></slot>
-            </gcds-nav-group>
+            <ul>
+              <gcds-nav-group class="gcds-mobile-nav" menuLabel="Menu" closeTrigger="Fermer" openTrigger="Menu" lang="fr">
+                <slot></slot>
+              </gcds-nav-group>
+            </ul>
           </nav>
         </mock:shadow-root>
       </gcds-side-nav>

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
@@ -177,28 +177,26 @@ export class GcdsTopNav {
     return (
       <Host>
         <div class="gcds-top-nav">
-          <nav
-            aria-label={`${label}${I18N[lang].navLabel}`}
-            class="gcds-top-nav__container"
-          >
-            <gcds-nav-group
-              menuLabel="Menu"
-              closeTrigger={lang == 'fr' ? 'Fermer' : 'Close'}
-              openTrigger="Menu"
-              class="gcds-mobile-nav gcds-mobile-nav-topnav"
-              ref={element =>
-                (this.mobile = element as HTMLGcdsNavGroupElement)
-              }
-              lang={lang}
-            >
-              <slot name="home"></slot>
-              <ul
-                role="menu"
-                class={`nav-container__list nav-list--${alignment}`}
+          <nav aria-label={`${label}${I18N[lang].navLabel}`}>
+            <ul class="gcds-top-nav__container">
+              <gcds-nav-group
+                menuLabel="Menu"
+                closeTrigger={lang == 'fr' ? 'Fermer' : 'Close'}
+                openTrigger="Menu"
+                class="gcds-mobile-nav gcds-mobile-nav-topnav"
+                ref={element =>
+                  (this.mobile = element as HTMLGcdsNavGroupElement)
+                }
+                lang={lang}
               >
-                <slot></slot>
-              </ul>
-            </gcds-nav-group>
+                <slot name="home"></slot>
+                <li class={`nav-container__list nav-list--${alignment}`}>
+                  <ul class={`nav-container__list nav-list--${alignment}`}>
+                    <slot></slot>
+                  </ul>
+                </li>
+              </gcds-nav-group>
+            </ul>
           </nav>
         </div>
       </Host>

--- a/packages/web/src/components/gcds-top-nav/test/gcds-top-nav.spec.tsx
+++ b/packages/web/src/components/gcds-top-nav/test/gcds-top-nav.spec.tsx
@@ -13,13 +13,17 @@ describe('gcds-top-nav', () => {
       <gcds-top-nav label="top-nav">
         <mock:shadow-root>
           <div class="gcds-top-nav">
-            <nav aria-label="top-nav - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu." class="gcds-top-nav__container">
-              <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en">
-                <slot name="home"></slot>
-                <ul class="nav-container__list nav-list--left" role="menu">
-                  <slot></slot>
-                </ul>
-              </gcds-nav-group>
+            <nav aria-label="top-nav - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu.">
+              <ul class="gcds-top-nav__container">
+                <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en">
+                  <slot name="home"></slot>
+                  <li class="nav-container__list nav-list--left">
+                    <ul class="nav-container__list nav-list--left">
+                      <slot></slot>
+                    </ul>
+                  </li>
+                </gcds-nav-group>
+              </ul>
             </nav>
           </div>
         </mock:shadow-root>
@@ -35,13 +39,17 @@ describe('gcds-top-nav', () => {
       <gcds-top-nav label="top-nav" lang="fr">
         <mock:shadow-root>
           <div class="gcds-top-nav">
-            <nav aria-label="top-nav - Utiliser la touche d'entrée pour sélectionner un élément du menu et voyager à la page indiquée. Utiliser les flèches gauches et droites pour naviguer entre les éléments et les sous-éléments du menu. Ouvrir les sous-éléments du menu avec la flèche droite lorsqu'il sont disponible. Fermer le menu avec la flèche gauche ou la touche d'échappement." class="gcds-top-nav__container">
-              <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Fermer" openTrigger="Menu" lang="fr">
-                <slot name="home"></slot>
-                <ul class="nav-container__list nav-list--left" role="menu">
-                  <slot></slot>
-                </ul>
-              </gcds-nav-group>
+            <nav aria-label="top-nav - Utiliser la touche d'entrée pour sélectionner un élément du menu et voyager à la page indiquée. Utiliser les flèches gauches et droites pour naviguer entre les éléments et les sous-éléments du menu. Ouvrir les sous-éléments du menu avec la flèche droite lorsqu'il sont disponible. Fermer le menu avec la flèche gauche ou la touche d'échappement.">
+              <ul class="gcds-top-nav__container">
+                <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Fermer" openTrigger="Menu" lang="fr">
+                  <slot name="home"></slot>
+                  <li class="nav-container__list nav-list--left">
+                    <ul class="nav-container__list nav-list--left">
+                      <slot></slot>
+                    </ul>
+                  </li>
+                </gcds-nav-group>
+              </ul>
             </nav>
           </div>
         </mock:shadow-root>
@@ -58,13 +66,17 @@ describe('gcds-top-nav', () => {
       <gcds-top-nav label="top-nav" alignment="center">
         <mock:shadow-root>
           <div class="gcds-top-nav">
-            <nav aria-label="top-nav - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu." class="gcds-top-nav__container">
-              <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en">
-                <slot name="home"></slot>
-                <ul class="nav-container__list nav-list--center" role="menu">
-                  <slot></slot>
-                </ul>
-              </gcds-nav-group>
+            <nav aria-label="top-nav - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu.">
+              <ul class="gcds-top-nav__container">
+                <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en">
+                  <slot name="home"></slot>
+                  <li class="nav-container__list nav-list--center">
+                    <ul class="nav-container__list nav-list--center">
+                      <slot></slot>
+                    </ul>
+                  </li>
+                </gcds-nav-group>
+              </ul>
             </nav>
           </div>
         </mock:shadow-root>
@@ -80,13 +92,17 @@ describe('gcds-top-nav', () => {
       <gcds-top-nav label="top-nav" alignment="right">
         <mock:shadow-root>
           <div class="gcds-top-nav">
-            <nav aria-label="top-nav - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu." class="gcds-top-nav__container">
-              <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en">
-                <slot name="home"></slot>
-                <ul class="nav-container__list nav-list--right" role="menu">
-                  <slot></slot>
-                </ul>
-              </gcds-nav-group>
+            <nav aria-label="top-nav - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu.">
+              <ul class="gcds-top-nav__container">
+                <gcds-nav-group class="gcds-mobile-nav gcds-mobile-nav-topnav" menuLabel="Menu" closeTrigger="Close" openTrigger="Menu" lang="en">
+                  <slot name="home"></slot>
+                  <li class="nav-container__list nav-list--right">
+                    <ul class="nav-container__list nav-list--right">
+                      <slot></slot>
+                    </ul>
+                  </li>
+                </gcds-nav-group>
+              </ul>
             </nav>
           </div>
         </mock:shadow-root>


### PR DESCRIPTION
# Summary | Résumé

As identified in https://github.com/cds-snc/design-gc-conception/issues/756 using `role="menu"` may cause issues with some assistive technologies. Removed use of menu roles from `gcds-top-nav`, `gcds-side-nav`, `gcds-nav-group` and `gcds-nav-link`.

Also removed/moved some classes that are used for styling off of the host elements of `gcds-nav-group` and `gcds-nav-link` to prevent hydration errors when used in SSR environment.
