### PR TITLE
fix: Remove CSS causing card title text to disappear on hover/focus

### DIFF
--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -81,13 +81,6 @@
         cursor: pointer;
         box-shadow: var(--gcds-card-hover-box-shadow);
       }
-
-      &.gcds-card--link:hover gcds-link::part(link) {
-        color: var(--gcds-card-hover-title-color);
-        text-decoration-thickness: var(
-          --gcds-card-hover-title-text-decoration-thickness
-        );
-      }
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Removed CSS from `<gcds-card type="link">` that caused the card title link text to display as the same colour as the background producing an accessibility error when the card was focused and hovered at the same time.
