### PR TITLE
feat: consistent component events

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -368,7 +368,7 @@ export class GcdsFileUploader {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -386,6 +386,10 @@ export declare interface GcdsFileUploader extends Components.GcdsFileUploader {
    * Emitted when the user has made a file selection.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
+  /**
+   * Emitted when the user has uplaoded a file.
+   */
+  gcdsInput: EventEmitter<CustomEvent<any>>;
   /**
    * Remove file and update value.
    */
@@ -571,7 +575,7 @@ export class GcdsInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsInput', 'gcdsChange', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -587,6 +591,10 @@ export declare interface GcdsInput extends Components.GcdsInput {
   gcdsBlur: EventEmitter<CustomEvent<void>>;
   /**
    * Emitted when the input has received input.
+   */
+  gcdsInput: EventEmitter<CustomEvent<any>>;
+  /**
+   * Emitted when the input has changed.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
@@ -904,7 +912,7 @@ export class GcdsSelect {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsChange', 'gcdsFocus', 'gcdsBlur', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, this.el, ['gcdsChange', 'gcdsInput', 'gcdsFocus', 'gcdsBlur', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -914,6 +922,10 @@ export declare interface GcdsSelect extends Components.GcdsSelect {
    * Emitted when the select value has changed.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
+  /**
+   * Emitted when the select has received input.
+   */
+  gcdsInput: EventEmitter<CustomEvent<any>>;
   /**
    * Emitted when the select has focus.
    */
@@ -1060,7 +1072,7 @@ export class GcdsTextarea {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -1078,6 +1090,10 @@ export declare interface GcdsTextarea extends Components.GcdsTextarea {
    * Emitted when the textarea has received input.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
+  /**
+   * Emitted when the textarea has changed.
+   */
+  gcdsInput: EventEmitter<CustomEvent<any>>;
   /**
    * Emitted when the textarea has a validation error.
    */

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -748,30 +748,38 @@ export declare interface GcdsNavLink extends Components.GcdsNavLink {
 
 
 @ProxyCmp({
-  inputs: ['currentPage', 'display', 'label', 'nextHref', 'nextLabel', 'pageChangeHandler', 'previousHref', 'previousLabel', 'totalPages', 'url']
+  inputs: ['currentPage', 'display', 'label', 'nextHref', 'nextLabel', 'previousHref', 'previousLabel', 'totalPages', 'url']
 })
 @Component({
   selector: 'gcds-pagination',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['currentPage', 'display', 'label', 'nextHref', 'nextLabel', 'pageChangeHandler', 'previousHref', 'previousLabel', 'totalPages', 'url'],
+  inputs: ['currentPage', 'display', 'label', 'nextHref', 'nextLabel', 'previousHref', 'previousLabel', 'totalPages', 'url'],
 })
 export class GcdsPagination {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsPageChange']);
+    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
   }
 }
 
 
 export declare interface GcdsPagination extends Components.GcdsPagination {
   /**
-   * Update value based on user input.
+   * Emitted when the link has focus.
    */
-  gcdsPageChange: EventEmitter<CustomEvent<void>>;
+  gcdsFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the link loses focus.
+   */
+  gcdsBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the link has been clicked.
+   */
+  gcdsClick: EventEmitter<CustomEvent<void>>;
 }
 
 

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -842,14 +842,14 @@ export declare interface GcdsRadioGroup extends Components.GcdsRadioGroup {
 
 
 @ProxyCmp({
-  inputs: ['action', 'method', 'name', 'placeholder', 'searchId', 'suggested']
+  inputs: ['action', 'method', 'name', 'placeholder', 'searchId', 'suggested', 'value']
 })
 @Component({
   selector: 'gcds-search',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['action', 'method', 'name', 'placeholder', 'searchId', 'suggested'],
+  inputs: ['action', 'method', 'name', 'placeholder', 'searchId', 'suggested', 'value'],
 })
 export class GcdsSearch {
   protected el: HTMLElement;
@@ -865,7 +865,7 @@ export declare interface GcdsSearch extends Components.GcdsSearch {
   /**
    * Emitted when the search input value has changed.
    */
-  gcdsChange: EventEmitter<CustomEvent<object>>;
+  gcdsChange: EventEmitter<CustomEvent<string>>;
   /**
    * Emitted when the search input value has gained focus.
    */

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -160,7 +160,7 @@ export class GcdsCheckbox {
 
 export declare interface GcdsCheckbox extends Components.GcdsCheckbox {
   /**
-   * Emitted when the checkbox has focus.
+   * Emitted when the checkbox has been clicked.
    */
   gcdsClick: EventEmitter<CustomEvent<void>>;
   /**
@@ -383,7 +383,7 @@ export declare interface GcdsFileUploader extends Components.GcdsFileUploader {
    */
   gcdsBlur: EventEmitter<CustomEvent<void>>;
   /**
-   * Update value based on user selection.
+   * Emitted when the user has made a file selection.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
@@ -586,7 +586,7 @@ export declare interface GcdsInput extends Components.GcdsInput {
    */
   gcdsBlur: EventEmitter<CustomEvent<void>>;
   /**
-   * Update value based on user input.
+   * Emitted when the input has received input.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
@@ -911,7 +911,7 @@ export class GcdsSelect {
 
 export declare interface GcdsSelect extends Components.GcdsSelect {
   /**
-   * Update value based on user selection.
+   * Emitted when the select value has changed.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
@@ -1075,7 +1075,7 @@ export declare interface GcdsTextarea extends Components.GcdsTextarea {
    */
   gcdsBlur: EventEmitter<CustomEvent<void>>;
   /**
-   * Update value based on user input.
+   * Emitted when the textarea has received input.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
   /**

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -387,7 +387,7 @@ export declare interface GcdsFileUploader extends Components.GcdsFileUploader {
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
-   * Emitted when the user has uplaoded a file.
+   * Emitted when the user has uploaded a file.
    */
   gcdsInput: EventEmitter<CustomEvent<any>>;
   /**
@@ -590,7 +590,7 @@ export declare interface GcdsInput extends Components.GcdsInput {
    */
   gcdsBlur: EventEmitter<CustomEvent<void>>;
   /**
-   * Emitted when the input has received input.
+   * Emitted when the element has received input.
    */
   gcdsInput: EventEmitter<CustomEvent<any>>;
   /**
@@ -1087,11 +1087,11 @@ export declare interface GcdsTextarea extends Components.GcdsTextarea {
    */
   gcdsBlur: EventEmitter<CustomEvent<void>>;
   /**
-   * Emitted when the textarea has received input.
+   * Emitted when the textarea has changed.
    */
   gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
-   * Emitted when the textarea has changed.
+   * Emitted when the textarea has received input.
    */
   gcdsInput: EventEmitter<CustomEvent<any>>;
   /**

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -224,7 +224,8 @@ export declare interface GcdsDateModified extends Components.GcdsDateModified {}
 
 
 @ProxyCmp({
-  inputs: ['detailsTitle', 'open']
+  inputs: ['detailsTitle', 'open'],
+  methods: ['toggle']
 })
 @Component({
   selector: 'gcds-details',
@@ -238,11 +239,25 @@ export class GcdsDetails {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
   }
 }
 
 
-export declare interface GcdsDetails extends Components.GcdsDetails {}
+export declare interface GcdsDetails extends Components.GcdsDetails {
+  /**
+   * Emitted when the details has focus.
+   */
+  gcdsFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the details loses focus.
+   */
+  gcdsBlur: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the details has been clicked.
+   */
+  gcdsClick: EventEmitter<CustomEvent<void>>;
+}
 
 
 @ProxyCmp({

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -689,16 +689,24 @@ export class GcdsNavGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsClick']);
+    proxyOutputs(this, this.el, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
   }
 }
 
 
 export declare interface GcdsNavGroup extends Components.GcdsNavGroup {
   /**
-   * Emitted when the button has focus.
+   * Emitted when the button has been clicked.
    */
   gcdsClick: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the button has been focus.
+   */
+  gcdsFocus: EventEmitter<CustomEvent<void>>;
+  /**
+   * Emitted when the button blurs.
+   */
+  gcdsBlur: EventEmitter<CustomEvent<void>>;
 }
 
 

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -368,7 +368,7 @@ export class GcdsFileUploader {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsFileUploaderChange', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -385,7 +385,7 @@ export declare interface GcdsFileUploader extends Components.GcdsFileUploader {
   /**
    * Update value based on user selection.
    */
-  gcdsFileUploaderChange: EventEmitter<CustomEvent<any>>;
+  gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
    * Remove file and update value.
    */
@@ -904,7 +904,7 @@ export class GcdsSelect {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsSelectChange', 'gcdsFocus', 'gcdsBlur', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, this.el, ['gcdsChange', 'gcdsFocus', 'gcdsBlur', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -913,7 +913,7 @@ export declare interface GcdsSelect extends Components.GcdsSelect {
   /**
    * Update value based on user selection.
    */
-  gcdsSelectChange: EventEmitter<CustomEvent<any>>;
+  gcdsChange: EventEmitter<CustomEvent<any>>;
   /**
    * Emitted when the select has focus.
    */

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -827,7 +827,7 @@ export class GcdsRadioGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsRadioChange', 'gcdsFocus', 'gcdsBlur']);
+    proxyOutputs(this, this.el, ['gcdsChange', 'gcdsFocus', 'gcdsBlur']);
   }
 }
 
@@ -836,7 +836,7 @@ export declare interface GcdsRadioGroup extends Components.GcdsRadioGroup {
   /**
    * Emitted when the radio button is checked
    */
-  gcdsRadioChange: EventEmitter<CustomEvent<void>>;
+  gcdsChange: EventEmitter<CustomEvent<void>>;
   /**
    * Emitted when the radio has focus.
    */

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -153,12 +153,16 @@ export class GcdsCheckbox {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, this.el, ['gcdsClick', 'gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsError', 'gcdsValid']);
   }
 }
 
 
 export declare interface GcdsCheckbox extends Components.GcdsCheckbox {
+  /**
+   * Emitted when the checkbox has focus.
+   */
+  gcdsClick: EventEmitter<CustomEvent<void>>;
   /**
    * Emitted when the checkbox has focus.
    */

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -8,14 +8,14 @@ import { Components } from '@cdssnc/gcds-components';
 
 
 @ProxyCmp({
-  inputs: ['alertRole', 'container', 'dismissHandler', 'heading', 'hideCloseBtn', 'hideRoleIcon', 'isFixed']
+  inputs: ['alertRole', 'container', 'heading', 'hideCloseBtn', 'hideRoleIcon', 'isFixed']
 })
 @Component({
   selector: 'gcds-alert',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['alertRole', 'container', 'dismissHandler', 'heading', 'hideCloseBtn', 'hideRoleIcon', 'isFixed'],
+  inputs: ['alertRole', 'container', 'heading', 'hideCloseBtn', 'hideRoleIcon', 'isFixed'],
 })
 export class GcdsAlert {
   protected el: HTMLElement;

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -80,27 +80,30 @@ export declare interface GcdsBreadcrumbsItem extends Components.GcdsBreadcrumbsI
 
 
 @ProxyCmp({
-  inputs: ['blurHandler', 'buttonId', 'buttonRole', 'clickHandler', 'disabled', 'download', 'focusHandler', 'href', 'name', 'rel', 'size', 'target', 'type'],
-  methods: ['focusElement']
+  inputs: ['buttonId', 'buttonRole', 'disabled', 'download', 'href', 'name', 'rel', 'size', 'target', 'type']
 })
 @Component({
   selector: 'gcds-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['blurHandler', 'buttonId', 'buttonRole', 'clickHandler', 'disabled', 'download', 'focusHandler', 'href', 'name', 'rel', 'size', 'target', 'type'],
+  inputs: ['buttonId', 'buttonRole', 'disabled', 'download', 'href', 'name', 'rel', 'size', 'target', 'type'],
 })
 export class GcdsButton {
   protected el: HTMLElement;
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur']);
+    proxyOutputs(this, this.el, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
   }
 }
 
 
 export declare interface GcdsButton extends Components.GcdsButton {
+  /**
+   * Emitted when the button has been clicked.
+   */
+  gcdsClick: EventEmitter<CustomEvent<void>>;
   /**
    * Emitted when the button has focus.
    */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -52,10 +52,6 @@ export namespace Components {
     }
     interface GcdsButton {
         /**
-          * Custom callback function on blur event
-         */
-        "blurHandler": Function;
-        /**
           * The buttonId attribute specifies the id for a <button> element.
          */
         "buttonId": string;
@@ -64,10 +60,6 @@ export namespace Components {
          */
         "buttonRole": 'primary' | 'secondary' | 'danger';
         /**
-          * Custom callback function on click event
-         */
-        "clickHandler": Function;
-        /**
           * The disabled attribute for a <button> element.
          */
         "disabled": boolean;
@@ -75,14 +67,6 @@ export namespace Components {
           * The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink
          */
         "download": string | undefined;
-        /**
-          * Focus element
-         */
-        "focusElement": () => Promise<void>;
-        /**
-          * Custom callback function on focus event
-         */
-        "focusHandler": Function;
         /**
           * The href attribute specifies the URL of the page the link goes to
          */
@@ -1250,6 +1234,7 @@ declare global {
         new (): HTMLGcdsBreadcrumbsItemElement;
     };
     interface HTMLGcdsButtonElementEventMap {
+        "gcdsClick": void;
         "gcdsFocus": void;
         "gcdsBlur": void;
     }
@@ -1753,10 +1738,6 @@ declare namespace LocalJSX {
     }
     interface GcdsButton {
         /**
-          * Custom callback function on blur event
-         */
-        "blurHandler"?: Function;
-        /**
           * The buttonId attribute specifies the id for a <button> element.
          */
         "buttonId"?: string;
@@ -1765,10 +1746,6 @@ declare namespace LocalJSX {
          */
         "buttonRole"?: 'primary' | 'secondary' | 'danger';
         /**
-          * Custom callback function on click event
-         */
-        "clickHandler"?: Function;
-        /**
           * The disabled attribute for a <button> element.
          */
         "disabled"?: boolean;
@@ -1776,10 +1753,6 @@ declare namespace LocalJSX {
           * The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink
          */
         "download"?: string | undefined;
-        /**
-          * Custom callback function on focus event
-         */
-        "focusHandler"?: Function;
         /**
           * The href attribute specifies the URL of the page the link goes to
          */
@@ -1792,6 +1765,10 @@ declare namespace LocalJSX {
           * Emitted when the button loses focus.
          */
         "onGcdsBlur"?: (event: GcdsButtonCustomEvent<void>) => void;
+        /**
+          * Emitted when the button has been clicked.
+         */
+        "onGcdsClick"?: (event: GcdsButtonCustomEvent<void>) => void;
         /**
           * Emitted when the button has focus.
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1523,7 +1523,7 @@ declare global {
         new (): HTMLGcdsPhaseBannerElement;
     };
     interface HTMLGcdsRadioGroupElementEventMap {
-        "gcdsRadioChange": void;
+        "gcdsChange": void;
         "gcdsFocus": void;
         "gcdsBlur": void;
     }
@@ -2657,13 +2657,13 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsRadioGroupCustomEvent<void>) => void;
         /**
+          * Emitted when the radio button is checked
+         */
+        "onGcdsChange"?: (event: GcdsRadioGroupCustomEvent<void>) => void;
+        /**
           * Emitted when the radio has focus.
          */
         "onGcdsFocus"?: (event: GcdsRadioGroupCustomEvent<void>) => void;
-        /**
-          * Emitted when the radio button is checked
-         */
-        "onGcdsRadioChange"?: (event: GcdsRadioGroupCustomEvent<void>) => void;
         /**
           * Options to render radio buttons
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1475,6 +1475,8 @@ declare global {
     };
     interface HTMLGcdsNavGroupElementEventMap {
         "gcdsClick": void;
+        "gcdsFocus": void;
+        "gcdsBlur": void;
     }
     interface HTMLGcdsNavGroupElement extends Components.GcdsNavGroup, HTMLStencilElement {
         addEventListener<K extends keyof HTMLGcdsNavGroupElementEventMap>(type: K, listener: (this: HTMLGcdsNavGroupElement, ev: GcdsNavGroupCustomEvent<HTMLGcdsNavGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2555,9 +2557,17 @@ declare namespace LocalJSX {
          */
         "menuLabel": string;
         /**
-          * Emitted when the button has focus.
+          * Emitted when the button blurs.
+         */
+        "onGcdsBlur"?: (event: GcdsNavGroupCustomEvent<void>) => void;
+        /**
+          * Emitted when the button has been clicked.
          */
         "onGcdsClick"?: (event: GcdsNavGroupCustomEvent<void>) => void;
+        /**
+          * Emitted when the button has been focus.
+         */
+        "onGcdsFocus"?: (event: GcdsNavGroupCustomEvent<void>) => void;
         /**
           * Has the nav group been expanded
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1346,7 +1346,7 @@ declare global {
     interface HTMLGcdsFileUploaderElementEventMap {
         "gcdsFocus": void;
         "gcdsBlur": void;
-        "gcdsFileUploaderChange": any;
+        "gcdsChange": any;
         "gcdsRemoveFile": any;
         "gcdsError": object;
         "gcdsValid": object;
@@ -1562,7 +1562,7 @@ declare global {
         new (): HTMLGcdsSearchElement;
     };
     interface HTMLGcdsSelectElementEventMap {
-        "gcdsSelectChange": any;
+        "gcdsChange": any;
         "gcdsFocus": void;
         "gcdsBlur": void;
         "gcdsError": object;
@@ -2087,13 +2087,13 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsFileUploaderCustomEvent<void>) => void;
         /**
+          * Update value based on user selection.
+         */
+        "onGcdsChange"?: (event: GcdsFileUploaderCustomEvent<any>) => void;
+        /**
           * Emitted when the input has a validation error.
          */
         "onGcdsError"?: (event: GcdsFileUploaderCustomEvent<object>) => void;
-        /**
-          * Update value based on user selection.
-         */
-        "onGcdsFileUploaderChange"?: (event: GcdsFileUploaderCustomEvent<any>) => void;
         /**
           * Emitted when the uploader has focus.
          */
@@ -2745,6 +2745,10 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsSelectCustomEvent<void>) => void;
         /**
+          * Update value based on user selection.
+         */
+        "onGcdsChange"?: (event: GcdsSelectCustomEvent<any>) => void;
+        /**
           * Emitted when the select has a validation error.
          */
         "onGcdsError"?: (event: GcdsSelectCustomEvent<object>) => void;
@@ -2752,10 +2756,6 @@ declare namespace LocalJSX {
           * Emitted when the select has focus.
          */
         "onGcdsFocus"?: (event: GcdsSelectCustomEvent<void>) => void;
-        /**
-          * Update value based on user selection.
-         */
-        "onGcdsSelectChange"?: (event: GcdsSelectCustomEvent<any>) => void;
         /**
           * Emitted when the select has a validation error.
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1347,6 +1347,7 @@ declare global {
         "gcdsFocus": void;
         "gcdsBlur": void;
         "gcdsChange": any;
+        "gcdsInput": any;
         "gcdsRemoveFile": any;
         "gcdsError": object;
         "gcdsValid": object;
@@ -1410,6 +1411,7 @@ declare global {
     interface HTMLGcdsInputElementEventMap {
         "gcdsFocus": void;
         "gcdsBlur": void;
+        "gcdsInput": any;
         "gcdsChange": any;
         "gcdsError": object;
         "gcdsValid": object;
@@ -1563,6 +1565,7 @@ declare global {
     };
     interface HTMLGcdsSelectElementEventMap {
         "gcdsChange": any;
+        "gcdsInput": any;
         "gcdsFocus": void;
         "gcdsBlur": void;
         "gcdsError": object;
@@ -1616,6 +1619,7 @@ declare global {
         "gcdsFocus": void;
         "gcdsBlur": void;
         "gcdsChange": any;
+        "gcdsInput": any;
         "gcdsError": object;
         "gcdsValid": object;
     }
@@ -2099,6 +2103,10 @@ declare namespace LocalJSX {
          */
         "onGcdsFocus"?: (event: GcdsFileUploaderCustomEvent<void>) => void;
         /**
+          * Emitted when the user has uplaoded a file.
+         */
+        "onGcdsInput"?: (event: GcdsFileUploaderCustomEvent<any>) => void;
+        /**
           * Remove file and update value.
          */
         "onGcdsRemoveFile"?: (event: GcdsFileUploaderCustomEvent<any>) => void;
@@ -2415,7 +2423,7 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsInputCustomEvent<void>) => void;
         /**
-          * Emitted when the input has received input.
+          * Emitted when the input has changed.
          */
         "onGcdsChange"?: (event: GcdsInputCustomEvent<any>) => void;
         /**
@@ -2426,6 +2434,10 @@ declare namespace LocalJSX {
           * Emitted when the input has focus.
          */
         "onGcdsFocus"?: (event: GcdsInputCustomEvent<void>) => void;
+        /**
+          * Emitted when the input has received input.
+         */
+        "onGcdsInput"?: (event: GcdsInputCustomEvent<any>) => void;
         /**
           * Emitted when the input has a validation error.
          */
@@ -2757,6 +2769,10 @@ declare namespace LocalJSX {
          */
         "onGcdsFocus"?: (event: GcdsSelectCustomEvent<void>) => void;
         /**
+          * Emitted when the select has received input.
+         */
+        "onGcdsInput"?: (event: GcdsSelectCustomEvent<any>) => void;
+        /**
           * Emitted when the select has a validation error.
          */
         "onGcdsValid"?: (event: GcdsSelectCustomEvent<object>) => void;
@@ -2936,6 +2952,10 @@ declare namespace LocalJSX {
           * Emitted when the textarea has focus.
          */
         "onGcdsFocus"?: (event: GcdsTextareaCustomEvent<void>) => void;
+        /**
+          * Emitted when the textarea has changed.
+         */
+        "onGcdsInput"?: (event: GcdsTextareaCustomEvent<any>) => void;
         /**
           * Emitted when the textarea has a validation error.
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -822,10 +822,6 @@ export namespace Components {
          */
         "nextLabel": string;
         /**
-          * Function to fire when pageChange event is called
-         */
-        "pageChangeHandler": Function;
-        /**
           * Simple display - href for previous link
          */
         "previousHref": string;
@@ -1512,7 +1508,9 @@ declare global {
         new (): HTMLGcdsNavLinkElement;
     };
     interface HTMLGcdsPaginationElementEventMap {
-        "gcdsPageChange": void;
+        "gcdsFocus": void;
+        "gcdsBlur": void;
+        "gcdsClick": void;
     }
     interface HTMLGcdsPaginationElement extends Components.GcdsPagination, HTMLStencilElement {
         addEventListener<K extends keyof HTMLGcdsPaginationElementEventMap>(type: K, listener: (this: HTMLGcdsPaginationElement, ev: GcdsPaginationCustomEvent<HTMLGcdsPaginationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2621,13 +2619,17 @@ declare namespace LocalJSX {
          */
         "nextLabel"?: string;
         /**
-          * Update value based on user input.
+          * Emitted when the link loses focus.
          */
-        "onGcdsPageChange"?: (event: GcdsPaginationCustomEvent<void>) => void;
+        "onGcdsBlur"?: (event: GcdsPaginationCustomEvent<void>) => void;
         /**
-          * Function to fire when pageChange event is called
+          * Emitted when the link has been clicked.
          */
-        "pageChangeHandler"?: Function;
+        "onGcdsClick"?: (event: GcdsPaginationCustomEvent<void>) => void;
+        /**
+          * Emitted when the link has focus.
+         */
+        "onGcdsFocus"?: (event: GcdsPaginationCustomEvent<void>) => void;
         /**
           * Simple display - href for previous link
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1863,7 +1863,7 @@ declare namespace LocalJSX {
          */
         "onGcdsChange"?: (event: GcdsCheckboxCustomEvent<any>) => void;
         /**
-          * Emitted when the checkbox has focus.
+          * Emitted when the checkbox has been clicked.
          */
         "onGcdsClick"?: (event: GcdsCheckboxCustomEvent<void>) => void;
         /**
@@ -2087,7 +2087,7 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsFileUploaderCustomEvent<void>) => void;
         /**
-          * Update value based on user selection.
+          * Emitted when the user has made a file selection.
          */
         "onGcdsChange"?: (event: GcdsFileUploaderCustomEvent<any>) => void;
         /**
@@ -2415,7 +2415,7 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsInputCustomEvent<void>) => void;
         /**
-          * Update value based on user input.
+          * Emitted when the input has received input.
          */
         "onGcdsChange"?: (event: GcdsInputCustomEvent<any>) => void;
         /**
@@ -2745,7 +2745,7 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsSelectCustomEvent<void>) => void;
         /**
-          * Update value based on user selection.
+          * Emitted when the select value has changed.
          */
         "onGcdsChange"?: (event: GcdsSelectCustomEvent<any>) => void;
         /**
@@ -2925,7 +2925,7 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsTextareaCustomEvent<void>) => void;
         /**
-          * Update value based on user input.
+          * Emitted when the textarea has received input.
          */
         "onGcdsChange"?: (event: GcdsTextareaCustomEvent<any>) => void;
         /**

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -265,6 +265,10 @@ export namespace Components {
           * Defines if the details panel is open by default or not.
          */
         "open"?: boolean;
+        /**
+          * Methods
+         */
+        "toggle": () => Promise<void>;
     }
     interface GcdsErrorMessage {
         /**
@@ -1167,6 +1171,10 @@ export interface GcdsCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLGcdsCheckboxElement;
 }
+export interface GcdsDetailsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLGcdsDetailsElement;
+}
 export interface GcdsFieldsetCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLGcdsFieldsetElement;
@@ -1298,7 +1306,20 @@ declare global {
         prototype: HTMLGcdsDateModifiedElement;
         new (): HTMLGcdsDateModifiedElement;
     };
+    interface HTMLGcdsDetailsElementEventMap {
+        "gcdsFocus": void;
+        "gcdsBlur": void;
+        "gcdsClick": void;
+    }
     interface HTMLGcdsDetailsElement extends Components.GcdsDetails, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLGcdsDetailsElementEventMap>(type: K, listener: (this: HTMLGcdsDetailsElement, ev: GcdsDetailsCustomEvent<HTMLGcdsDetailsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLGcdsDetailsElementEventMap>(type: K, listener: (this: HTMLGcdsDetailsElement, ev: GcdsDetailsCustomEvent<HTMLGcdsDetailsElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLGcdsDetailsElement: {
         prototype: HTMLGcdsDetailsElement;
@@ -1957,6 +1978,18 @@ declare namespace LocalJSX {
           * The details title summarizes the panel content.
          */
         "detailsTitle": string;
+        /**
+          * Emitted when the details loses focus.
+         */
+        "onGcdsBlur"?: (event: GcdsDetailsCustomEvent<void>) => void;
+        /**
+          * Emitted when the details has been clicked.
+         */
+        "onGcdsClick"?: (event: GcdsDetailsCustomEvent<void>) => void;
+        /**
+          * Emitted when the details has focus.
+         */
+        "onGcdsFocus"?: (event: GcdsDetailsCustomEvent<void>) => void;
         /**
           * Defines if the details panel is open by default or not.
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -2103,7 +2103,7 @@ declare namespace LocalJSX {
          */
         "onGcdsFocus"?: (event: GcdsFileUploaderCustomEvent<void>) => void;
         /**
-          * Emitted when the user has uplaoded a file.
+          * Emitted when the user has uploaded a file.
          */
         "onGcdsInput"?: (event: GcdsFileUploaderCustomEvent<any>) => void;
         /**
@@ -2435,7 +2435,7 @@ declare namespace LocalJSX {
          */
         "onGcdsFocus"?: (event: GcdsInputCustomEvent<void>) => void;
         /**
-          * Emitted when the input has received input.
+          * Emitted when the element has received input.
          */
         "onGcdsInput"?: (event: GcdsInputCustomEvent<any>) => void;
         /**
@@ -2941,7 +2941,7 @@ declare namespace LocalJSX {
          */
         "onGcdsBlur"?: (event: GcdsTextareaCustomEvent<void>) => void;
         /**
-          * Emitted when the textarea has received input.
+          * Emitted when the textarea has changed.
          */
         "onGcdsChange"?: (event: GcdsTextareaCustomEvent<any>) => void;
         /**
@@ -2953,7 +2953,7 @@ declare namespace LocalJSX {
          */
         "onGcdsFocus"?: (event: GcdsTextareaCustomEvent<void>) => void;
         /**
-          * Emitted when the textarea has changed.
+          * Emitted when the textarea has received input.
          */
         "onGcdsInput"?: (event: GcdsTextareaCustomEvent<any>) => void;
         /**

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -22,10 +22,6 @@ export namespace Components {
          */
         "container"?: 'full' | 'xl' | 'lg' | 'md' | 'sm' | 'xs';
         /**
-          * Callback when the close button is clicked.
-         */
-        "dismissHandler": Function;
-        /**
           * Defines the alert heading.
          */
         "heading": string;
@@ -1697,10 +1693,6 @@ declare namespace LocalJSX {
           * Defines the max width of the alert content.
          */
         "container"?: 'full' | 'xl' | 'lg' | 'md' | 'sm' | 'xs';
-        /**
-          * Callback when the close button is clicked.
-         */
-        "dismissHandler"?: Function;
         /**
           * Defines the alert heading.
          */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -880,13 +880,17 @@ export namespace Components {
          */
         "placeholder": string;
         /**
-          * Set the name of the search input
+          * Set the id of the search input
          */
         "searchId": string;
         /**
           * Set a list of predefined search terms
          */
         "suggested": Array<string>;
+        /**
+          * Set the value of the search input
+         */
+        "value": string;
     }
     interface GcdsSelect {
         /**
@@ -1552,7 +1556,7 @@ declare global {
         new (): HTMLGcdsRadioGroupElement;
     };
     interface HTMLGcdsSearchElementEventMap {
-        "gcdsChange": object;
+        "gcdsChange": string;
         "gcdsFocus": object;
         "gcdsBlur": object;
         "gcdsSubmit": object;
@@ -2703,7 +2707,7 @@ declare namespace LocalJSX {
         /**
           * Emitted when the search input value has changed.
          */
-        "onGcdsChange"?: (event: GcdsSearchCustomEvent<object>) => void;
+        "onGcdsChange"?: (event: GcdsSearchCustomEvent<string>) => void;
         /**
           * Emitted when the search input value has gained focus.
          */
@@ -2717,13 +2721,17 @@ declare namespace LocalJSX {
          */
         "placeholder"?: string;
         /**
-          * Set the name of the search input
+          * Set the id of the search input
          */
         "searchId"?: string;
         /**
           * Set a list of predefined search terms
          */
         "suggested"?: Array<string>;
+        /**
+          * Set the value of the search input
+         */
+        "value"?: string;
     }
     interface GcdsSelect {
         /**

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1259,6 +1259,7 @@ declare global {
         new (): HTMLGcdsCardElement;
     };
     interface HTMLGcdsCheckboxElementEventMap {
+        "gcdsClick": void;
         "gcdsFocus": void;
         "gcdsBlur": void;
         "gcdsChange": any;
@@ -1861,6 +1862,10 @@ declare namespace LocalJSX {
           * Update value based on user input.
          */
         "onGcdsChange"?: (event: GcdsCheckboxCustomEvent<any>) => void;
+        /**
+          * Emitted when the checkbox has focus.
+         */
+        "onGcdsClick"?: (event: GcdsCheckboxCustomEvent<void>) => void;
         /**
           * Emitted when the input has a validation error.
          */

--- a/packages/web/src/components/gcds-alert/gcds-alert.tsx
+++ b/packages/web/src/components/gcds-alert/gcds-alert.tsx
@@ -8,7 +8,7 @@ import {
   State,
   h,
 } from '@stencil/core';
-import { assignLanguage, observerConfig } from '../../utils/utils';
+import { assignLanguage, observerConfig, emitEvent } from '../../utils/utils';
 import i18n from './i18n/i18n';
 
 @Component({
@@ -32,11 +32,6 @@ export class GcdsAlert {
    * Defines the max width of the alert content.
    */
   @Prop() container?: 'full' | 'xl' | 'lg' | 'md' | 'sm' | 'xs' = 'full';
-
-  /**
-   * Callback when the close button is clicked.
-   */
-  @Prop() dismissHandler: Function;
 
   /**
    * Defines the alert heading.
@@ -77,16 +72,6 @@ export class GcdsAlert {
    */
 
   @Event() gcdsDismiss!: EventEmitter<void>;
-
-  private onDismiss = e => {
-    this.gcdsDismiss.emit();
-
-    if (this.dismissHandler) {
-      this.dismissHandler(e);
-    } else {
-      this.isOpen = false;
-    }
-  };
 
   /*
    * Observe lang attribute change
@@ -171,7 +156,12 @@ export class GcdsAlert {
                 {!hideCloseBtn && (
                   <button
                     class="alert__close-btn"
-                    onClick={e => this.onDismiss(e)}
+                    onClick={e => {
+                      const event = emitEvent(e, this.gcdsDismiss);
+                      if (event) {
+                        this.isOpen = false;
+                      }
+                    }}
                     aria-label={i18n[lang].closeBtn}
                   >
                     <gcds-icon aria-hidden="true" name="times" size="text" />

--- a/packages/web/src/components/gcds-alert/readme.md
+++ b/packages/web/src/components/gcds-alert/readme.md
@@ -11,7 +11,6 @@
 | ---------------------- | ---------------- | -------------------------------------------------------- | ------------------------------------------------ | ----------- |
 | `alertRole`            | `alert-role`     | Defines alert role.                                      | `"danger" \| "info" \| "success" \| "warning"`   | `'info'`    |
 | `container`            | `container`      | Defines the max width of the alert content.              | `"full" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"` | `'full'`    |
-| `dismissHandler`       | --               | Callback when the close button is clicked.               | `Function`                                       | `undefined` |
 | `heading` _(required)_ | `heading`        | Defines the alert heading.                               | `string`                                         | `undefined` |
 | `hideCloseBtn`         | `hide-close-btn` | Defines if the alert's close button is displayed or not. | `boolean`                                        | `false`     |
 | `hideRoleIcon`         | `hide-role-icon` | Defines if the alert's role icon is displayed or not.    | `boolean`                                        | `false`     |

--- a/packages/web/src/components/gcds-button/gcds-button.tsx
+++ b/packages/web/src/components/gcds-button/gcds-button.tsx
@@ -3,7 +3,6 @@ import {
   Element,
   Event,
   EventEmitter,
-  Method,
   Host,
   Watch,
   Prop,
@@ -11,7 +10,7 @@ import {
   h,
 } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
-import { inheritAttributes } from '../../utils/utils';
+import { inheritAttributes, emitEvent } from '../../utils/utils';
 import i18n from './i18n/i18n';
 
 @Component({
@@ -111,21 +110,6 @@ export class GcdsButton {
   @Prop() download: string | undefined;
 
   /**
-   * Custom callback function on click event
-   */
-  @Prop() clickHandler: Function;
-
-  /**
-   * Custom callback function on focus event
-   */
-  @Prop() focusHandler: Function;
-
-  /**
-   * Custom callback function on blur event
-   */
-  @Prop() blurHandler: Function;
-
-  /**
    * Set additional HTML attributes not available in component properties
    */
   @State() inheritedAttributes: Object = {};
@@ -138,6 +122,11 @@ export class GcdsButton {
   /**
    * Events
    */
+
+  /**
+   * Emitted when the button has been clicked.
+   */
+  @Event() gcdsClick!: EventEmitter<void>;
 
   /**
    * Emitted when the button has focus.
@@ -175,18 +164,10 @@ export class GcdsButton {
     this.updateLang();
   }
 
-  /**
-   * Focus element
-   */
-  @Method()
-  async focusElement() {
-    this.shadowElement.focus();
-  }
-
   private handleClick = (e: Event) => {
-    if (this.clickHandler) {
-      this.clickHandler(e);
-    } else {
+    const event = emitEvent(e, this.gcdsClick);
+
+    if (event) {
       if (!this.disabled && this.type != 'button' && this.type != 'link') {
         // Attach button to form
         const form = this.el.closest('form');
@@ -205,26 +186,10 @@ export class GcdsButton {
           formButton.remove();
         }
       }
+
+      // Has any inherited attributes changed on click
+      this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
     }
-
-    // Has any inherited attributes changed on click
-    this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
-  };
-
-  private onFocus = e => {
-    if (this.focusHandler) {
-      this.focusHandler(e);
-    }
-
-    this.gcdsFocus.emit();
-  };
-
-  private onBlur = e => {
-    if (this.blurHandler) {
-      this.blurHandler(e);
-    }
-
-    this.gcdsBlur.emit();
   };
 
   render() {
@@ -263,8 +228,8 @@ export class GcdsButton {
         <Tag
           {...attrs}
           id={buttonId}
-          onBlur={e => this.onBlur(e)}
-          onFocus={e => this.onFocus(e)}
+          onBlur={() => this.gcdsBlur.emit()}
+          onFocus={() => this.gcdsFocus.emit()}
           onClick={e => this.handleClick(e)}
           class={`gcds-button button--role-${buttonRole} button--${size}`}
           ref={element => (this.shadowElement = element as HTMLElement)}

--- a/packages/web/src/components/gcds-button/readme.md
+++ b/packages/web/src/components/gcds-button/readme.md
@@ -5,42 +5,27 @@
 
 ## Properties
 
-| Property       | Attribute     | Description                                                                                                                                        | Type                                        | Default     |
-| -------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------- |
-| `blurHandler`  | --            | Custom callback function on blur event                                                                                                             | `Function`                                  | `undefined` |
-| `buttonId`     | `button-id`   | The buttonId attribute specifies the id for a <button> element.                                                                                    | `string`                                    | `undefined` |
-| `buttonRole`   | `button-role` | Set the main style                                                                                                                                 | `"danger" \| "primary" \| "secondary"`      | `'primary'` |
-| `clickHandler` | --            | Custom callback function on click event                                                                                                            | `Function`                                  | `undefined` |
-| `disabled`     | `disabled`    | The disabled attribute for a <button> element.                                                                                                     | `boolean`                                   | `undefined` |
-| `download`     | `download`    | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                                    | `undefined` |
-| `focusHandler` | --            | Custom callback function on focus event                                                                                                            | `Function`                                  | `undefined` |
-| `href`         | `href`        | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                                    | `undefined` |
-| `name`         | `name`        | The name attribute specifies the name for a <button> element.                                                                                      | `string`                                    | `undefined` |
-| `rel`          | `rel`         | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                                    | `undefined` |
-| `size`         | `size`        | Set the button size                                                                                                                                | `"regular" \| "small"`                      | `'regular'` |
-| `target`       | `target`      | The target attribute specifies where to open the linked document                                                                                   | `string`                                    | `undefined` |
-| `type`         | `type`        | Set button types                                                                                                                                   | `"button" \| "link" \| "reset" \| "submit"` | `'button'`  |
+| Property     | Attribute     | Description                                                                                                                                        | Type                                        | Default     |
+| ------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | ----------- |
+| `buttonId`   | `button-id`   | The buttonId attribute specifies the id for a <button> element.                                                                                    | `string`                                    | `undefined` |
+| `buttonRole` | `button-role` | Set the main style                                                                                                                                 | `"danger" \| "primary" \| "secondary"`      | `'primary'` |
+| `disabled`   | `disabled`    | The disabled attribute for a <button> element.                                                                                                     | `boolean`                                   | `undefined` |
+| `download`   | `download`    | The download attribute specifies that the target (the file specified in the href attribute) will be downloaded when a user clicks on the hyperlink | `string`                                    | `undefined` |
+| `href`       | `href`        | The href attribute specifies the URL of the page the link goes to                                                                                  | `string`                                    | `undefined` |
+| `name`       | `name`        | The name attribute specifies the name for a <button> element.                                                                                      | `string`                                    | `undefined` |
+| `rel`        | `rel`         | The rel attribute specifies the relationship between the current document and the linked document                                                  | `string`                                    | `undefined` |
+| `size`       | `size`        | Set the button size                                                                                                                                | `"regular" \| "small"`                      | `'regular'` |
+| `target`     | `target`      | The target attribute specifies where to open the linked document                                                                                   | `string`                                    | `undefined` |
+| `type`       | `type`        | Set button types                                                                                                                                   | `"button" \| "link" \| "reset" \| "submit"` | `'button'`  |
 
 
 ## Events
 
-| Event       | Description                          | Type                |
-| ----------- | ------------------------------------ | ------------------- |
-| `gcdsBlur`  | Emitted when the button loses focus. | `CustomEvent<void>` |
-| `gcdsFocus` | Emitted when the button has focus.   | `CustomEvent<void>` |
-
-
-## Methods
-
-### `focusElement() => Promise<void>`
-
-Focus element
-
-#### Returns
-
-Type: `Promise<void>`
-
-
+| Event       | Description                               | Type                |
+| ----------- | ----------------------------------------- | ------------------- |
+| `gcdsBlur`  | Emitted when the button loses focus.      | `CustomEvent<void>` |
+| `gcdsClick` | Emitted when the button has been clicked. | `CustomEvent<void>` |
+| `gcdsFocus` | Emitted when the button has focus.        | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -15,6 +15,7 @@ import {
 import {
   assignLanguage,
   elementGroupCheck,
+  emitEvent,
   inheritAttributes,
   observerConfig,
 } from '../../utils/utils';
@@ -182,11 +183,12 @@ export class GcdsCheckbox {
   /**
    * Emitted when the checkbox has focus.
    */
-  @Event() gcdsFocus!: EventEmitter<void>;
+  @Event() gcdsClick!: EventEmitter<void>;
 
-  private onFocus = () => {
-    this.gcdsFocus.emit();
-  };
+  /**
+   * Emitted when the checkbox has focus.
+   */
+  @Event() gcdsFocus!: EventEmitter<void>;
 
   /**
    * Emitted when the checkbox loses focus.
@@ -207,6 +209,16 @@ export class GcdsCheckbox {
   @Event() gcdsChange: EventEmitter;
 
   /**
+   * Emitted when the input has a validation error.
+   */
+  @Event() gcdsError!: EventEmitter<object>;
+
+  /**
+   * Emitted when the input has a validation error.
+   */
+  @Event() gcdsValid!: EventEmitter<object>;
+
+  /**
    * Call any active validators
    */
   @Method()
@@ -225,16 +237,6 @@ export class GcdsCheckbox {
       this.gcdsValid.emit({ id: `#${this.checkboxId}` });
     }
   }
-
-  /**
-   * Emitted when the input has a validation error.
-   */
-  @Event() gcdsError!: EventEmitter<object>;
-
-  /**
-   * Emitted when the input has a validation error.
-   */
-  @Event() gcdsValid!: EventEmitter<object>;
 
   @Listen('submit', { target: 'document' })
   submitListener(e) {
@@ -374,8 +376,9 @@ export class GcdsCheckbox {
             type="checkbox"
             {...attrsInput}
             onBlur={() => this.onBlur()}
-            onFocus={() => this.onFocus()}
-            onClick={e => this.onChange(e)}
+            onFocus={() => this.gcdsFocus.emit()}
+            onChange={e => this.onChange(e)}
+            onClick={e => emitEvent(e, this.gcdsClick)}
             ref={element => (this.shadowElement = element as HTMLElement)}
           />
 

--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -181,7 +181,7 @@ export class GcdsCheckbox {
    */
 
   /**
-   * Emitted when the checkbox has focus.
+   * Emitted when the checkbox has been clicked.
    */
   @Event() gcdsClick!: EventEmitter<void>;
 

--- a/packages/web/src/components/gcds-checkbox/readme.md
+++ b/packages/web/src/components/gcds-checkbox/readme.md
@@ -28,7 +28,7 @@
 | ------------ | ---------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the checkbox loses focus.         | `CustomEvent<void>`   |
 | `gcdsChange` | Update value based on user input.              | `CustomEvent<any>`    |
-| `gcdsClick`  | Emitted when the checkbox has focus.           | `CustomEvent<void>`   |
+| `gcdsClick`  | Emitted when the checkbox has been clicked.    | `CustomEvent<void>`   |
 | `gcdsError`  | Emitted when the input has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the checkbox has focus.           | `CustomEvent<void>`   |
 | `gcdsValid`  | Emitted when the input has a validation error. | `CustomEvent<object>` |

--- a/packages/web/src/components/gcds-checkbox/readme.md
+++ b/packages/web/src/components/gcds-checkbox/readme.md
@@ -28,6 +28,7 @@
 | ------------ | ---------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the checkbox loses focus.         | `CustomEvent<void>`   |
 | `gcdsChange` | Update value based on user input.              | `CustomEvent<any>`    |
+| `gcdsClick`  | Emitted when the checkbox has focus.           | `CustomEvent<void>`   |
 | `gcdsError`  | Emitted when the input has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the checkbox has focus.           | `CustomEvent<void>`   |
 | `gcdsValid`  | Emitted when the input has a validation error. | `CustomEvent<object>` |

--- a/packages/web/src/components/gcds-details/gcds-details.tsx
+++ b/packages/web/src/components/gcds-details/gcds-details.tsx
@@ -72,8 +72,8 @@ export class GcdsDetails {
           <button
             aria-expanded={open.toString()}
             aria-controls="details__panel"
-            onBlur={e => emitEvent(e, this.gcdsBlur)}
-            onFocus={e => emitEvent(e, this.gcdsFocus)}
+            onBlur={() => this.gcdsBlur.emit()}
+            onFocus={() => this.gcdsFocus.emit()}
             onClick={e => {
               const event = emitEvent(e, this.gcdsClick);
               if (event) {

--- a/packages/web/src/components/gcds-details/gcds-details.tsx
+++ b/packages/web/src/components/gcds-details/gcds-details.tsx
@@ -1,4 +1,14 @@
-import { Component, Element, Host, Prop, h } from '@stencil/core';
+import {
+  Component,
+  Element,
+  Host,
+  Prop,
+  Method,
+  Event,
+  EventEmitter,
+  h,
+} from '@stencil/core';
+import { emitEvent } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-details',
@@ -22,6 +32,37 @@ export class GcdsDetails {
    */
   @Prop({ mutable: true, reflect: true }) open?: boolean = false;
 
+  /**
+   * Events
+   */
+
+  /**
+   * Emitted when the details has focus.
+   */
+  @Event() gcdsFocus!: EventEmitter<void>;
+
+  /**
+   * Emitted when the details loses focus.
+   */
+  @Event() gcdsBlur!: EventEmitter<void>;
+
+  /**
+   * Emitted when the details has been clicked.
+   */
+  @Event() gcdsClick!: EventEmitter<void>;
+
+  /**
+   * Methods
+   */
+
+  /*
+   * Toggle details open or closed
+   */
+  @Method()
+  async toggle() {
+    this.open = !this.open;
+  }
+
   render() {
     const { detailsTitle, open } = this;
 
@@ -31,7 +72,14 @@ export class GcdsDetails {
           <button
             aria-expanded={open.toString()}
             aria-controls="details__panel"
-            onClick={() => (this.open = !open)}
+            onBlur={e => emitEvent(e, this.gcdsBlur)}
+            onFocus={e => emitEvent(e, this.gcdsFocus)}
+            onClick={e => {
+              const event = emitEvent(e, this.gcdsClick);
+              if (event) {
+                this.toggle();
+              }
+            }}
             class="details__summary"
             id="details__summary"
           >

--- a/packages/web/src/components/gcds-details/readme.md
+++ b/packages/web/src/components/gcds-details/readme.md
@@ -13,6 +13,28 @@
 | `open`                      | `open`          | Defines if the details panel is open by default or not. | `boolean` | `false`     |
 
 
+## Events
+
+| Event       | Description                                | Type                |
+| ----------- | ------------------------------------------ | ------------------- |
+| `gcdsBlur`  | Emitted when the details loses focus.      | `CustomEvent<void>` |
+| `gcdsClick` | Emitted when the details has been clicked. | `CustomEvent<void>` |
+| `gcdsFocus` | Emitted when the details has focus.        | `CustomEvent<void>` |
+
+
+## Methods
+
+### `toggle() => Promise<void>`
+
+Methods
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -180,7 +180,12 @@ export class GcdsFileUploader {
    */
   @Event() gcdsChange: EventEmitter;
 
-  handleChange = e => {
+  /**
+   * Emitted when the user has uplaoded a file.
+   */
+  @Event() gcdsInput: EventEmitter;
+
+  handleInput = e => {
     const filesContainer: string[] = [];
     const files = Array.from(e.target.files);
 
@@ -199,7 +204,7 @@ export class GcdsFileUploader {
       }, 100);
     }
 
-    this.gcdsChange.emit(this.value);
+    this.gcdsInput.emit(this.value);
   };
 
   /**
@@ -420,7 +425,8 @@ export class GcdsFileUploader {
               {...attrsInput}
               onBlur={() => this.onBlur()}
               onFocus={() => this.gcdsFocus.emit()}
-              onChange={e => this.handleChange(e)}
+              onInput={e => this.handleInput(e)}
+              onChange={e => this.handleInput(e)}
               aria-invalid={hasError ? 'true' : 'false'}
               ref={element =>
                 (this.shadowElement = element as HTMLInputElement)

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -181,7 +181,7 @@ export class GcdsFileUploader {
   @Event() gcdsChange: EventEmitter;
 
   /**
-   * Emitted when the user has uplaoded a file.
+   * Emitted when the user has uploaded a file.
    */
   @Event() gcdsInput: EventEmitter;
 

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -176,7 +176,7 @@ export class GcdsFileUploader {
   };
 
   /**
-   * Update value based on user selection.
+   * Emitted when the user has made a file selection.
    */
   @Event() gcdsChange: EventEmitter;
 

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -162,10 +162,6 @@ export class GcdsFileUploader {
    */
   @Event() gcdsFocus!: EventEmitter<void>;
 
-  private onFocus = () => {
-    this.gcdsFocus.emit();
-  };
-
   /**
    * Emitted when the uploader loses focus.
    */
@@ -182,7 +178,7 @@ export class GcdsFileUploader {
   /**
    * Update value based on user selection.
    */
-  @Event() gcdsFileUploaderChange: EventEmitter;
+  @Event() gcdsChange: EventEmitter;
 
   handleChange = e => {
     const filesContainer: string[] = [];
@@ -203,7 +199,7 @@ export class GcdsFileUploader {
       }, 100);
     }
 
-    this.gcdsFileUploaderChange.emit(this.value);
+    this.gcdsChange.emit(this.value);
   };
 
   /**
@@ -423,7 +419,7 @@ export class GcdsFileUploader {
               id={uploaderId}
               {...attrsInput}
               onBlur={() => this.onBlur()}
-              onFocus={() => this.onFocus()}
+              onFocus={() => this.gcdsFocus.emit()}
               onChange={e => this.handleChange(e)}
               aria-invalid={hasError ? 'true' : 'false'}
               ref={element =>

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -31,6 +31,7 @@
 | `gcdsChange`     | Emitted when the user has made a file selection. | `CustomEvent<any>`    |
 | `gcdsError`      | Emitted when the input has a validation error.   | `CustomEvent<object>` |
 | `gcdsFocus`      | Emitted when the uploader has focus.             | `CustomEvent<void>`   |
+| `gcdsInput`      | Emitted when the user has uplaoded a file.       | `CustomEvent<any>`    |
 | `gcdsRemoveFile` | Remove file and update value.                    | `CustomEvent<any>`    |
 | `gcdsValid`      | Emitted when the input has a validation error.   | `CustomEvent<object>` |
 

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -25,14 +25,14 @@
 
 ## Events
 
-| Event                    | Description                                    | Type                  |
-| ------------------------ | ---------------------------------------------- | --------------------- |
-| `gcdsBlur`               | Emitted when the uploader loses focus.         | `CustomEvent<void>`   |
-| `gcdsError`              | Emitted when the input has a validation error. | `CustomEvent<object>` |
-| `gcdsFileUploaderChange` | Update value based on user selection.          | `CustomEvent<any>`    |
-| `gcdsFocus`              | Emitted when the uploader has focus.           | `CustomEvent<void>`   |
-| `gcdsRemoveFile`         | Remove file and update value.                  | `CustomEvent<any>`    |
-| `gcdsValid`              | Emitted when the input has a validation error. | `CustomEvent<object>` |
+| Event            | Description                                    | Type                  |
+| ---------------- | ---------------------------------------------- | --------------------- |
+| `gcdsBlur`       | Emitted when the uploader loses focus.         | `CustomEvent<void>`   |
+| `gcdsChange`     | Update value based on user selection.          | `CustomEvent<any>`    |
+| `gcdsError`      | Emitted when the input has a validation error. | `CustomEvent<object>` |
+| `gcdsFocus`      | Emitted when the uploader has focus.           | `CustomEvent<void>`   |
+| `gcdsRemoveFile` | Remove file and update value.                  | `CustomEvent<any>`    |
+| `gcdsValid`      | Emitted when the input has a validation error. | `CustomEvent<object>` |
 
 
 ## Methods

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -25,14 +25,14 @@
 
 ## Events
 
-| Event            | Description                                    | Type                  |
-| ---------------- | ---------------------------------------------- | --------------------- |
-| `gcdsBlur`       | Emitted when the uploader loses focus.         | `CustomEvent<void>`   |
-| `gcdsChange`     | Update value based on user selection.          | `CustomEvent<any>`    |
-| `gcdsError`      | Emitted when the input has a validation error. | `CustomEvent<object>` |
-| `gcdsFocus`      | Emitted when the uploader has focus.           | `CustomEvent<void>`   |
-| `gcdsRemoveFile` | Remove file and update value.                  | `CustomEvent<any>`    |
-| `gcdsValid`      | Emitted when the input has a validation error. | `CustomEvent<object>` |
+| Event            | Description                                      | Type                  |
+| ---------------- | ------------------------------------------------ | --------------------- |
+| `gcdsBlur`       | Emitted when the uploader loses focus.           | `CustomEvent<void>`   |
+| `gcdsChange`     | Emitted when the user has made a file selection. | `CustomEvent<any>`    |
+| `gcdsError`      | Emitted when the input has a validation error.   | `CustomEvent<object>` |
+| `gcdsFocus`      | Emitted when the uploader has focus.             | `CustomEvent<void>`   |
+| `gcdsRemoveFile` | Remove file and update value.                    | `CustomEvent<any>`    |
+| `gcdsValid`      | Emitted when the input has a validation error.   | `CustomEvent<object>` |
 
 
 ## Methods

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -31,7 +31,7 @@
 | `gcdsChange`     | Emitted when the user has made a file selection. | `CustomEvent<any>`    |
 | `gcdsError`      | Emitted when the input has a validation error.   | `CustomEvent<object>` |
 | `gcdsFocus`      | Emitted when the uploader has focus.             | `CustomEvent<void>`   |
-| `gcdsInput`      | Emitted when the user has uplaoded a file.       | `CustomEvent<any>`    |
+| `gcdsInput`      | Emitted when the user has uploaded a file.       | `CustomEvent<any>`    |
 | `gcdsRemoveFile` | Remove file and update value.                    | `CustomEvent<any>`    |
 | `gcdsValid`      | Emitted when the input has a validation error.   | `CustomEvent<object>` |
 

--- a/packages/web/src/components/gcds-hint/readme.md
+++ b/packages/web/src/components/gcds-hint/readme.md
@@ -19,13 +19,6 @@
 | `"hint"` |             |
 
 
-## Shadow Parts
-
-| Part     | Description |
-| -------- | ----------- |
-| `"hint"` |             |
-
-
 ## Dependencies
 
 ### Used by

--- a/packages/web/src/components/gcds-hint/readme.md
+++ b/packages/web/src/components/gcds-hint/readme.md
@@ -19,6 +19,13 @@
 | `"hint"` |             |
 
 
+## Shadow Parts
+
+| Part     | Description |
+| -------- | ----------- |
+| `"hint"` |             |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -190,15 +190,20 @@ export class GcdsInput {
   /**
    * Emitted when the input has received input.
    */
-  @Event() gcdsChange: EventEmitter;
+  @Event() gcdsInput: EventEmitter;
 
-  private handleChange(e) {
+  private handleInput(e) {
     const val = e.target && e.target.value;
     this.value = val;
     this.internals.setFormValue(val ? val : null);
 
-    this.gcdsChange.emit(this.value);
+    this.gcdsInput.emit(this.value);
   }
+
+  /**
+   * Emitted when the input has changed.
+   */
+  @Event() gcdsChange: EventEmitter;
 
   /**
    * Call any active validators
@@ -388,7 +393,8 @@ export class GcdsInput {
             name={name}
             onBlur={() => this.onBlur()}
             onFocus={() => this.gcdsFocus.emit()}
-            onInput={e => this.handleChange(e)}
+            onInput={e => this.handleInput(e)}
+            onChange={e => this.handleInput(e)}
             aria-labelledby={`label-for-${inputId}`}
             aria-invalid={errorMessage ? 'true' : 'false'}
             maxlength={size}

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -188,7 +188,7 @@ export class GcdsInput {
   };
 
   /**
-   * Update value based on user input.
+   * Emitted when the input has received input.
    */
   @Event() gcdsChange: EventEmitter;
 

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -188,7 +188,7 @@ export class GcdsInput {
   };
 
   /**
-   * Emitted when the input has received input.
+   * Emitted when the element has received input.
    */
   @Event() gcdsInput: EventEmitter;
 

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -30,9 +30,10 @@
 | Event        | Description                                    | Type                  |
 | ------------ | ---------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the input loses focus.            | `CustomEvent<void>`   |
-| `gcdsChange` | Emitted when the input has received input.     | `CustomEvent<any>`    |
+| `gcdsChange` | Emitted when the input has changed.            | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the input has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the input has focus.              | `CustomEvent<void>`   |
+| `gcdsInput`  | Emitted when the input has received input.     | `CustomEvent<any>`    |
 | `gcdsValid`  | Emitted when the input has a validation error. | `CustomEvent<object>` |
 
 

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -33,7 +33,7 @@
 | `gcdsChange` | Emitted when the input has changed.            | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the input has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the input has focus.              | `CustomEvent<void>`   |
-| `gcdsInput`  | Emitted when the input has received input.     | `CustomEvent<any>`    |
+| `gcdsInput`  | Emitted when the element has received input.   | `CustomEvent<any>`    |
 | `gcdsValid`  | Emitted when the input has a validation error. | `CustomEvent<object>` |
 
 

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -30,7 +30,7 @@
 | Event        | Description                                    | Type                  |
 | ------------ | ---------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the input loses focus.            | `CustomEvent<void>`   |
-| `gcdsChange` | Update value based on user input.              | `CustomEvent<any>`    |
+| `gcdsChange` | Emitted when the input has received input.     | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the input has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the input has focus.              | `CustomEvent<void>`   |
 | `gcdsValid`  | Emitted when the input has a validation error. | `CustomEvent<object>` |

--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -10,7 +10,7 @@ import {
   h,
 } from '@stencil/core';
 import { assignLanguage, observerConfig } from '../../utils/utils';
-import { inheritAttributes } from '../../utils/utils';
+import { inheritAttributes, emitEvent } from '../../utils/utils';
 import i18n from './i18n/i18n';
 
 @Component({
@@ -193,9 +193,9 @@ export class GcdsLink {
           rel={isExternal ? 'noopener noreferrer' : rel}
           {...inheritedAttributes}
           part="link"
-          onBlur={() => this.gcdsBlur.emit()}
-          onFocus={() => this.gcdsFocus.emit()}
-          onClick={() => this.gcdsClick.emit()}
+          onBlur={e => emitEvent(e, this.gcdsBlur)}
+          onFocus={e => emitEvent(e, this.gcdsFocus)}
+          onClick={e => emitEvent(e, this.gcdsClick, href)}
         >
           <slot></slot>
           {target === '_blank' || external ? (

--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -193,8 +193,8 @@ export class GcdsLink {
           rel={isExternal ? 'noopener noreferrer' : rel}
           {...inheritedAttributes}
           part="link"
-          onBlur={e => emitEvent(e, this.gcdsBlur)}
-          onFocus={e => emitEvent(e, this.gcdsFocus)}
+          onBlur={() => this.gcdsBlur.emit()}
+          onFocus={() => this.gcdsFocus.emit()}
           onClick={e => emitEvent(e, this.gcdsClick, href)}
         >
           <slot></slot>

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -10,7 +10,7 @@ import {
   Listen,
   h,
 } from '@stencil/core';
-import { assignLanguage, observerConfig } from '../../utils/utils';
+import { assignLanguage, observerConfig, emitEvent } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-nav-group',
@@ -43,9 +43,19 @@ export class GcdsNavGroup {
   @Prop({ reflect: true, mutable: true }) open: boolean = false;
 
   /**
-   * Emitted when the button has focus.
+   * Emitted when the button has been clicked.
    */
   @Event() gcdsClick!: EventEmitter<void>;
+
+  /**
+   * Emitted when the button has been focus.
+   */
+  @Event() gcdsFocus!: EventEmitter<void>;
+
+  /**
+   * Emitted when the button blurs.
+   */
+  @Event() gcdsBlur!: EventEmitter<void>;
 
   /**
    * Language of rendered component
@@ -144,9 +154,13 @@ export class GcdsNavGroup {
           aria-expanded={open.toString()}
           ref={element => (this.triggerElement = element as HTMLElement)}
           class={`gcds-nav-group__trigger gcds-trigger--${this.navStyle}`}
-          onClick={() => {
-            this.toggleNav();
-            this.gcdsClick.emit();
+          onBlur={e => emitEvent(e, this.gcdsBlur)}
+          onFocus={e => emitEvent(e, this.gcdsFocus)}
+          onClick={e => {
+            const event = emitEvent(e, this.gcdsClick);
+            if (event) {
+              this.toggleNav();
+            }
           }}
         >
           <gcds-icon name={open ? 'angle-up' : 'angle-down'}></gcds-icon>

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -154,8 +154,8 @@ export class GcdsNavGroup {
           aria-expanded={open.toString()}
           ref={element => (this.triggerElement = element as HTMLElement)}
           class={`gcds-nav-group__trigger gcds-trigger--${this.navStyle}`}
-          onBlur={e => emitEvent(e, this.gcdsBlur)}
-          onFocus={e => emitEvent(e, this.gcdsFocus)}
+          onBlur={() => this.gcdsBlur.emit()}
+          onFocus={() => this.gcdsFocus.emit()}
           onClick={e => {
             const event = emitEvent(e, this.gcdsClick);
             if (event) {

--- a/packages/web/src/components/gcds-nav-group/readme.md
+++ b/packages/web/src/components/gcds-nav-group/readme.md
@@ -17,9 +17,11 @@
 
 ## Events
 
-| Event       | Description                        | Type                |
-| ----------- | ---------------------------------- | ------------------- |
-| `gcdsClick` | Emitted when the button has focus. | `CustomEvent<void>` |
+| Event       | Description                               | Type                |
+| ----------- | ----------------------------------------- | ------------------- |
+| `gcdsBlur`  | Emitted when the button blurs.            | `CustomEvent<void>` |
+| `gcdsClick` | Emitted when the button has been clicked. | `CustomEvent<void>` |
+| `gcdsFocus` | Emitted when the button has been focus.   | `CustomEvent<void>` |
 
 
 ## Methods

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
@@ -108,8 +108,8 @@ export class GcdsNavLink {
           class={`gcds-nav-link gcds-nav-link--${this.navStyle}`}
           href={href}
           {...linkAttrs}
-          onBlur={e => emitEvent(e, this.gcdsBlur)}
-          onFocus={e => emitEvent(e, this.gcdsFocus)}
+          onBlur={() => this.gcdsBlur.emit()}
+          onFocus={() => this.gcdsFocus.emit()}
           onClick={e => emitEvent(e, this.gcdsClick, href)}
           ref={element => (this.linkElement = element as HTMLElement)}
         >

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
@@ -9,7 +9,7 @@ import {
   EventEmitter,
   h,
 } from '@stencil/core';
-import { assignLanguage, observerConfig } from '../../utils/utils';
+import { assignLanguage, observerConfig, emitEvent } from '../../utils/utils';
 
 @Component({
   tag: 'gcds-nav-link',
@@ -76,18 +76,6 @@ export class GcdsNavLink {
     observer.observe(this.el, observerConfig);
   }
 
-  private onClick = e => {
-    this.gcdsClick.emit(e);
-  };
-
-  private onFocus = e => {
-    this.gcdsFocus.emit(e);
-  };
-
-  private onBlur = e => {
-    this.gcdsBlur.emit(e);
-  };
-
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
@@ -120,9 +108,9 @@ export class GcdsNavLink {
           class={`gcds-nav-link gcds-nav-link--${this.navStyle}`}
           href={href}
           {...linkAttrs}
-          onBlur={e => this.onBlur(e)}
-          onFocus={e => this.onFocus(e)}
-          onClick={e => this.onClick(e)}
+          onBlur={e => emitEvent(e, this.gcdsBlur)}
+          onFocus={e => emitEvent(e, this.gcdsFocus)}
+          onClick={e => emitEvent(e, this.gcdsClick, href)}
           ref={element => (this.linkElement = element as HTMLElement)}
         >
           <slot></slot>

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
@@ -152,8 +152,8 @@ export class GcdsPagination {
               .replace('{#}', --page)
               .replace('{total}', this.totalPages)
               .replace('{label}', this.label)}`,
-      'onBlur': e => emitEvent(e, this.gcdsBlur),
-      'onFocus': e => emitEvent(e, this.gcdsFocus),
+      'onBlur': () => this.gcdsBlur.emit(),
+      'onFocus': () => this.gcdsFocus.emit(),
       'onClick': e => emitEvent(e, this.gcdsClick, { page: page, href }),
     };
 
@@ -395,8 +395,8 @@ export class GcdsPagination {
                     aria-label={`${I18N[lang].previousPage}${
                       previousLabel ? `: ${previousLabel}` : ''
                     }`}
-                    onBlur={e => emitEvent(e, this.gcdsBlur)}
-                    onFocus={e => emitEvent(e, this.gcdsFocus)}
+                    onBlur={() => this.gcdsBlur.emit()}
+                    onFocus={() => this.gcdsFocus.emit()}
                     onClick={e => emitEvent(e, this.gcdsClick, previousHref)}
                   >
                     <gcds-icon margin-right="200" name="arrow-left"></gcds-icon>
@@ -414,8 +414,8 @@ export class GcdsPagination {
                     aria-label={`${I18N[lang].nextPage}${
                       nextLabel ? `: ${nextLabel}` : ''
                     }`}
-                    onBlur={e => emitEvent(e, this.gcdsBlur)}
-                    onFocus={e => emitEvent(e, this.gcdsFocus)}
+                    onBlur={() => this.gcdsBlur.emit()}
+                    onFocus={() => this.gcdsFocus.emit()}
                     onClick={e => emitEvent(e, this.gcdsClick, nextHref)}
                   >
                     <div class="gcds-pagination-simple-text">

--- a/packages/web/src/components/gcds-pagination/readme.md
+++ b/packages/web/src/components/gcds-pagination/readme.md
@@ -14,7 +14,6 @@
 | `label` _(required)_ | `label`          | Navigation element label                                                | `string`             | `undefined` |
 | `nextHref`           | `next-href`      | Simple display - href for next link                                     | `string`             | `undefined` |
 | `nextLabel`          | `next-label`     | Simple display - lable for next link                                    | `string`             | `undefined` |
-| `pageChangeHandler`  | --               | Function to fire when pageChange event is called                        | `Function`           | `undefined` |
 | `previousHref`       | `previous-href`  | Simple display - href for previous link                                 | `string`             | `undefined` |
 | `previousLabel`      | `previous-label` | Simple display - label for previous link                                | `string`             | `undefined` |
 | `totalPages`         | `total-pages`    | List display - Total number of pages                                    | `number`             | `undefined` |
@@ -23,9 +22,11 @@
 
 ## Events
 
-| Event            | Description                       | Type                |
-| ---------------- | --------------------------------- | ------------------- |
-| `gcdsPageChange` | Update value based on user input. | `CustomEvent<void>` |
+| Event       | Description                             | Type                |
+| ----------- | --------------------------------------- | ------------------- |
+| `gcdsBlur`  | Emitted when the link loses focus.      | `CustomEvent<void>` |
+| `gcdsClick` | Emitted when the link has been clicked. | `CustomEvent<void>` |
+| `gcdsFocus` | Emitted when the link has focus.        | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-radio-group/gcds-radio-group.tsx
+++ b/packages/web/src/components/gcds-radio-group/gcds-radio-group.tsx
@@ -92,16 +92,12 @@ export class GcdsRadioGroup {
   /**
    * Emitted when the radio button is checked
    */
-  @Event() gcdsRadioChange!: EventEmitter<void>;
+  @Event() gcdsChange!: EventEmitter<void>;
 
   /**
    * Emitted when the radio has focus.
    */
   @Event() gcdsFocus!: EventEmitter<void>;
-
-  private onFocus = () => {
-    this.gcdsFocus.emit();
-  };
 
   /**
    * Emitted when the radio loses focus.
@@ -142,7 +138,7 @@ export class GcdsRadioGroup {
   }
 
   private onChange = e => {
-    this.gcdsRadioChange.emit();
+    this.gcdsChange.emit(e.target.value);
     this.internals.setFormValue(e.target.value, 'checked');
   };
 
@@ -206,7 +202,7 @@ export class GcdsRadioGroup {
                   {...attrsInput}
                   onChange={e => this.onChange(e)}
                   onBlur={() => this.onBlur()}
-                  onFocus={() => this.onFocus()}
+                  onFocus={() => this.gcdsFocus.emit()}
                   ref={element =>
                     (this.shadowElement = element as HTMLInputElement)
                   }

--- a/packages/web/src/components/gcds-radio-group/readme.md
+++ b/packages/web/src/components/gcds-radio-group/readme.md
@@ -15,11 +15,11 @@
 
 ## Events
 
-| Event             | Description                              | Type                |
-| ----------------- | ---------------------------------------- | ------------------- |
-| `gcdsBlur`        | Emitted when the radio loses focus.      | `CustomEvent<void>` |
-| `gcdsFocus`       | Emitted when the radio has focus.        | `CustomEvent<void>` |
-| `gcdsRadioChange` | Emitted when the radio button is checked | `CustomEvent<void>` |
+| Event        | Description                              | Type                |
+| ------------ | ---------------------------------------- | ------------------- |
+| `gcdsBlur`   | Emitted when the radio loses focus.      | `CustomEvent<void>` |
+| `gcdsChange` | Emitted when the radio button is checked | `CustomEvent<void>` |
+| `gcdsFocus`  | Emitted when the radio has focus.        | `CustomEvent<void>` |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-search/gcds-search.tsx
+++ b/packages/web/src/components/gcds-search/gcds-search.tsx
@@ -8,13 +8,13 @@ import {
   EventEmitter,
   h,
 } from '@stencil/core';
-import { assignLanguage, observerConfig } from '../../utils/utils';
+import { assignLanguage, observerConfig, emitEvent } from '../../utils/utils';
 import I18N from './i18n/I18N';
 
 @Component({
   tag: 'gcds-search',
   styleUrl: 'gcds-search.css',
-  shadow: true
+  shadow: true,
 })
 export class GcdsSearch {
   @Element() el: HTMLElement;
@@ -40,9 +40,14 @@ export class GcdsSearch {
   @Prop() name: string = 'q';
 
   /**
-   * Set the name of the search input
+   * Set the id of the search input
    */
   @Prop() searchId: string = 'search';
+
+  /**
+   * Set the value of the search input
+   */
+  @Prop({ mutable: true }) value: string;
 
   /**
    * Set a list of predefined search terms
@@ -56,7 +61,7 @@ export class GcdsSearch {
   /**
    * Emitted when the search input value has changed.
    */
-  @Event() gcdsChange!: EventEmitter<object>;
+  @Event() gcdsChange!: EventEmitter<string>;
 
   /**
    * Emitted when the search input value has gained focus.
@@ -78,6 +83,13 @@ export class GcdsSearch {
    */
   @State() lang: string;
 
+  private onInput = e => {
+    const input = e.target as HTMLInputElement;
+    this.value = input.value;
+
+    this.gcdsChange.emit(this.value);
+  };
+
   /*
    * Observe lang attribute change
    */
@@ -96,8 +108,16 @@ export class GcdsSearch {
   }
 
   render() {
-    const { placeholder, action, method, name, lang, searchId, suggested } =
-      this;
+    const {
+      placeholder,
+      action,
+      method,
+      name,
+      value,
+      lang,
+      searchId,
+      suggested,
+    } = this;
 
     const labelText = `${I18N[lang].searchLabel.replace('{$}', placeholder)}`;
 
@@ -119,7 +139,7 @@ export class GcdsSearch {
             action={formAction}
             method={method}
             role="search"
-            onSubmit={() => this.gcdsSubmit.emit()}
+            onSubmit={e => emitEvent(e, this.gcdsSubmit)}
             class="gcds-search__form"
           >
             <gcds-label
@@ -133,11 +153,12 @@ export class GcdsSearch {
               list="search-list"
               size={34}
               maxLength={170}
-              onChange={() => this.gcdsChange.emit()}
+              onInput={e => this.onInput(e)}
               onFocus={() => this.gcdsFocus.emit()}
               onBlur={() => this.gcdsBlur.emit()}
               {...attrsInput}
               class="gcds-search__input"
+              value={value}
             ></input>
 
             {suggested && (

--- a/packages/web/src/components/gcds-search/readme.md
+++ b/packages/web/src/components/gcds-search/readme.md
@@ -13,8 +13,9 @@
 | `method`      | `method`      | Set the form method of the search form                                             | `"get" \| "post"` | `'get'`          |
 | `name`        | `name`        | Set the name of the search input                                                   | `string`          | `'q'`            |
 | `placeholder` | `placeholder` | Set the placeholder and label for the search input. Becomes "Search [placeholder]" | `string`          | `'Canada.ca'`    |
-| `searchId`    | `search-id`   | Set the name of the search input                                                   | `string`          | `'search'`       |
+| `searchId`    | `search-id`   | Set the id of the search input                                                     | `string`          | `'search'`       |
 | `suggested`   | --            | Set a list of predefined search terms                                              | `string[]`        | `undefined`      |
+| `value`       | `value`       | Set the value of the search input                                                  | `string`          | `undefined`      |
 
 
 ## Events
@@ -22,7 +23,7 @@
 | Event        | Description                                           | Type                  |
 | ------------ | ----------------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the search input has lost focus.         | `CustomEvent<object>` |
-| `gcdsChange` | Emitted when the search input value has changed.      | `CustomEvent<object>` |
+| `gcdsChange` | Emitted when the search input value has changed.      | `CustomEvent<string>` |
 | `gcdsFocus`  | Emitted when the search input value has gained focus. | `CustomEvent<object>` |
 | `gcdsSubmit` | Emitted when the search form has submitted.           | `CustomEvent<object>` |
 

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -159,7 +159,7 @@ export class GcdsSelect {
    */
 
   /**
-   * Update value based on user selection.
+   * Emitted when the select value has changed.
    */
   @Event() gcdsChange: EventEmitter;
 

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -164,6 +164,19 @@ export class GcdsSelect {
   @Event() gcdsChange: EventEmitter;
 
   /**
+   * Emitted when the select has received input.
+   */
+  @Event() gcdsInput: EventEmitter;
+
+  handleInput = e => {
+    const val = e.target && e.target.value;
+    this.value = val;
+    this.internals.setFormValue(val);
+
+    this.gcdsInput.emit(this.value);
+  };
+
+  /**
    * Emitted when the select has focus.
    */
   @Event() gcdsFocus!: EventEmitter<void>;
@@ -220,14 +233,6 @@ export class GcdsSelect {
       }
     }
   }
-
-  handleChange = e => {
-    const val = e.target && e.target.value;
-    this.value = val;
-    this.internals.setFormValue(val);
-
-    this.gcdsChange.emit(this.value);
-  };
 
   /**
    * Check if an option is selected or value matches an option's value
@@ -380,7 +385,8 @@ export class GcdsSelect {
             id={selectId}
             onBlur={() => this.onBlur()}
             onFocus={() => this.gcdsFocus.emit()}
-            onInput={e => this.handleChange(e)}
+            onInput={e => this.handleInput(e)}
+            onChange={e => this.handleInput(e)}
             aria-invalid={hasError ? 'true' : 'false'}
             ref={element => (this.shadowElement = element as HTMLSelectElement)}
           >

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -161,16 +161,12 @@ export class GcdsSelect {
   /**
    * Update value based on user selection.
    */
-  @Event() gcdsSelectChange: EventEmitter;
+  @Event() gcdsChange: EventEmitter;
 
   /**
    * Emitted when the select has focus.
    */
   @Event() gcdsFocus!: EventEmitter<void>;
-
-  private onFocus = () => {
-    this.gcdsFocus.emit();
-  };
 
   /**
    * Emitted when the select loses focus.
@@ -230,7 +226,7 @@ export class GcdsSelect {
     this.value = val;
     this.internals.setFormValue(val);
 
-    this.gcdsSelectChange.emit(this.value);
+    this.gcdsChange.emit(this.value);
   };
 
   /**
@@ -383,8 +379,8 @@ export class GcdsSelect {
             {...attrsSelect}
             id={selectId}
             onBlur={() => this.onBlur()}
-            onFocus={() => this.onFocus()}
-            onChange={e => this.handleChange(e)}
+            onFocus={() => this.gcdsFocus.emit()}
+            onInput={e => this.handleChange(e)}
             aria-invalid={hasError ? 'true' : 'false'}
             ref={element => (this.shadowElement = element as HTMLSelectElement)}
           >

--- a/packages/web/src/components/gcds-select/readme.md
+++ b/packages/web/src/components/gcds-select/readme.md
@@ -27,7 +27,7 @@
 | Event        | Description                                     | Type                  |
 | ------------ | ----------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the select loses focus.            | `CustomEvent<void>`   |
-| `gcdsChange` | Update value based on user selection.           | `CustomEvent<any>`    |
+| `gcdsChange` | Emitted when the select value has changed.      | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the select has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the select has focus.              | `CustomEvent<void>`   |
 | `gcdsValid`  | Emitted when the select has a validation error. | `CustomEvent<object>` |

--- a/packages/web/src/components/gcds-select/readme.md
+++ b/packages/web/src/components/gcds-select/readme.md
@@ -30,6 +30,7 @@
 | `gcdsChange` | Emitted when the select value has changed.      | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the select has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the select has focus.              | `CustomEvent<void>`   |
+| `gcdsInput`  | Emitted when the select has received input.     | `CustomEvent<any>`    |
 | `gcdsValid`  | Emitted when the select has a validation error. | `CustomEvent<object>` |
 
 

--- a/packages/web/src/components/gcds-select/readme.md
+++ b/packages/web/src/components/gcds-select/readme.md
@@ -24,13 +24,13 @@
 
 ## Events
 
-| Event              | Description                                     | Type                  |
-| ------------------ | ----------------------------------------------- | --------------------- |
-| `gcdsBlur`         | Emitted when the select loses focus.            | `CustomEvent<void>`   |
-| `gcdsError`        | Emitted when the select has a validation error. | `CustomEvent<object>` |
-| `gcdsFocus`        | Emitted when the select has focus.              | `CustomEvent<void>`   |
-| `gcdsSelectChange` | Update value based on user selection.           | `CustomEvent<any>`    |
-| `gcdsValid`        | Emitted when the select has a validation error. | `CustomEvent<object>` |
+| Event        | Description                                     | Type                  |
+| ------------ | ----------------------------------------------- | --------------------- |
+| `gcdsBlur`   | Emitted when the select loses focus.            | `CustomEvent<void>`   |
+| `gcdsChange` | Update value based on user selection.           | `CustomEvent<any>`    |
+| `gcdsError`  | Emitted when the select has a validation error. | `CustomEvent<object>` |
+| `gcdsFocus`  | Emitted when the select has focus.              | `CustomEvent<void>`   |
+| `gcdsValid`  | Emitted when the select has a validation error. | `CustomEvent<object>` |
 
 
 ## Methods

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -187,7 +187,7 @@ export class GcdsTextarea {
   };
 
   /**
-   * Update value based on user input.
+   * Emitted when the textarea has received input.
    */
   @Event() gcdsChange: EventEmitter;
 

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -187,12 +187,12 @@ export class GcdsTextarea {
   };
 
   /**
-   * Emitted when the textarea has received input.
+   * Emitted when the textarea has changed.
    */
   @Event() gcdsChange: EventEmitter;
 
   /**
-   * Emitted when the textarea has changed.
+   * Emitted when the textarea has received input.
    */
   @Event() gcdsInput: EventEmitter;
 

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -173,10 +173,6 @@ export class GcdsTextarea {
    */
   @Event() gcdsFocus!: EventEmitter<void>;
 
-  private onFocus = () => {
-    this.gcdsFocus.emit();
-  };
-
   /**
    * Emitted when the textarea loses focus.
    */
@@ -378,7 +374,7 @@ export class GcdsTextarea {
             class={hasError ? 'gcds-error' : null}
             id={textareaId}
             onBlur={() => this.onBlur()}
-            onFocus={() => this.onFocus()}
+            onFocus={() => this.gcdsFocus.emit()}
             onInput={e => this.handleChange(e)}
             aria-labelledby={`label-for-${textareaId}`}
             aria-invalid={errorMessage ? 'true' : 'false'}

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -192,6 +192,19 @@ export class GcdsTextarea {
   @Event() gcdsChange: EventEmitter;
 
   /**
+   * Emitted when the textarea has changed.
+   */
+  @Event() gcdsInput: EventEmitter;
+
+  handleInput(e) {
+    const val = e.target && e.target.value;
+    this.value = val;
+    this.internals.setFormValue(val ? val : null);
+
+    this.gcdsInput.emit(this.value);
+  }
+
+  /**
    * Call any active validators
    */
   @Method()
@@ -206,14 +219,6 @@ export class GcdsTextarea {
       this.errorMessage = '';
       this.gcdsValid.emit({ id: `#${this.textareaId}` });
     }
-  }
-
-  handleChange(e) {
-    const val = e.target && e.target.value;
-    this.value = val;
-    this.internals.setFormValue(val ? val : null);
-
-    this.gcdsChange.emit(this.value);
   }
 
   /**
@@ -375,7 +380,8 @@ export class GcdsTextarea {
             id={textareaId}
             onBlur={() => this.onBlur()}
             onFocus={() => this.gcdsFocus.emit()}
-            onInput={e => this.handleChange(e)}
+            onInput={e => this.handleInput(e)}
+            onChange={e => this.handleInput(e)}
             aria-labelledby={`label-for-${textareaId}`}
             aria-invalid={errorMessage ? 'true' : 'false'}
             maxlength={characterCount ? characterCount : null}

--- a/packages/web/src/components/gcds-textarea/readme.md
+++ b/packages/web/src/components/gcds-textarea/readme.md
@@ -30,7 +30,7 @@
 | Event        | Description                                       | Type                  |
 | ------------ | ------------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the textarea loses focus.            | `CustomEvent<void>`   |
-| `gcdsChange` | Update value based on user input.                 | `CustomEvent<any>`    |
+| `gcdsChange` | Emitted when the textarea has received input.     | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the textarea has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the textarea has focus.              | `CustomEvent<void>`   |
 | `gcdsValid`  | Emitted when the textarea has a validation error. | `CustomEvent<object>` |

--- a/packages/web/src/components/gcds-textarea/readme.md
+++ b/packages/web/src/components/gcds-textarea/readme.md
@@ -33,6 +33,7 @@
 | `gcdsChange` | Emitted when the textarea has received input.     | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the textarea has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the textarea has focus.              | `CustomEvent<void>`   |
+| `gcdsInput`  | Emitted when the textarea has changed.            | `CustomEvent<any>`    |
 | `gcdsValid`  | Emitted when the textarea has a validation error. | `CustomEvent<object>` |
 
 

--- a/packages/web/src/components/gcds-textarea/readme.md
+++ b/packages/web/src/components/gcds-textarea/readme.md
@@ -30,10 +30,10 @@
 | Event        | Description                                       | Type                  |
 | ------------ | ------------------------------------------------- | --------------------- |
 | `gcdsBlur`   | Emitted when the textarea loses focus.            | `CustomEvent<void>`   |
-| `gcdsChange` | Emitted when the textarea has received input.     | `CustomEvent<any>`    |
+| `gcdsChange` | Emitted when the textarea has changed.            | `CustomEvent<any>`    |
 | `gcdsError`  | Emitted when the textarea has a validation error. | `CustomEvent<object>` |
 | `gcdsFocus`  | Emitted when the textarea has focus.              | `CustomEvent<void>`   |
-| `gcdsInput`  | Emitted when the textarea has changed.            | `CustomEvent<any>`    |
+| `gcdsInput`  | Emitted when the textarea has received input.     | `CustomEvent<any>`    |
 | `gcdsValid`  | Emitted when the textarea has a validation error. | `CustomEvent<object>` |
 
 

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -99,8 +99,8 @@ export const emitEvent = (
 ) => {
   const event = customEvent.emit(value);
 
-  // Was the custom event interrupted
-  if (event.defaultPrevented) {
+  // Was the custom or native event interrupted
+  if (event.defaultPrevented || e.defaultPrevented) {
     // Stop native HTML event in shadow-dom
     e.preventDefault();
     return false;

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -91,6 +91,7 @@ export const elementGroupCheck = name => {
 };
 
 // Emit event with logic to cancel HTML events
+// Returns false if event has been prevented
 export const emitEvent = (
   e: Event,
   customEvent: EventEmitter,

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from '@stencil/core';
+
 export function format(label: string): string {
   return label ? ` ${label}` : 'Fallback Button Label';
 }
@@ -86,4 +88,22 @@ export const elementGroupCheck = name => {
     }
   }
   return !hasCheck;
+};
+
+// Emit event with logic to cancel HTML events
+export const emitEvent = (
+  e: Event,
+  customEvent: EventEmitter,
+  value?: unknown,
+) => {
+  const event = customEvent.emit(value);
+
+  // Was the custom event interrupted
+  if (event.defaultPrevented) {
+    // Stop native HTML event in shadow-dom
+    e.preventDefault();
+    return false;
+  }
+
+  return true;
 };


### PR DESCRIPTION
# Summary | Résumé

Went through the interactive components to make sure event naming and firing(emitting) behaviour was consistent between components. Also created a `emitEvent` utility function that will properly cancel cancelled events if either the gcds custom event or the native HTML event has been prevented.

## Changes

### `emitEvent` function

``` js
// Emit event with logic to cancel HTML events
// Returns false if event has been prevented
export const emitEvent = (
  e: Event,
  customEvent: EventEmitter,
  value?: unknown,
) => {
  const event = customEvent.emit(value);

  // Was the custom or native event interrupted
  if (event.defaultPrevented || e.defaultPrevented) {
    // Stop native HTML event in shadow-dom
    e.preventDefault();
    return false;
  }

  return true;
};
```

The `emitEvent` function allows the developer to cancel either the native HTML event or the gcds custom event in the `gcds-components`. An example would be using the `gcds-link` component, a developer would be able to use `e.preventDefault()` on either `click` or the `gcdsClick` event to stop the event from firing.

Does not need to be applied to every event since not all HTML events are cancellable.

### General component changes

- removed extra `onFocus` private method from several components to clean up the code
- Renamed some events to `gcdsChnage` to be consistent between eachother. Example: `gcdsFileUploaderChange` is now `gcdsChange`
- Added `toggle` method to `gcds-details` to allow toggling by code. This will allow developers to create an accordion style pattern.
- Added relevant information to the details of custom events. Example:
  - `gcds-link` click event now contains the `href` of the link. 
  - `gcds-pagination type="list"` now contains `{ page: page number, href }` in event details 