### PR TITLE
feat: add tag prop to gcds-sr-only component

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -941,13 +941,14 @@ export declare interface GcdsSignature extends Components.GcdsSignature {}
 
 
 @ProxyCmp({
+  inputs: ['tag']
 })
 @Component({
   selector: 'gcds-sr-only',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [],
+  inputs: ['tag'],
 })
 export class GcdsSrOnly {
   protected el: HTMLElement;

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1049,6 +1049,17 @@ export namespace Components {
         "variant": 'colour' | 'white';
     }
     interface GcdsSrOnly {
+        /**
+          * Sets the appropriate HTML tag for the content.
+         */
+        "tag"?: | 'h1'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'p'
+    | 'span';
     }
     interface GcdsStepper {
         /**
@@ -2938,6 +2949,17 @@ declare namespace LocalJSX {
         "variant"?: 'colour' | 'white';
     }
     interface GcdsSrOnly {
+        /**
+          * Sets the appropriate HTML tag for the content.
+         */
+        "tag"?: | 'h1'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'p'
+    | 'span';
     }
     interface GcdsStepper {
         /**

--- a/packages/web/src/components/gcds-button/readme.md
+++ b/packages/web/src/components/gcds-button/readme.md
@@ -47,7 +47,6 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [gcds-header](../gcds-header)
  - [gcds-search](../gcds-search)
 
 ### Depends on
@@ -58,7 +57,6 @@ Type: `Promise<void>`
 ```mermaid
 graph TD;
   gcds-button --> gcds-icon
-  gcds-header --> gcds-button
   gcds-search --> gcds-button
   style gcds-button fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.css
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.css
@@ -14,5 +14,4 @@
       margin: var(--gcds-date-modified-description-margin);
     }
   }
-
 }

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
@@ -69,7 +69,8 @@
     padding: var(--gcds-file-uploader-button-padding);
     background-color: var(--gcds-file-uploader-button-background);
     color: var(--gcds-file-uploader-button-text);
-    border: var(--gcds-file-uploader-button-border-width) solid var(--gcds-file-uploader-button-text);
+    border: var(--gcds-file-uploader-button-border-width) solid
+      var(--gcds-file-uploader-button-text);
     border-radius: var(--gcds-file-uploader-button-border-radius);
     transition: all 0.15s ease-in-out;
   }
@@ -84,13 +85,6 @@
     cursor: pointer;
   }
 
-  #file-uploader__summary {
-    visibility: hidden;
-    height: 0;
-    margin: 0;
-    overflow: hidden;
-  }
-
   &:hover button {
     background-color: var(--gcds-file-uploader-hover-button-background);
   }
@@ -98,7 +92,8 @@
   &:focus-within button {
     background-color: var(--gcds-file-uploader-focus-button-background);
     color: var(--gcds-file-uploader-focus-button-text);
-    outline: var(--gcds-file-uploader-button-outline-width) solid var(--gcds-file-uploader-focus-button-background);
+    outline: var(--gcds-file-uploader-button-outline-width) solid
+      var(--gcds-file-uploader-focus-button-background);
     border-color: currentColor;
   }
 
@@ -118,7 +113,8 @@
   font-weight: var(--gcds-file-uploader-button-font-weight);
   color: var(--gcds-file-uploader-default-text);
   padding: var(--gcds-file-uploader-file-padding);
-  border: var(--gcds-file-uploader-file-border-width) solid var(--gcds-file-uploader-file-border-color);
+  border: var(--gcds-file-uploader-file-border-width) solid
+    var(--gcds-file-uploader-file-border-color);
   cursor: pointer;
 
   &:not(:last-of-type) {
@@ -148,8 +144,12 @@
       transition: box-shadow 0.35s;
       overflow: visible;
       text-decoration: underline;
-      text-underline-offset: var(--gcds-file-uploader-file-button-underline-offset);
-      text-decoration-thickness: var(--gcds-file-uploader-file-button-default-decoration-thickness);
+      text-underline-offset: var(
+        --gcds-file-uploader-file-button-underline-offset
+      );
+      text-decoration-thickness: var(
+        --gcds-file-uploader-file-button-default-decoration-thickness
+      );
     }
 
     &:hover {
@@ -157,13 +157,16 @@
     }
 
     &:hover span {
-      text-decoration-thickness: var(--gcds-file-uploader-file-button-hover-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-file-uploader-file-button-hover-decoration-thickness
+      );
     }
 
     &:focus {
       background-color: var(--gcds-file-uploader-focus-button-background);
       color: var(--gcds-file-uploader-focus-button-text);
-      outline: var(--gcds-file-uploader-focus-button-outline-width) solid var(--gcds-file-uploader-focus-button-background);
+      outline: var(--gcds-file-uploader-focus-button-outline-width) solid
+        var(--gcds-file-uploader-focus-button-background);
       outline-offset: var(--gcds-file-uploader-focus-button-outline-offset);
       border-color: var(--gcds-file-uploader-focus-button-background);
       text-decoration-color: transparent;

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -363,9 +363,8 @@ export class GcdsFileUploader {
     if (hint || errorMessage) {
       const hintID = hint ? `hint-${uploaderId} ` : '';
       const errorID = errorMessage ? `error-message-${uploaderId} ` : '';
-      attrsInput[
-        'aria-describedby'
-      ] = `${hintID}${errorID}${attrsInput['aria-describedby']}`;
+      attrsInput['aria-describedby'] =
+        `${hintID}${errorID}${attrsInput['aria-describedby']}`;
     }
 
     return (
@@ -409,14 +408,16 @@ export class GcdsFileUploader {
               }
             />
             {value.length > 0 ? (
-              <p id="file-uploader__summary">
+              <gcds-sr-only id="file-uploader__summary">
                 <span>{i18n[lang].summary.selected} </span>
                 {value.map(file => (
                   <span>{file} </span>
                 ))}
-              </p>
+              </gcds-sr-only>
             ) : (
-              <p id="file-uploader__summary">{i18n[lang].summary.unselected}</p>
+              <gcds-sr-only id="file-uploader__summary">
+                {i18n[lang].summary.unselected}
+              </gcds-sr-only>
             )}
           </div>
 

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -16,7 +16,7 @@ describe('gcds-file-uploader', () => {
               Choose file
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected.</p>
+            <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
           </div>
         </div>
       </gcds-file-uploader>
@@ -40,7 +40,7 @@ describe('gcds-file-uploader', () => {
               Choose file
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" disabled="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected.</p>
+            <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
           </div>
         </div>
       </gcds-file-uploader>
@@ -65,7 +65,7 @@ describe('gcds-file-uploader', () => {
               Choose file
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="true" aria-describedby="error-message-file-uploader file-uploader__summary" />
-            <p id="file-uploader__summary">No file currently selected.</p>
+            <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
           </div>
         </div>
       </gcds-file-uploader>
@@ -90,7 +90,7 @@ describe('gcds-file-uploader', () => {
               Choose file
             </button>
             <input id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" aria-describedby="hint-file-uploader file-uploader__summary" />
-            <p id="file-uploader__summary">No file currently selected.</p>
+            <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
           </div>
         </div>
       </gcds-file-uploader>
@@ -114,7 +114,7 @@ describe('gcds-file-uploader', () => {
               Choose file
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected.</p>
+            <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
           </div>
         </div>
       </gcds-file-uploader>
@@ -138,7 +138,7 @@ describe('gcds-file-uploader', () => {
               Choose file
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" />
-            <p id="file-uploader__summary">No file currently selected.</p>
+            <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
           </div>
         </div>
       </gcds-file-uploader>
@@ -162,7 +162,7 @@ describe('gcds-file-uploader', () => {
               Choose file
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader" type="file" value="" aria-invalid="false" required="" />
-            <p id="file-uploader__summary">No file currently selected.</p>
+            <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
           </div>
         </div>
       </gcds-file-uploader>

--- a/packages/web/src/components/gcds-footer/gcds-footer.css
+++ b/packages/web/src/components/gcds-footer/gcds-footer.css
@@ -6,17 +6,6 @@
     display: initial;
   }
 
-  .sub__header,
-  .themenav__header,
-  .gcds-footer__header {
-    clip: rect(1px, 1px, 1px, 1px);
-    height: 1px;
-    margin: 0;
-    overflow: hidden;
-    position: absolute;
-    width: 1px;
-  }
-
   [class$='__container'] {
     justify-content: space-between;
     width: 90%;

--- a/packages/web/src/components/gcds-footer/gcds-footer.tsx
+++ b/packages/web/src/components/gcds-footer/gcds-footer.tsx
@@ -143,13 +143,13 @@ export class GcdsFooter {
     let subLinkCount = 0;
 
     return (
-      <Host role="contentinfo">
-        <h2 class="gcds-footer__header">{I18N[lang].about}</h2>
+      <Host role="contentinfo" aria-label="Footer">
+        <gcds-sr-only tag="h2">{I18N[lang].about}</gcds-sr-only>
         {contextualLinksObject && contextualHeading && (
           <div class="gcds-footer__contextual">
             <div class="contextual__container">
-              <nav aria-labelledby="contextual__header">
-                <h3 id="contextual__header" class="contextual__header">
+              <nav aria-labelledby="contextual__heading">
+                <h3 id="contextual__heading" class="contextual__heading">
                   {contextualHeading}
                 </h3>
                 <ul class="contextual__list">
@@ -172,8 +172,8 @@ export class GcdsFooter {
         {display === 'full' ? (
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav class="main__govnav" aria-labelledby="govnav__header">
-                <h3 id="govnav__header">{I18N[lang].gov.heading}</h3>
+              <nav class="main__govnav" aria-labelledby="govnav__heading">
+                <h3 id="govnav__heading">{I18N[lang].gov.heading}</h3>
                 <ul class="govnav__list">
                   {Object.keys(govNav).map(value => (
                     <li>
@@ -182,11 +182,10 @@ export class GcdsFooter {
                   ))}
                 </ul>
               </nav>
-              <nav
-                class="main__themenav"
-                aria-labelledby="themenav__header"
-              >
-                <h4 id="themenav__header" class="themenav__header">{I18N[lang].themes.heading}</h4>
+              <nav class="main__themenav" aria-labelledby="themenav__heading">
+                <gcds-sr-only tag="h4" id="themenav__heading">
+                  {I18N[lang].themes.heading}
+                </gcds-sr-only>
                 <ul class="themenav__list">
                   {Object.keys(themeNav).map(value => (
                     <li>
@@ -201,8 +200,10 @@ export class GcdsFooter {
 
         <div class="gcds-footer__sub">
           <div class="sub__container">
-            <nav aria-labelledby="sub__header">
-              <h3 id="sub__header" class="sub__header">{I18N[lang].site.heading}</h3>
+            <nav aria-labelledby="sub__heading">
+              <gcds-sr-only tag="h3" id="sub__heading">
+                {I18N[lang].site.heading}
+              </gcds-sr-only>
               <ul>
                 {subLinks
                   ? Object.keys(subLinksObject).map(key => {

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
@@ -8,15 +8,15 @@ describe('gcds-footer', () => {
       html: `<gcds-footer display="compact" lang="en"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" display="compact" lang="en">
+      <gcds-footer role="contentinfo" display="compact" lang="en" aria-label="Footer">
         <mock:shadow-root>
-          <h2 class="gcds-footer__header">About this site</h2>
+          <gcds-sr-only tag="h2">About this site</gcds-sr-only>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-labelledby="sub__header">
-                <h3 class="sub__header" id="sub__header">
+              <nav aria-labelledby="sub__heading">
+                <gcds-sr-only id="sub__heading" tag="h3">
                   Government of Canada Corporate
-                </h3>
+                </gcds-sr-only>
                 <ul>
                   <li>
                     <a href="https://www.canada.ca/en/social.html">
@@ -61,13 +61,13 @@ describe('gcds-footer', () => {
       html: `<gcds-footer display="full" lang="en"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" display="full" lang="en">
+      <gcds-footer role="contentinfo" display="full" lang="en" aria-label="Footer">
         <mock:shadow-root>
-          <h2 class="gcds-footer__header">About this site</h2>
+          <gcds-sr-only tag="h2">About this site</gcds-sr-only>
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav aria-labelledby="govnav__header" class="main__govnav">
-                <h3 id="govnav__header">
+              <nav aria-labelledby="govnav__heading" class="main__govnav">
+                <h3 id="govnav__heading">
                   Government of Canada
                 </h3>
                 <ul class="govnav__list">
@@ -88,10 +88,10 @@ describe('gcds-footer', () => {
                   </li>
                 </ul>
               </nav>
-              <nav aria-labelledby="themenav__header" class="main__themenav">
-                <h4 class="themenav__header" id="themenav__header">
+              <nav aria-labelledby="themenav__heading" class="main__themenav">
+                <gcds-sr-only tag="h4" id="themenav__heading">
                   Themes and topics
-                </h4>
+                </gcds-sr-only>
                 <ul class="themenav__list">
                   <li>
                     <a href="https://www.canada.ca/en/services/jobs.html">
@@ -189,10 +189,10 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-labelledby="sub__header">
-                <h3 class="sub__header" id="sub__header">
+              <nav aria-labelledby="sub__heading">
+                <gcds-sr-only id="sub__heading" tag="h3">
                   Government of Canada Corporate
-                </h3>
+                </gcds-sr-only>
                 <ul>
                   <li>
                     <a href="https://www.canada.ca/en/social.html">
@@ -237,15 +237,15 @@ describe('gcds-footer', () => {
       html: `<gcds-footer display="compact" lang="fr"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" display="compact" lang="fr">
+      <gcds-footer role="contentinfo" display="compact" lang="fr" aria-label="Footer">
         <mock:shadow-root>
-          <h2 class="gcds-footer__header">À propos de ce site</h2>
+          <gcds-sr-only tag="h2">À propos de ce site</gcds-sr-only>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-labelledby="sub__header">
-                <h3 class="sub__header" id="sub__header">
+              <nav aria-labelledby="sub__heading">
+                <gcds-sr-only id="sub__heading" tag="h3">
                   Organisation du gouvernement du Canada
-                </h3>
+                </gcds-sr-only>
                 <ul>
                   <li>
                     <a href="https://www.canada.ca/fr/sociaux.html">
@@ -290,13 +290,13 @@ describe('gcds-footer', () => {
       html: `<gcds-footer display="full" lang="fr"></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" display="full" lang="fr">
+      <gcds-footer role="contentinfo" display="full" lang="fr" aria-label="Footer">
         <mock:shadow-root>
-          <h2 class="gcds-footer__header">À propos de ce site</h2>
+          <gcds-sr-only tag="h2">À propos de ce site</gcds-sr-only>
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav aria-labelledby="govnav__header" class="main__govnav">
-                <h3 id="govnav__header">
+              <nav aria-labelledby="govnav__heading" class="main__govnav">
+                <h3 id="govnav__heading">
                   Gouvernement du Canada
                 </h3>
                 <ul class="govnav__list">
@@ -317,10 +317,10 @@ describe('gcds-footer', () => {
                   </li>
                 </ul>
               </nav>
-              <nav aria-labelledby="themenav__header" class="main__themenav">
-                <h4 class="themenav__header" id="themenav__header">
+              <nav aria-labelledby="themenav__heading" class="main__themenav">
+                <gcds-sr-only tag="h4" id="themenav__heading">
                   Thèmes et sujets
-                </h4>
+                </gcds-sr-only>
                 <ul class="themenav__list">
                   <li>
                     <a href="https://www.canada.ca/fr/services/emplois.html">
@@ -418,10 +418,10 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-labelledby="sub__header">
-                <h3 class="sub__header" id="sub__header">
+              <nav aria-labelledby="sub__heading">
+                <gcds-sr-only id="sub__heading" tag="h3">
                   Organisation du gouvernement du Canada
-                </h3>
+                </gcds-sr-only>
                 <ul>
                   <li>
                     <a href="https://www.canada.ca/fr/sociaux.html">
@@ -471,13 +471,13 @@ describe('gcds-footer', () => {
       ></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer contextual-heading="Heading" contextual-links="{ &quot;Link 1&quot;: &quot;#red&quot;, &quot;Link 2&quot;: &quot;#green&quot;, &quot;Link 3&quot;: &quot;#blue&quot; }" display="full" lang="en" role="contentinfo">
+      <gcds-footer contextual-heading="Heading" contextual-links="{ &quot;Link 1&quot;: &quot;#red&quot;, &quot;Link 2&quot;: &quot;#green&quot;, &quot;Link 3&quot;: &quot;#blue&quot; }" display="full" lang="en" role="contentinfo" aria-label="Footer">
         <mock:shadow-root>
-          <h2 class="gcds-footer__header">About this site</h2>
+          <gcds-sr-only tag="h2">About this site</gcds-sr-only>
           <div class="gcds-footer__contextual">
             <div class="contextual__container">
-              <nav aria-labelledby="contextual__header">
-                <h3 class="contextual__header" id="contextual__header">
+              <nav aria-labelledby="contextual__heading">
+                <h3 class="contextual__heading" id="contextual__heading">
                   Heading
                 </h3>
                 <ul class="contextual__list">
@@ -502,8 +502,8 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__main">
             <div class="main__container">
-              <nav aria-labelledby="govnav__header" class="main__govnav">
-                <h3 id="govnav__header">
+              <nav aria-labelledby="govnav__heading" class="main__govnav">
+                <h3 id="govnav__heading">
                   Government of Canada
                 </h3>
                 <ul class="govnav__list">
@@ -524,10 +524,10 @@ describe('gcds-footer', () => {
                   </li>
                 </ul>
               </nav>
-              <nav aria-labelledby="themenav__header" class="main__themenav">
-                <h4 class="themenav__header" id="themenav__header">
+              <nav aria-labelledby="themenav__heading" class="main__themenav">
+                <gcds-sr-only tag="h4" id="themenav__heading">
                   Themes and topics
-                </h4>
+                </gcds-sr-only>
                 <ul class="themenav__list">
                   <li>
                     <a href="https://www.canada.ca/en/services/jobs.html">
@@ -625,10 +625,10 @@ describe('gcds-footer', () => {
           </div>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-labelledby="sub__header">
-                <h3 class="sub__header" id="sub__header">
+              <nav aria-labelledby="sub__heading">
+                <gcds-sr-only id="sub__heading" tag="h3">
                   Government of Canada Corporate
-                </h3>
+                </gcds-sr-only>
                 <ul>
                   <li>
                     <a href="https://www.canada.ca/en/social.html">
@@ -677,15 +677,15 @@ describe('gcds-footer', () => {
         ></gcds-footer>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-footer role="contentinfo" display="compact" lang="en" sub-links="{ &quot;Link 1&quot;: &quot;#red&quot;, &quot;Link 2&quot;: &quot;#green&quot;, &quot;Link 3&quot;: &quot;#blue&quot; }">
+      <gcds-footer role="contentinfo" display="compact" lang="en" sub-links="{ &quot;Link 1&quot;: &quot;#red&quot;, &quot;Link 2&quot;: &quot;#green&quot;, &quot;Link 3&quot;: &quot;#blue&quot; }" aria-label="Footer">
         <mock:shadow-root>
-          <h2 class="gcds-footer__header">About this site</h2>
+          <gcds-sr-only tag="h2">About this site</gcds-sr-only>
           <div class="gcds-footer__sub">
             <div class="sub__container">
-              <nav aria-labelledby="sub__header">
-                <h3 class="sub__header" id="sub__header">
+              <nav aria-labelledby="sub__heading">
+                <gcds-sr-only id="sub__heading" tag="h3">
                   Government of Canada Corporate
-                </h3>
+                </gcds-sr-only>
                 <ul>
                   <li>
                     <a href="#red">

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -64,7 +64,10 @@ export class GcdsHeader {
       return <slot name="skip-to-nav"></slot>;
     } else if (this.skipToHref) {
       return (
-        <nav class="gcds-header__skip-to-nav" aria-label={i18n[this.lang].skip}>
+        <nav
+          class="gcds-header__skip-to-nav"
+          aria-label={i18n[this.lang].skipLabel}
+        >
           <gcds-link href={this.skipToHref}>{i18n[this.lang].skip}</gcds-link>
         </nav>
       );

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -64,7 +64,7 @@ export class GcdsHeader {
       return <slot name="skip-to-nav"></slot>;
     } else if (this.skipToHref) {
       return (
-        <nav class="gcds-header__skip-to-nav">
+        <nav class="gcds-header__skip-to-nav" aria-label={i18n[this.lang].skip}>
           <gcds-link href={this.skipToHref}>{i18n[this.lang].skip}</gcds-link>
         </nav>
       );

--- a/packages/web/src/components/gcds-header/i18n/i18n.js
+++ b/packages/web/src/components/gcds-header/i18n/i18n.js
@@ -1,9 +1,11 @@
 const I18N = {
   en: {
     skip: 'Skip to main content',
+    skipLabel: 'Skip to',
   },
   fr: {
     skip: 'Passer au contenu principal',
+    skipLabel: 'Passer au',
   },
 };
 

--- a/packages/web/src/components/gcds-header/readme.md
+++ b/packages/web/src/components/gcds-header/readme.md
@@ -19,17 +19,17 @@
 
 ### Depends on
 
-- [gcds-button](../gcds-button)
+- [gcds-link](../gcds-link)
 - [gcds-lang-toggle](../gcds-lang-toggle)
 - [gcds-signature](../gcds-signature)
 
 ### Graph
 ```mermaid
 graph TD;
-  gcds-header --> gcds-button
+  gcds-header --> gcds-link
   gcds-header --> gcds-lang-toggle
   gcds-header --> gcds-signature
-  gcds-button --> gcds-icon
+  gcds-link --> gcds-icon
   style gcds-header fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
+++ b/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
@@ -31,7 +31,7 @@ describe('gcds-header', () => {
     expect(page.root).toEqualHtml(`
       <gcds-header lang-href="/fr/" role="banner" signature-has-link="true" signature-variant="colour" skip-to-href="#main">
         <mock:shadow-root>
-          <nav class="gcds-header__skip-to-nav" aria-label="Skip to main content">
+          <nav class="gcds-header__skip-to-nav" aria-label="Skip to">
             <gcds-link href="#main">
               Skip to main content
             </gcds-link>

--- a/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
+++ b/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
@@ -31,7 +31,7 @@ describe('gcds-header', () => {
     expect(page.root).toEqualHtml(`
       <gcds-header lang-href="/fr/" role="banner" signature-has-link="true" signature-variant="colour" skip-to-href="#main">
         <mock:shadow-root>
-          <nav class="gcds-header__skip-to-nav">
+          <nav class="gcds-header__skip-to-nav" aria-label="Skip to main content">
             <gcds-link href="#main">
               Skip to main content
             </gcds-link>

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
@@ -2,13 +2,6 @@
   display: block;
   font: var(--gcds-lang-toggle-font);
 
-  h2 {
-    margin: 0;
-    overflow: hidden;
-    position: absolute;
-    width: 0;
-  }
-
   a {
     color: var(--gcds-lang-toggle-default-text);
     padding: var(--gcds-lang-toggle-padding);

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.tsx
@@ -48,13 +48,15 @@ export class GcdsLangToggle {
 
     return (
       <Host>
-        <div>
-          <h2>{i18n[lang].heading}</h2>
+        <nav aria-labelledby="lang-toggle__heading">
+          <gcds-sr-only id="lang-toggle__heading" tag="h2">
+            {i18n[lang].heading}
+          </gcds-sr-only>
           <a href={href} lang={i18n[lang].abbreviation}>
             <span>{i18n[lang].language}</span>
             <abbr title={i18n[lang].language}>{i18n[lang].abbreviation}</abbr>
           </a>
-        </div>
+        </nav>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-lang-toggle/i18n/i18n.js
+++ b/packages/web/src/components/gcds-lang-toggle/i18n/i18n.js
@@ -1,7 +1,7 @@
 const I18N = {
   en: {
     abbreviation: 'fr',
-    heading: 'Language Selection',
+    heading: 'Language selection',
     language: 'Français',
   },
   fr: {

--- a/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.spec.tsx
@@ -10,13 +10,15 @@ describe('gcds-lang-toggle', () => {
     expect(page.root).toEqualHtml(`
       <gcds-lang-toggle href="/fr/" lang="en">
         <mock:shadow-root>
-        <div>
-          <h2>Language Selection</h2>
-          <a href="/fr/" lang="fr">
-            <span>Français</span>
-            <abbr title="Français">fr</abbr>
-          </a>
-        </div>
+          <nav aria-labelledby="lang-toggle__heading">
+            <gcds-sr-only id="lang-toggle__heading" tag="h2">
+              Language selection
+            </gcds-sr-only>
+            <a href="/fr/" lang="fr">
+              <span>Français</span>
+              <abbr title="Français">fr</abbr>
+            </a>
+          </nav>
         </mock:shadow-root>
       </gcds-lang-toggle>
     `);
@@ -30,13 +32,15 @@ describe('gcds-lang-toggle', () => {
     expect(page.root).toEqualHtml(`
       <gcds-lang-toggle href="/en/" lang="fr">
         <mock:shadow-root>
-        <div>
-          <h2>Sélection de la langue</h2>
-          <a href="/en/" lang="en">
-            <span>English</span>
-            <abbr title="English">en</abbr>
-          </a>
-        </div>
+          <nav aria-labelledby="lang-toggle__heading">
+            <gcds-sr-only id="lang-toggle__heading" tag="h2">
+              Sélection de la langue
+            </gcds-sr-only>
+            <a href="/en/" lang="en">
+              <span>English</span>
+              <abbr title="English">en</abbr>
+            </a>
+          </nav>
         </mock:shadow-root>
       </gcds-lang-toggle>
     `);

--- a/packages/web/src/components/gcds-link/readme.md
+++ b/packages/web/src/components/gcds-link/readme.md
@@ -31,6 +31,10 @@
 
 ## Dependencies
 
+### Used by
+
+ - [gcds-header](../gcds-header)
+
 ### Depends on
 
 - [gcds-icon](../gcds-icon)
@@ -39,6 +43,7 @@
 ```mermaid
 graph TD;
   gcds-link --> gcds-icon
+  gcds-header --> gcds-link
   style gcds-link fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-search/gcds-search.css
+++ b/packages/web/src/components/gcds-search/gcds-search.css
@@ -3,14 +3,6 @@
 @layer defaults {
   :host {
     .gcds-search {
-      .gcds-search__header {
-        display: block;
-        width: 0;
-        height: 0;
-        margin: 0;
-        overflow: hidden;
-      }
-
       .gcds-search__form {
         display: flex;
         margin: var(--gcds-search-margin) !important;
@@ -28,7 +20,9 @@
         border: var(--gcds-search-border-width) solid currentColor;
         border-radius: var(--gcds-search-border-radius);
         box-sizing: border-box;
-        transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+        transition:
+          border-color ease-in-out 0.15s,
+          box-shadow ease-in-out 0.15s;
       }
 
       ::part(button) {
@@ -38,8 +32,8 @@
       }
     }
 
-    [type="search"]::-webkit-search-cancel-button,
-    [type="search"]::-webkit-search-decoration {
+    [type='search']::-webkit-search-cancel-button,
+    [type='search']::-webkit-search-decoration {
       -webkit-appearance: none;
       appearance: none;
     }
@@ -51,7 +45,8 @@
     input.gcds-search__input {
       &:focus {
         border-color: var(--gcds-search-focus-text);
-        outline: var(--gcds-search-outline-width) solid var(--gcds-search-focus-text);
+        outline: var(--gcds-search-outline-width) solid
+          var(--gcds-search-focus-text);
         outline-offset: var(--gcds-search-border-width);
         border-radius: var(--gcds-search-focus-border-radius);
         box-shadow: var(--gcds-search-focus-box-shadow);
@@ -61,7 +56,7 @@
 
     ::part(button):focus {
       border-radius: var(--gcds-search-focus-border-radius);
-      box-shadow:  var(--gcds-search-focus-box-shadow);
+      box-shadow: var(--gcds-search-focus-box-shadow);
     }
   }
 }

--- a/packages/web/src/components/gcds-search/gcds-search.tsx
+++ b/packages/web/src/components/gcds-search/gcds-search.tsx
@@ -115,7 +115,7 @@ export class GcdsSearch {
     return (
       <Host>
         <div class="gcds-search">
-          <h2 class="gcds-search__header">{I18N[lang].search}</h2>
+          <gcds-sr-only tag="h2">{I18N[lang].search}</gcds-sr-only>
           <form
             action={formAction}
             method={method}

--- a/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
+++ b/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
@@ -10,9 +10,7 @@ describe('gcds-search', () => {
     expect(page.root).toEqualHtml(`
       <gcds-search>
         <div class="gcds-search">
-          <h2 class="gcds-search__header">
-            Search
-          </h2>
+          <gcds-sr-only tag="h2">Search</gcds-sr-only>
           <form action="https://www.canada.ca/en/sr/srb.html" class="gcds-search__form" method="get" role="search">
             <gcds-label hide-label="" label="Search Canada.ca" label-for="search"></gcds-label>
             <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Search Canada.ca" size="34" type="search">
@@ -32,9 +30,7 @@ describe('gcds-search', () => {
     expect(page.root).toEqualHtml(`
       <gcds-search lang="fr">
       <div class="gcds-search">
-          <h2 class="gcds-search__header">
-            Recherche
-          </h2>
+          <gcds-sr-only tag="h2">Recherche</gcds-sr-only>
           <form action="https://www.canada.ca/fr/sr/srb.html" class="gcds-search__form" method="get" role="search">
             <gcds-label hide-label="" label="Rechercher dans Canada.ca" label-for="search"></gcds-label>
             <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Rechercher dans Canada.ca" size="34" type="search">
@@ -60,9 +56,7 @@ describe('gcds-search', () => {
     expect(page.root).toEqualHtml(`
       <gcds-search action="submit.html" method="post" name="s" placeholder="Text.ca" search-id="searchForm">
         <div class="gcds-search">
-          <h2 class="gcds-search__header">
-            Search
-          </h2>
+          <gcds-sr-only tag="h2">Search</gcds-sr-only>
           <form action="submit.html" class="gcds-search__form" method="post" role="search">
           <gcds-label hide-label="" label="Search Text.ca" label-for="searchForm"></gcds-label>
             <input class="gcds-search__input" id="searchForm" list="search-list" maxlength="170" name="s" placeholder="Search Text.ca" size="34" type="search">

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
@@ -1,4 +1,12 @@
-@layer default;
+@layer reset, default;
+
+@layer reset {
+  :host {
+    slot {
+      display: initial;
+    }
+  }
+}
 
 @layer default {
   :host {
@@ -7,9 +15,5 @@
     height: 0;
     margin: 0;
     overflow: hidden;
-
-    slot {
-      display: initial;
-    }
   }
 }

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.tsx
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h } from '@stencil/core';
+import { Component, Host, Watch, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'gcds-sr-only',
@@ -6,10 +6,41 @@ import { Component, Host, h } from '@stencil/core';
   shadow: true,
 })
 export class GcdsSrOnly {
+  /**
+   * Sets the appropriate HTML tag for the content.
+   */
+  @Prop({ mutable: true }) tag?:
+    | 'h1'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'p'
+    | 'span' = 'p';
+
+  @Watch('tag')
+  validateTag(newValue: string) {
+    const values = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span'];
+
+    if (!values.includes(newValue)) {
+      this.tag = 'p';
+    }
+  }
+
+  componentWillLoad() {
+    // Validate attributes and set defaults
+    this.validateTag(this.tag);
+  }
+
   render() {
+    const Tag = this.tag;
+
     return (
       <Host>
-        <slot></slot>
+        <Tag>
+          <slot></slot>
+        </Tag>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-sr-only/readme.md
+++ b/packages/web/src/components/gcds-sr-only/readme.md
@@ -5,6 +5,26 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property | Attribute | Description                                    | Type                                                            | Default |
+| -------- | --------- | ---------------------------------------------- | --------------------------------------------------------------- | ------- |
+| `tag`    | `tag`     | Sets the appropriate HTML tag for the content. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "span"` | `'p'`   |
+
+
+## Dependencies
+
+### Used by
+
+ - [gcds-card](../gcds-card)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-card --> gcds-sr-only
+  style gcds-sr-only fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
+++ b/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
@@ -2,6 +2,19 @@ export default {
   title: 'Components/Screen reader only',
 
   argTypes: {
+    // Props
+    tag: {
+      control: { type: 'select' },
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'p' },
+      },
+      type: {
+        required: false,
+      },
+    },
+
     // Slots
     default: {
       control: {
@@ -17,18 +30,18 @@ export default {
 const Template = args =>
   `
 <!-- Web component code (Angular, Vue) -->
-<gcds-sr-only>
+<gcds-sr-only ${args.tag != 'p' ? `tag="${args.tag}"` : null}>
   ${args.default}
 </gcds-sr-only>
 
 <!-- React code -->
-<GcdsSrOnly>
+<GcdsSrOnly ${args.tag != 'p' ? `tag="${args.tag}"` : null}>
   ${args.default}
 </GcdsSrOnly>
 `.replace(/ null/g, '');
 
 const TemplatePlayground = args => `
-<gcds-sr-only>
+<gcds-sr-only ${args.tag != 'p' ? `tag="${args.tag}"` : null}>
   ${args.default}
 </gcds-sr-only>
 `;
@@ -38,6 +51,15 @@ const TemplatePlayground = args => `
 export const Default = Template.bind({});
 Default.args = {
   default: 'Text only seen by assistive technologies',
+  tag: 'p',
+};
+
+// ------ Screen reader only tag ------
+
+export const Tag = Template.bind({});
+Tag.args = {
+  default: 'Text only seen by assistive technologies',
+  tag: 'h2',
 };
 
 // ------ Screen reader only  events & props ------
@@ -45,6 +67,7 @@ Default.args = {
 export const Props = Template.bind({});
 Props.args = {
   default: 'Text only seen by assistive technologies',
+  tag: 'p',
 };
 
 // ------ Screen reader only  playground ------
@@ -52,4 +75,5 @@ Props.args = {
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   default: 'Text only seen by assistive technologies',
+  tag: 'p',
 };

--- a/packages/web/src/components/gcds-sr-only/stories/overview.mdx
+++ b/packages/web/src/components/gcds-sr-only/stories/overview.mdx
@@ -9,6 +9,12 @@ _Also called: visually hidden, assistive text._
 
 <Canvas of={SROnly.Default} story={{ inline: true }} />
 
+## Tag
+
+Change the `tag` to a context-appropriate value from the list of available options. Using established standards for HTML tags that are semantic increase the accessibility of the content and improves the experience for everyone.
+
+<Canvas of={SROnly.Tag} story={{ inline: true }} />
+
 ## Resources
 
 {/* prettier-ignore */}

--- a/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
+++ b/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
@@ -10,7 +10,43 @@ describe('gcds-sr-only', () => {
     expect(page.root).toEqualHtml(`
       <gcds-sr-only>
         <mock:shadow-root>
-          <slot></slot>
+          <p>
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders p tag if invalid tag value', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="aside">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="aside">
+        <mock:shadow-root>
+          <p>
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders heading tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="h2">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="h2">
+        <mock:shadow-root>
+          <h2>
+            <slot></slot>
+          </h2>
         </mock:shadow-root>
         Hidden text
       </gcds-sr-only>

--- a/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
+++ b/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.spec.tsx
@@ -36,7 +36,58 @@ describe('gcds-sr-only', () => {
     `);
   });
 
-  it('renders heading tag', async () => {
+  it('renders p tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="p">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="p">
+        <mock:shadow-root>
+          <p>
+            <slot></slot>
+          </p>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders span tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="span">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="span">
+        <mock:shadow-root>
+          <span>
+            <slot></slot>
+          </span>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders h1 heading tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="h1">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="h1">
+        <mock:shadow-root>
+          <h1>
+            <slot></slot>
+          </h1>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders h2 heading tag', async () => {
     const page = await newSpecPage({
       components: [GcdsSrOnly],
       html: `<gcds-sr-only tag="h2">Hidden text</gcds-sr-only>`,
@@ -47,6 +98,74 @@ describe('gcds-sr-only', () => {
           <h2>
             <slot></slot>
           </h2>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders h3 heading tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="h3">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="h3">
+        <mock:shadow-root>
+          <h3>
+            <slot></slot>
+          </h3>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders h4 heading tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="h4">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="h4">
+        <mock:shadow-root>
+          <h4>
+            <slot></slot>
+          </h4>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders h5 heading tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="h5">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="h5">
+        <mock:shadow-root>
+          <h5>
+            <slot></slot>
+          </h5>
+        </mock:shadow-root>
+        Hidden text
+      </gcds-sr-only>
+    `);
+  });
+
+  it('renders h6 heading tag', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSrOnly],
+      html: `<gcds-sr-only tag="h6">Hidden text</gcds-sr-only>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-sr-only tag="h6">
+        <mock:shadow-root>
+          <h6>
+            <slot></slot>
+          </h6>
         </mock:shadow-root>
         Hidden text
       </gcds-sr-only>

--- a/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
+++ b/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
@@ -11,15 +11,6 @@
   :host {
     display: block;
 
-    .gcds-topic-menu__main,
-    .gcds-topic-menu__heading {
-      display: inherit;
-      width: 0;
-      height: 0;
-      margin: 0;
-      overflow: hidden;
-    }
-
     .visible-sm-inline {
       display: none;
     }

--- a/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.tsx
+++ b/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.tsx
@@ -465,8 +465,10 @@ export class GcdsTopicMenu {
     const { home, lang } = this;
     return (
       <Host>
-        <nav class="gcds-topic-menu">
-          <h2 class="gcds-topic-menu__heading">Menu</h2>
+        <nav class="gcds-topic-menu" aria-labelledby="gcds-topic-menu__heading">
+          <gcds-sr-only id="gcds-topic-menu__heading" tag="h2">
+            {I18N[lang].menuLabelFull}
+          </gcds-sr-only>
           <button
             aria-haspopup="true"
             aria-expanded={this.open.toString()}
@@ -477,13 +479,17 @@ export class GcdsTopicMenu {
           >
             {this.lang == 'en' ? (
               <>
-                <span class="gcds-topic-menu__main">Main </span>
-                Menu
+                <gcds-sr-only tag="span">
+                  {I18N[lang].menuLabelHidden}
+                </gcds-sr-only>
+                {I18N[lang].menuToggle}
               </>
             ) : (
               <>
-                Menu
-                <span class="gcds-topic-menu__main"> principal</span>
+                {I18N[lang].menuToggle}
+                <gcds-sr-only tag="span">
+                  {I18N[lang].menuLabelHidden}
+                </gcds-sr-only>
               </>
             )}
             <gcds-icon

--- a/packages/web/src/components/gcds-topic-menu/i18n/i18n.js
+++ b/packages/web/src/components/gcds-topic-menu/i18n/i18n.js
@@ -2,10 +2,16 @@ const I18N = {
   en: {
     buttonLabel:
       'Press the SPACEBAR to expand or the escape key to collapse this menu. Use the Up and Down arrow keys to choose a submenu item. Press the Enter or Right arrow key to expand it, or the Left arrow or Escape key to collapse it. Use the Up and Down arrow keys to choose an item on that level and the Enter key to access it.',
+    menuLabelFull: 'Main menu',
+    menuLabelHidden: 'Main ',
+    menuToggle: 'Menu',
   },
   fr: {
     buttonLabel:
       "Appuyez sur la barre d'espacement pour ouvrir ou sur la touche d'échappement pour fermer le menu. Utilisez les flèches haut et bas pour choisir un élément de sous-menu. Appuyez sur la touche Entrée ou sur la flèche vers la droite pour le développer, ou sur la flèche vers la gauche ou la touche Échap pour le réduire. Utilisez les flèches haut et bas pour choisir un élément de ce niveau et la touche Entrée pour y accéder.",
+    menuLabelFull: 'Menu principal',
+    menuLabelHidden: ' principal',
+    menuToggle: 'Menu',
   },
 };
 

--- a/packages/web/src/components/gcds-topic-menu/test/gcds-topic-menu.spec.tsx
+++ b/packages/web/src/components/gcds-topic-menu/test/gcds-topic-menu.spec.tsx
@@ -12,14 +12,14 @@ describe('gcds-topic-menu', () => {
     expect(page.root).toEqualHtml(`
       <gcds-topic-menu>
         <mock:shadow-root>
-          <nav class="gcds-topic-menu">
-            <h2 class="gcds-topic-menu__heading">
-              Menu
-            </h2>
+          <nav class="gcds-topic-menu" aria-labelledby="gcds-topic-menu__heading">
+            <gcds-sr-only id="gcds-topic-menu__heading" tag="h2">
+              Main menu
+            </gcds-sr-only>
             <button aria-expanded="false" aria-haspopup="true" aria-label="Press the SPACEBAR to expand or the escape key to collapse this menu. Use the Up and Down arrow keys to choose a submenu item. Press the Enter or Right arrow key to expand it, or the Left arrow or Escape key to collapse it. Use the Up and Down arrow keys to choose an item on that level and the Enter key to access it.">
-              <span class="gcds-topic-menu__main">
+              <gcds-sr-only tag="span">
                 Main
-              </span>
+              </gcds-sr-only>
               Menu
               <gcds-icon margin-left="150" name="chevron-down" size="caption"></gcds-icon>
             </button>
@@ -92,15 +92,15 @@ describe('gcds-topic-menu', () => {
     expect(page.root).toEqualHtml(`
       <gcds-topic-menu lang="fr">
         <mock:shadow-root>
-          <nav class="gcds-topic-menu">
-            <h2 class="gcds-topic-menu__heading">
-              Menu
-            </h2>
+          <nav class="gcds-topic-menu" aria-labelledby="gcds-topic-menu__heading">
+            <gcds-sr-only id="gcds-topic-menu__heading" tag="h2">
+              Menu principal
+            </gcds-sr-only>
             <button aria-expanded="false" aria-haspopup="true" aria-label="Appuyez sur la barre d'espacement pour ouvrir ou sur la touche d'échappement pour fermer le menu. Utilisez les flèches haut et bas pour choisir un élément de sous-menu. Appuyez sur la touche Entrée ou sur la flèche vers la droite pour le développer, ou sur la flèche vers la gauche ou la touche Échap pour le réduire. Utilisez les flèches haut et bas pour choisir un élément de ce niveau et la touche Entrée pour y accéder.">
               Menu
-              <span class="gcds-topic-menu__main">
+              <gcds-sr-only tag="span">
                 principal
-              </span>
+              </gcds-sr-only>
               <gcds-icon margin-left="150" name="chevron-down" size="caption"></gcds-icon>
             </button>
             <ul aria-orientation="vertical" data-top-menu role="menu">
@@ -172,14 +172,14 @@ describe('gcds-topic-menu', () => {
     expect(page.root).toEqualHtml(`
       <gcds-topic-menu home>
         <mock:shadow-root>
-          <nav class="gcds-topic-menu">
-            <h2 class="gcds-topic-menu__heading">
-              Menu
-            </h2>
+          <nav class="gcds-topic-menu" aria-labelledby="gcds-topic-menu__heading">
+            <gcds-sr-only id="gcds-topic-menu__heading" tag="h2">
+              Main menu
+            </gcds-sr-only>
             <button aria-expanded="false" aria-haspopup="true" class="gcds-topic-menu--home" aria-label="Press the SPACEBAR to expand or the escape key to collapse this menu. Use the Up and Down arrow keys to choose a submenu item. Press the Enter or Right arrow key to expand it, or the Left arrow or Escape key to collapse it. Use the Up and Down arrow keys to choose an item on that level and the Enter key to access it.">
-              <span class="gcds-topic-menu__main">
+              <gcds-sr-only tag="span">
                 Main
-              </span>
+              </gcds-sr-only>
               Menu
               <gcds-icon margin-left="150" name="chevron-down" size="caption"></gcds-icon>
             </button>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -676,9 +676,7 @@
       <gcds-heading tag="h2">Screen reader only</gcds-heading>
       <gcds-text>There is invisible text below this</gcds-text>
       <gcds-sr-only>
-        <gcds-text
-          >This text is only available to assistive technologies.</gcds-text
-        >
+        This text is only available to assistive technologies.
       </gcds-sr-only>
 
       <hr class="my-550" />


### PR DESCRIPTION
# Summary | Résumé

Added `tag` prop to `gcds-sr-only` to allow users to hide heading content as well as regular text content.

Integrated into the following, existing components:
- gcds-search
- gcds-file-uploader
- gcds-lang-toggle
- gcds-topic-menu
- gcds-header
- gcds-footer

[Dev board ticket](https://github.com/orgs/cds-snc/projects/38/views/1?layout=board&pane=issue&itemId=55606741)