### PR TITLE
fix: undefined custom elements in SSR package

### DIFF
--- a/packages/react-ssr/scripts/utils.ts
+++ b/packages/react-ssr/scripts/utils.ts
@@ -65,7 +65,7 @@ import { ${defineCustomElementFunction} } from '${importPath}';
 import { omitEventCallbacks, useEventListeners, gcdsAttributeGenerator } from './lib/utils.js';
 import { GcdsWrapper } from './lib/client';
 
-if (!customElements.get('${elementName}')) {
+if(typeof customElements !== 'undefined' && !customElements.get('${elementName}')) {
   ${defineCustomElementFunction}();
 }
 


### PR DESCRIPTION
# Summary | Résumé
Was getting this error, this change fixes it
```bash
 ⨯ ../gcds-components/packages/react-ssr/dist/esm/gcds-alert.js (14:1) @ eval
 ⨯ ReferenceError: customElements is not defined
    at eval (../../gcds-components/packages/react-ssr/dist/esm/gcds-alert.js:24:1)
    at (ssr)/../../gcds-components/packages/react-ssr/dist/esm/gcds-alert.js (/Users/daine-rosetrinidad/projects/gcds/gcds-examples/example/.next/server/app/page.js:822:1)
    at __webpack_require__ (/Users/daine-rosetrinidad/projects/gcds/gcds-examples/example/.next/server/webpack-runtime.js:33:42)
    at eval (../../gcds-components/packages/react-ssr/dist/esm/index.js:44:69)
    at (ssr)/../../gcds-components/packages/react-ssr/dist/esm/index.js (/Users/daine-rosetrinidad/projects/gcds/gcds-examples/example/.next/server/app/page.js:1262:1)
    at __webpack_require__ (/Users/daine-rosetrinidad/projects/gcds/gcds-examples/example/.next/server/webpack-runtime.js:33:42)
    at eval (./app/components/client/Heading.tsx:7:91)
    at (ssr)/./app/components/client/Heading.tsx (/Users/daine-rosetrinidad/projects/gcds/gcds-examples/example/.next/server/app/page.js:1295:1)
    at Object.__webpack_require__ [as require] (/Users/daine-rosetrinidad/projects/gcds/gcds-examples/example/.next/server/webpack-runtime.js:33:42)
digest: "2237547932"
  12 | //   return;
  13 | // }
> 14 | if(!customElements.get('gcds-alert')) {
     | ^
  15 |   console.log("[GCDS React SSR] call defineCustomElement function")
  16 |
  17 |   defineCustomElement();
```