### PR TITLE
 fix: types error on build

### DIFF
--- a/packages/react-ssr/scripts/utils.ts
+++ b/packages/react-ssr/scripts/utils.ts
@@ -183,7 +183,7 @@ ${NATIVE_GLOBAL_EVENTS.map(
   (eventName) => `on${toPascalCase(eventName)}: (event: GlobalEventHandlersEventMap['${eventName}']) => void`,
 ).join(',\n')}
 };
-type IsEnum<T> = T extends ${enums.join(' | ')} ? true : false;
+${isEnum(enums)}
 type EnumsToStringLiterals<T> = {
   [K in keyof T]: Exclude<IsEnum<T[K]> extends true ? \`\${T[K]}\` : T[K], 'undefined'>;
 };
@@ -192,6 +192,8 @@ ${elements.map((elementName) => toTypeDeclaration(elementName, customEvents[elem
 
 ${toExport(elements.map(toPascalCase).join(',\n'))}
 `;
+
+export const isEnum = (enums) => (enums.length > 0 ? `type IsEnum<T> = T extends ${enums.join(' | ')} ? true : false;` : '');
 
 export const toIndexFile = (modules: string[]) => `${modules.map((module) => `export * from './${module}';`).join('\n')}\n`;
 


### PR DESCRIPTION
# Summary | Résumé
Getting this error when building my nextjs app:
```bash
Type error: '?' expected.

  69 | onWheel: (event: GlobalEventHandlersEventMap['wheel']) => void
  70 | };
> 71 | type IsEnum<T> = T extends  ? true : false;
     |                                    ^
  72 | type EnumsToStringLiterals<T> = {
  73 |   [K in keyof T]: Exclude<IsEnum<T[K]> extends true ? `${T[K]}` : T[K], 'undefined'>;
  74 | };
```

Looks like it's supposed to have an enum after `extends`, so moved the code into a function so it doesn't get written if the enum array is empty