### PR TITLE
chore: rename SSR package to more specific name

### DIFF
--- a/packages/ssr/package-lock.json
+++ b/packages/ssr/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cdssnc/gcds-components-ssr",
+  "name": "@cdssnc/gcds-components-react-ssr",
   "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cdssnc/gcds-components-ssr",
+      "name": "@cdssnc/gcds-components-react-ssr",
       "version": "0.17.1",
       "hasInstallScript": true,
       "license": "MIT",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cdssnc/gcds-components-ssr",
+  "name": "@cdssnc/gcds-components-react-ssr",
   "version": "0.19.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "license": "MIT",


### PR DESCRIPTION
# Summary | Résumé

Rename `@cdssnc/gcds-components-ssr` to `@cdssnc/gcds-components-react-ssr` for better understanding of what environment to use the package in.
