### PR TITLE
fix: Update utility functions for more usability

### DIFF
--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -12,7 +12,7 @@ export const inheritAttributes = (
   // Check for any aria or data attributes
   for (let i = 0; i < el.attributes.length; i++) {
     const attr = el.attributes[i];
-    if (attr.name.includes('aria-') || attr.name.includes('data-')) {
+    if (attr.name.includes('aria-')) {
       attributeObject[attr.name] = attr.value;
       el.removeAttribute(attr.name);
     }

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -39,10 +39,10 @@ export const inheritAttributes = (
 export const assignLanguage = (el: HTMLElement) => {
   let lang = '';
   if (!el.getAttribute('lang')) {
-    if (
-      document.documentElement.getAttribute('lang') == 'en' ||
-      !document.documentElement.getAttribute('lang')
-    ) {
+    const closestLangAttribute = closestElement('[lang]', el)?.getAttribute(
+      'lang',
+    );
+    if (closestLangAttribute == 'en' || !closestLangAttribute) {
       lang = 'en';
     } else {
       lang = 'fr';
@@ -54,6 +54,18 @@ export const assignLanguage = (el: HTMLElement) => {
   }
 
   return lang;
+};
+
+// Allows use of closest() function across shadow boundaries
+const closestElement = (selector, el) => {
+  if (el) {
+    return (
+      (el && el != document && el != window && el.closest(selector)) ||
+      closestElement(selector, el.getRootNode().host)
+    );
+  }
+
+  return null;
 };
 
 export const observerConfig = {


### PR DESCRIPTION
# Summary | Résumé

Update the `assignLanguage` and `inheritAttributes` to be more usable and functional with GC Design System components going forward.

## assignLanguage changes

Previously the `assignLanguage` would check if a `lang` attribute has been assigned to the host element of a component if needed. If not found, the function would then check the document element to get the page language for the component.

To better match how `lang` works in HTML, the component will now check it's ancestors all the way up to the document element for a `lang` attribute. This allows developers to tag sections of a page a different language from the default page language and have the component inherit the correct language.

## inheritAttributes changes

`inheritAttributes` was built to take data attributes assigned to form components and pass them down to the input rendered in each form component and remove the attribute from the host element. With the introduction of form-associated components and shadow-dom, data attributes will no longer be passed down to the rendered input since the component is now recognized as a form input in HTML forms.
