### PR TITLE
docs: add new contributions template for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributions.yml
+++ b/.github/ISSUE_TEMPLATE/contributions.yml
@@ -11,8 +11,6 @@ body:
           required: true
         - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
           required: true
-        - label: I've searched for [existing issues](https://github.com/cds-snc/gcds-components/issues) that already report this problem, without success.
-          required: true
   - type: dropdown
     id: contribution-type
     attributes:

--- a/.github/ISSUE_TEMPLATE/contributions.yml
+++ b/.github/ISSUE_TEMPLATE/contributions.yml
@@ -1,0 +1,30 @@
+name: 👷 Contribute to next priorities
+description: Help us with our work on our next priorities 
+title: 'contribution: '
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: Complete all of the following.
+      options:
+        - label: I've read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
+          required: true
+        - label: I've searched for [existing issues](https://github.com/cds-snc/gcds-components/issues) that already report this problem, without success.
+          required: true
+  - type: dropdown
+    id: contribution-type
+    attributes:
+      label: Which component or pattern is this contribution for?
+      options:
+        - Data Table
+        - Card (v2)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe your contribution.
+      description: Attach screenshots, or a detailed description of your contribution.
+    validations:
+      required: true


### PR DESCRIPTION
# Summary | Résumé
This adds a template to let users submit contributions

Fixes:
- https://github.com/cds-snc/design-gc-conception/issues/709

More info in this [google doc (section next priorities)](https://docs.google.com/document/d/1UPjV8DQkvb8a40-BulgPJbwmv6z_64cx06QnqI1qL5c/edit)