### PR TITLE
refactor: change gcds-error-message and gcds-hint to use slot instead of prop

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -246,14 +246,14 @@ export declare interface GcdsDetails extends Components.GcdsDetails {}
 
 
 @ProxyCmp({
-  inputs: ['message', 'messageId']
+  inputs: ['messageId']
 })
 @Component({
   selector: 'gcds-error-message',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['message', 'messageId'],
+  inputs: ['messageId'],
 })
 export class GcdsErrorMessage {
   protected el: HTMLElement;

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -490,14 +490,14 @@ export declare interface GcdsHeading extends Components.GcdsHeading {}
 
 
 @ProxyCmp({
-  inputs: ['hint', 'hintId']
+  inputs: ['hintId']
 })
 @Component({
   selector: 'gcds-hint',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['hint', 'hintId'],
+  inputs: ['hintId'],
 })
 export class GcdsHint {
   protected el: HTMLElement;

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -272,10 +272,6 @@ export namespace Components {
     }
     interface GcdsErrorMessage {
         /**
-          * Error message for an invalid form field.
-         */
-        "message": string;
-        /**
           * Id attribute for the error message.
          */
         "messageId": string;
@@ -1975,10 +1971,6 @@ declare namespace LocalJSX {
         "open"?: boolean;
     }
     interface GcdsErrorMessage {
-        /**
-          * Error message for an invalid form field.
-         */
-        "message": string;
         /**
           * Id attribute for the error message.
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -566,10 +566,6 @@ export namespace Components {
     }
     interface GcdsHint {
         /**
-          * Hint displayed below the label and above the input field.
-         */
-        "hint"?: string;
-        /**
           * Id attribute for the hint.
          */
         "hintId": string;
@@ -2305,10 +2301,6 @@ declare namespace LocalJSX {
         "tag": 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
     }
     interface GcdsHint {
-        /**
-          * Hint displayed below the label and above the input field.
-         */
-        "hint"?: string;
         /**
           * Id attribute for the hint.
          */

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -385,7 +385,7 @@ export class GcdsCheckbox {
             lang={lang}
           ></gcds-label>
 
-          {hint ? <gcds-hint hint={hint} hint-id={checkboxId} /> : null}
+          {hint ? <gcds-hint hint-id={checkboxId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
             <gcds-error-message messageId={checkboxId} message={errorMessage} />

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -388,7 +388,9 @@ export class GcdsCheckbox {
           {hint ? <gcds-hint hint-id={checkboxId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
-            <gcds-error-message messageId={checkboxId} message={errorMessage} />
+            <gcds-error-message messageId={checkboxId}>
+              {errorMessage}
+            </gcds-error-message>
           ) : null}
 
           {parentError ? (

--- a/packages/web/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
+++ b/packages/web/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
@@ -82,9 +82,11 @@ describe('gcds-checkbox', () => {
           <div class="gcds-checkbox gcds-checkbox--error">
             <input aria-describedby="error-message-checkbox " aria-invalid="true" id="checkbox" name="checkbox" type="checkbox">
             <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
-            <gcds-error-message message="This needs to be checked" messageId="checkbox"></gcds-error-message>
+            <gcds-error-message messageId="checkbox">
+              This needs to be checked
+            </gcds-error-message>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-checkbox>
     `);
   });
@@ -105,7 +107,7 @@ describe('gcds-checkbox', () => {
             <input disabled="" id="checkbox" name="checkbox" type="checkbox">
             <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-checkbox>
     `);
   });

--- a/packages/web/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
+++ b/packages/web/src/components/gcds-checkbox/test/gcds-checkbox.spec.tsx
@@ -18,7 +18,7 @@ describe('gcds-checkbox', () => {
             <input id="checkbox" name="checkbox" type="checkbox">
             <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-checkbox>
     `);
   });
@@ -40,7 +40,7 @@ describe('gcds-checkbox', () => {
             <input checked="" id="checkbox" name="checkbox" type="checkbox" value="terms">
             <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-checkbox>
     `);
   });
@@ -51,18 +51,18 @@ describe('gcds-checkbox', () => {
           label="checkbox"
           name="checkbox"
           checkbox-id="checkbox"
-          hint="this is a hint"
+          hint="This is a hint."
         ></gcds-checkbox>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-checkbox checkbox-id="checkbox" hint="this is a hint" label="checkbox" name="checkbox">
+      <gcds-checkbox checkbox-id="checkbox" hint="This is a hint." label="checkbox" name="checkbox">
         <mock:shadow-root>
           <div class="gcds-checkbox">
             <input aria-describedby="hint-checkbox " id="checkbox" name="checkbox" type="checkbox">
             <gcds-label label="checkbox" label-for="checkbox" lang="en"></gcds-label>
-            <gcds-hint hint="this is a hint" hint-id="checkbox"></gcds-hint>
+            <gcds-hint hint-id="checkbox">This is a hint.</gcds-hint>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-checkbox>
     `);
   });

--- a/packages/web/src/components/gcds-error-message/gcds-error-message.css
+++ b/packages/web/src/components/gcds-error-message/gcds-error-message.css
@@ -3,6 +3,10 @@
 @layer reset {
   :host {
     display: inline-block;
+
+    slot {
+      display: initial;
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
+++ b/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
@@ -17,13 +17,8 @@ export class GcdsErrorMessage {
    */
   @Prop() messageId!: string;
 
-  /**
-   * Error message for an invalid form field.
-   */
-  @Prop() message!: string;
-
   render() {
-    const { messageId, message } = this;
+    const { messageId } = this;
 
     return (
       <Host
@@ -31,7 +26,7 @@ export class GcdsErrorMessage {
         class="gcds-error-message-wrapper"
       >
         <gcds-text class="error-message" role="alert" margin-bottom="0">
-          {message}
+          <slot></slot>
         </gcds-text>
       </Host>
     );

--- a/packages/web/src/components/gcds-error-message/readme.md
+++ b/packages/web/src/components/gcds-error-message/readme.md
@@ -7,10 +7,9 @@
 
 ## Properties
 
-| Property                 | Attribute    | Description                              | Type     | Default     |
-| ------------------------ | ------------ | ---------------------------------------- | -------- | ----------- |
-| `message` _(required)_   | `message`    | Error message for an invalid form field. | `string` | `undefined` |
-| `messageId` _(required)_ | `message-id` | Id attribute for the error message.      | `string` | `undefined` |
+| Property                 | Attribute    | Description                         | Type     | Default     |
+| ------------------------ | ------------ | ----------------------------------- | -------- | ----------- |
+| `messageId` _(required)_ | `message-id` | Id attribute for the error message. | `string` | `undefined` |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
+++ b/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
@@ -14,14 +14,14 @@ export default {
         required: true,
       },
     },
-    message: {
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: '-' },
+
+    // Slots
+    default: {
+      control: {
+        type: 'text',
       },
-      type: {
-        required: true,
+      table: {
+        category: 'Slots | Fentes',
       },
     },
   },
@@ -30,25 +30,19 @@ export default {
 const Template = args =>
   `
 <!-- Web component code (Angular, Vue) -->
-<gcds-error-message
-  message-id="${args.messageId}"
-  message="${args.message}"
->
+<gcds-error-message message-id="${args.messageId}">
+  ${args.default}
 </gcds-error-message>
 
 <!-- React code -->
-<GcdsErrorMessage
-  messageId="${args.messageId}"
-  message="${args.message}"
->
+<GcdsErrorMessage messageId="${args.messageId}">
+  ${args.default}"
 </GcdsErrorMessage>
-`.replace(/\s\snull\n/g, '');
+`;
 
 const TemplatePlayground = args => `
-<gcds-error-message
-  message-id="${args.messageId}"
-  message="${args.message}"
->
+<gcds-error-message message-id="${args.messageId}">
+  ${args.default}
 </gcds-error-message>
 `;
 
@@ -57,7 +51,7 @@ const TemplatePlayground = args => `
 export const Default = Template.bind({});
 Default.args = {
   messageId: 'message-default',
-  message: 'Error message or validation message.',
+  default: 'Error message or validation message.',
 };
 
 // ------ Error message events & props ------
@@ -65,7 +59,7 @@ Default.args = {
 export const Props = Template.bind({});
 Props.args = {
   messageId: 'message-props',
-  message: 'Error message or validation message.',
+  default: 'Error message or validation message.',
 };
 
 // ------ Error message playground ------
@@ -73,5 +67,5 @@ Props.args = {
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   messageId: 'message-playground',
-  message: 'Error message or validation message.',
+  default: 'Error message or validation message.',
 };

--- a/packages/web/src/components/gcds-error-message/test/gcds-error-message.spec.ts
+++ b/packages/web/src/components/gcds-error-message/test/gcds-error-message.spec.ts
@@ -5,15 +5,16 @@ describe('gcds-error-message', () => {
   it('renders', async () => {
     const { root } = await newSpecPage({
       components: [GcdsErrorMessage],
-      html: '<gcds-error-message message-id="input-renders" message="This field is required" />',
+      html: '<gcds-error-message message-id="input-renders">This field is required</gcds-error-message>',
     });
     expect(root).toEqualHtml(`
-      <gcds-error-message message-id="input-renders" message="This field is required" id="error-message-input-renders" class="gcds-error-message-wrapper">
+      <gcds-error-message message-id="input-renders" id="error-message-input-renders" class="gcds-error-message-wrapper">
         <mock:shadow-root>
           <gcds-text class="error-message" role="alert" margin-bottom="0">
-            This field is required
+            <slot></slot>
           </gcds-text>
         </mock:shadow-root>
+        This field is required
       </gcds-error-message>
     `);
   });

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -313,7 +313,7 @@ export class GcdsFieldset {
             ) : null}
           </legend>
 
-          {hint ? <gcds-hint hint={hint} hint-id={fieldsetId} /> : null}
+          {hint ? <gcds-hint hint-id={fieldsetId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
             <gcds-error-message messageId={fieldsetId} message={errorMessage} />

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -316,7 +316,9 @@ export class GcdsFieldset {
           {hint ? <gcds-hint hint-id={fieldsetId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
-            <gcds-error-message messageId={fieldsetId} message={errorMessage} />
+            <gcds-error-message messageId={fieldsetId}>
+              {errorMessage}
+            </gcds-error-message>
           ) : null}
           <slot></slot>
         </fieldset>

--- a/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
+++ b/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
@@ -72,7 +72,9 @@ describe('gcds-fieldset', () => {
             <legend id="legend-field">
               Fieldset legend
             </legend>
-            <gcds-error-message message="Fieldset error" messageId="field"></gcds-error-message>
+            <gcds-error-message messageId="field">
+              Fieldset error
+            </gcds-error-message>
             <slot></slot>
           </fieldset>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
+++ b/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
@@ -53,7 +53,7 @@ describe('gcds-fieldset', () => {
             <legend id="legend-field">
               Fieldset legend
             </legend>
-            <gcds-hint hint="Fieldset hint" hint-id="field"></gcds-hint>
+            <gcds-hint hint-id="field">Fieldset hint</gcds-hint>
             <slot></slot>
           </fieldset>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -398,7 +398,7 @@ export class GcdsFileUploader {
         >
           <gcds-label {...attrsLabel} label-for={uploaderId} lang={lang} />
 
-          {hint ? <gcds-hint hint={hint} hint-id={uploaderId} /> : null}
+          {hint ? <gcds-hint hint-id={uploaderId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
             <gcds-error-message messageId={uploaderId} message={errorMessage} />

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -401,7 +401,9 @@ export class GcdsFileUploader {
           {hint ? <gcds-hint hint-id={uploaderId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
-            <gcds-error-message messageId={uploaderId} message={errorMessage} />
+            <gcds-error-message messageId={uploaderId}>
+              {errorMessage}
+            </gcds-error-message>
           ) : null}
 
           <div

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -64,7 +64,9 @@ describe('gcds-file-uploader', () => {
         <mock:shadow-root>
           <div class="gcds-file-uploader-wrapper gcds-error">
             <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
-            <gcds-error-message message="This is an error message." messageId="file-uploader"></gcds-error-message>
+            <gcds-error-message messageId="file-uploader">
+              This is an error message.
+            </gcds-error-message>
             <div class="file-uploader__input">
               <button type="button" tabindex="-1">
                 Choose file

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -91,7 +91,7 @@ describe('gcds-file-uploader', () => {
         <mock:shadow-root>
           <div class="gcds-file-uploader-wrapper">
             <gcds-label label="file-uploader" label-for="file-uploader" lang="en"></gcds-label>
-            <gcds-hint hint="This is a hint." hint-id="file-uploader"></gcds-hint>
+            <gcds-hint hint-id="file-uploader">This is a hint.</gcds-hint>
             <div class="file-uploader__input">
               <button type="button" tabindex="-1">
                 Choose file

--- a/packages/web/src/components/gcds-hint/gcds-hint.css
+++ b/packages/web/src/components/gcds-hint/gcds-hint.css
@@ -3,6 +3,10 @@
 @layer reset {
   :host {
     display: block;
+
+    slot {
+      display: initial;
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-hint/gcds-hint.tsx
+++ b/packages/web/src/components/gcds-hint/gcds-hint.tsx
@@ -13,22 +13,17 @@ export class GcdsHint {
    */
 
   /**
-   * Hint displayed below the label and above the input field.
-   */
-  @Prop() hint?: string;
-
-  /**
    * Id attribute for the hint.
    */
   @Prop() hintId: string;
 
   render() {
-    const { hint, hintId } = this;
+    const { hintId } = this;
 
     return (
       <Host id={`hint-${hintId}`}>
         <gcds-text class="gcds-hint" margin-bottom="0" part="hint">
-          {hint}
+          <slot></slot>
         </gcds-text>
       </Host>
     );

--- a/packages/web/src/components/gcds-hint/readme.md
+++ b/packages/web/src/components/gcds-hint/readme.md
@@ -7,10 +7,16 @@
 
 ## Properties
 
-| Property | Attribute | Description                                               | Type     | Default     |
-| -------- | --------- | --------------------------------------------------------- | -------- | ----------- |
-| `hint`   | `hint`    | Hint displayed below the label and above the input field. | `string` | `undefined` |
-| `hintId` | `hint-id` | Id attribute for the hint.                                | `string` | `undefined` |
+| Property | Attribute | Description                | Type     | Default     |
+| -------- | --------- | -------------------------- | -------- | ----------- |
+| `hintId` | `hint-id` | Id attribute for the hint. | `string` | `undefined` |
+
+
+## Shadow Parts
+
+| Part     | Description |
+| -------- | ----------- |
+| `"hint"` |             |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
+++ b/packages/web/src/components/gcds-hint/test/gcds-hint.spec.ts
@@ -5,13 +5,16 @@ describe('gcds-hint', () => {
   it('renders', async () => {
     const { root } = await newSpecPage({
       components: [GcdsHint],
-      html: '<gcds-hint hint-id="input-renders" hint="Hint Test" />',
+      html: '<gcds-hint hint-id="input-renders">Hint Test</gcds-hint>',
     });
     expect(root).toEqualHtml(`
-      <gcds-hint hint-id="input-renders" hint="Hint Test" id="hint-input-renders">
+      <gcds-hint hint-id="input-renders" id="hint-input-renders">
         <mock:shadow-root>
-          <gcds-text class="gcds-hint" margin-bottom="0" part="hint">Hint Test</gcds-text>
+          <gcds-text class="gcds-hint" margin-bottom="0" part="hint">
+            <slot></slot>
+          </gcds-text>
         </mock:shadow-root>
+        Hint Test
       </gcds-hint>
     `);
   });

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -373,7 +373,7 @@ export class GcdsInput {
             lang={lang}
           />
 
-          {hint ? <gcds-hint hint={hint} hint-id={inputId} /> : null}
+          {hint ? <gcds-hint hint-id={inputId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
             <gcds-error-message messageId={inputId} message={errorMessage} />

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -376,7 +376,9 @@ export class GcdsInput {
           {hint ? <gcds-hint hint-id={inputId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
-            <gcds-error-message messageId={inputId} message={errorMessage} />
+            <gcds-error-message messageId={inputId}>
+              {errorMessage}
+            </gcds-error-message>
           ) : null}
 
           <input

--- a/packages/web/src/components/gcds-input/test/gcds-input.spec.ts
+++ b/packages/web/src/components/gcds-input/test/gcds-input.spec.ts
@@ -263,7 +263,7 @@ describe('gcds-input', () => {
         <mock:shadow-root>
           <div class="gcds-input-wrapper">
             <gcds-label label-for="input-with-hint" label="Label" lang="en"></gcds-label>
-            <gcds-hint hint-id="input-with-hint" hint="This is an input hint."></gcds-hint>
+            <gcds-hint hint-id="input-with-hint">This is an input hint.</gcds-hint>
             <input
               type="text"
               id="input-with-hint"

--- a/packages/web/src/components/gcds-input/test/gcds-input.spec.ts
+++ b/packages/web/src/components/gcds-input/test/gcds-input.spec.ts
@@ -208,7 +208,9 @@ describe('gcds-input', () => {
         <mock:shadow-root>
           <div class="gcds-input-wrapper gcds-error">
             <gcds-label label-for="input-with-error" label="Label" lang="en"></gcds-label>
-            <gcds-error-message messageId="input-with-error" message="This is an error message."></gcds-error-message>
+            <gcds-error-message messageId="input-with-error">
+              This is an error message.
+            </gcds-error-message>
             <input
               type="text"
               id="input-with-error"

--- a/packages/web/src/components/gcds-radio-group/gcds-radio-group.tsx
+++ b/packages/web/src/components/gcds-radio-group/gcds-radio-group.tsx
@@ -219,7 +219,7 @@ export class GcdsRadioGroup {
                 ></gcds-label>
 
                 {radio.hint ? (
-                  <gcds-hint hint={radio.hint} hint-id={radio.id} />
+                  <gcds-hint hint-id={radio.id}>{radio.hint}</gcds-hint>
                 ) : null}
               </div>
             );

--- a/packages/web/src/components/gcds-radio-group/test/gcds-radio-group.spec.tsx
+++ b/packages/web/src/components/gcds-radio-group/test/gcds-radio-group.spec.tsx
@@ -18,7 +18,7 @@ describe('gcds-radio-group', () => {
             <input id="radio" name="radio" type="radio" value="radio">
             <gcds-label label="Label" label-for="radio" lang="en"></gcds-label>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-radio-group>
     `);
   });
@@ -38,7 +38,7 @@ describe('gcds-radio-group', () => {
             <input checked="" id="radio" name="radio" type="radio" value="radio">
             <gcds-label label="Label" label-for="radio" lang="en"></gcds-label>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-radio-group>
     `);
   });
@@ -47,19 +47,19 @@ describe('gcds-radio-group', () => {
       components: [GcdsRadioGroup],
       html: `<gcds-radio-group
           name="radio"
-          options='[{ "label": "Label", "id": "radio", "value": "radio", "hint": "this is a hint"}]'
+          options='[{ "label": "Label", "id": "radio", "value": "radio", "hint": "This is a hint."}]'
         >
         </gcds-radio-group>`,
     });
     expect(page.root).toEqualHtml(`
-      <gcds-radio-group name="radio" options='[{ "label": "Label", "id": "radio", "value": "radio", "hint": "this is a hint"}]'>
+      <gcds-radio-group name="radio" options='[{ "label": "Label", "id": "radio", "value": "radio", "hint": "This is a hint."}]'>
         <mock:shadow-root>
           <div class="gcds-radio">
             <input aria-describedby="hint-radio " id="radio" name="radio" type="radio" value="radio">
             <gcds-label label="Label" label-for="radio" lang="en"></gcds-label>
-            <gcds-hint hint="this is a hint" hint-id="radio"></gcds-hint>
+            <gcds-hint hint-id="radio">This is a hint.</gcds-hint>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-radio-group>
     `);
   });
@@ -79,7 +79,7 @@ describe('gcds-radio-group', () => {
             <input disabled="" id="radio" name="radio" type="radio" value="radio">
             <gcds-label label="Label" label-for="radio" lang="en"></gcds-label>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-radio-group>
     `);
   });
@@ -107,7 +107,7 @@ describe('gcds-radio-group', () => {
             <input id="radio3" name="radio" type="radio" value="radio3">
             <gcds-label label="Label 3" label-for="radio3" lang="en"></gcds-label>
           </div>
-         </mock:shadow-root>
+        </mock:shadow-root>
       </gcds-radio-group>
     `);
   });

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -374,7 +374,9 @@ export class GcdsSelect {
           {hint ? <gcds-hint hint-id={selectId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
-            <gcds-error-message messageId={selectId} message={errorMessage} />
+            <gcds-error-message messageId={selectId}>
+              {errorMessage}
+            </gcds-error-message>
           ) : null}
 
           <select

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -371,7 +371,7 @@ export class GcdsSelect {
         >
           <gcds-label {...attrsLabel} label-for={selectId} lang={lang} />
 
-          {hint ? <gcds-hint hint={hint} hint-id={selectId} /> : null}
+          {hint ? <gcds-hint hint-id={selectId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
             <gcds-error-message messageId={selectId} message={errorMessage} />

--- a/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
+++ b/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
@@ -54,7 +54,9 @@ describe('gcds-select', () => {
         <mock:shadow-root>
           <div class="gcds-select-wrapper gcds-error">
             <gcds-label label="select" label-for="select" lang="en"></gcds-label>
-            <gcds-error-message message="This is an error message." messageId="select"></gcds-error-message>
+            <gcds-error-message messageId="select">
+              This is an error message.
+            </gcds-error-message>
             <select id="select" name="select-name" aria-invalid="true" aria-describedby="error-message-select ">
             </select>
           </div>

--- a/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
+++ b/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
@@ -76,7 +76,7 @@ describe('gcds-select', () => {
         <mock:shadow-root>
           <div class="gcds-select-wrapper">
             <gcds-label label="select" label-for="select" lang="en"></gcds-label>
-            <gcds-hint hint="This is a hint." hint-id="select"></gcds-hint>
+            <gcds-hint hint-id="select">This is a hint.</gcds-hint>
             <select id="select" name="select-name" aria-invalid="false" aria-describedby="hint-select ">
             </select>
           </div>

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -368,7 +368,9 @@ export class GcdsTextarea {
           {hint ? <gcds-hint hint-id={textareaId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
-            <gcds-error-message messageId={textareaId} message={errorMessage} />
+            <gcds-error-message messageId={textareaId}>
+              {errorMessage}
+            </gcds-error-message>
           ) : null}
 
           <textarea

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -365,7 +365,7 @@ export class GcdsTextarea {
             lang={lang}
           />
 
-          {hint ? <gcds-hint hint={hint} hint-id={textareaId} /> : null}
+          {hint ? <gcds-hint hint-id={textareaId}>{hint}</gcds-hint> : null}
 
           {errorMessage ? (
             <gcds-error-message messageId={textareaId} message={errorMessage} />

--- a/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
+++ b/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
@@ -255,7 +255,7 @@ describe('gcds-textarea', () => {
         <mock:shadow-root>
           <div class="gcds-textarea-wrapper">
             <gcds-label label-for="textarea-with-hint" label="Label" lang="en"></gcds-label>
-            <gcds-hint hint="This is a textarea hint." hint-id="textarea-with-hint"></gcds-hint>
+            <gcds-hint hint-id="textarea-with-hint">This is a textarea hint.</gcds-hint>
             <textarea
               id="textarea-with-hint"
               name="textarea-with-hint-name"

--- a/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
+++ b/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
@@ -120,7 +120,9 @@ describe('gcds-textarea', () => {
         <mock:shadow-root>
           <div class="gcds-textarea-wrapper gcds-error">
             <gcds-label label-for="textarea-with-error" label="Label" lang="en"></gcds-label>
-            <gcds-error-message messageId="textarea-with-error" message="This is an error message."></gcds-error-message>
+            <gcds-error-message messageId="textarea-with-error">
+              This is an error message.
+            </gcds-error-message>
             <textarea
               id="textarea-with-error"
               class="gcds-error"


### PR DESCRIPTION
# Summary | Résumé

As discussed in dev sync:

- Change gcds-error-message to use slot instead of message prop
- Change gcds-hint to use slot instead of hint prop