### PR TITLE
fix: package path not found for gcds.css

### DIFF
--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -23,6 +23,10 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
     },
+    "./gcds.css": {
+      "import": "./gcds.css",
+      "require": "./gcds.css"
+    },
     "./server": {
       "import": "./dist/esm/lib/server.js",
       "require": "./dist/cjs/lib/server.js",


### PR DESCRIPTION
# Summary | Résumé
Importing css in my react file like
```javascript
import "@cdssnc/gcds-components-react-ssr/gcds.css";
```

gives me the following error:
`Module not found: Package path ./gcds.css is not exported from package <path>/@cdssnc/gcds-components-react-ssr (see exports field in node_modules/@cdssnc/gcds-components-react-ssr/package.json)`


This PR fixes the issue