### PR TITLE
fix: emit proper events onChange

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -871,12 +871,16 @@ export class GcdsSearch {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsChange', 'gcdsFocus', 'gcdsBlur', 'gcdsSubmit']);
+    proxyOutputs(this, this.el, ['gcdsInput', 'gcdsChange', 'gcdsFocus', 'gcdsBlur', 'gcdsSubmit']);
   }
 }
 
 
 export declare interface GcdsSearch extends Components.GcdsSearch {
+  /**
+   * Emitted when the search element has recieved input.
+   */
+  gcdsInput: EventEmitter<CustomEvent<string>>;
   /**
    * Emitted when the search input value has changed.
    */

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1544,6 +1544,7 @@ declare global {
         new (): HTMLGcdsRadioGroupElement;
     };
     interface HTMLGcdsSearchElementEventMap {
+        "gcdsInput": string;
         "gcdsChange": string;
         "gcdsFocus": object;
         "gcdsBlur": object;
@@ -2706,6 +2707,10 @@ declare namespace LocalJSX {
           * Emitted when the search input value has gained focus.
          */
         "onGcdsFocus"?: (event: GcdsSearchCustomEvent<object>) => void;
+        /**
+          * Emitted when the search element has recieved input.
+         */
+        "onGcdsInput"?: (event: GcdsSearchCustomEvent<string>) => void;
         /**
           * Emitted when the search form has submitted.
          */

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -185,7 +185,7 @@ export class GcdsFileUploader {
    */
   @Event() gcdsInput: EventEmitter;
 
-  handleInput = e => {
+  private handleInput = (e, customEvent) => {
     const filesContainer: string[] = [];
     const files = Array.from(e.target.files);
 
@@ -204,7 +204,7 @@ export class GcdsFileUploader {
       }, 100);
     }
 
-    this.gcdsInput.emit(this.value);
+    customEvent.emit(this.value);
   };
 
   /**
@@ -425,8 +425,8 @@ export class GcdsFileUploader {
               {...attrsInput}
               onBlur={() => this.onBlur()}
               onFocus={() => this.gcdsFocus.emit()}
-              onInput={e => this.handleInput(e)}
-              onChange={e => this.handleInput(e)}
+              onInput={e => this.handleInput(e, this.gcdsInput)}
+              onChange={e => this.handleInput(e, this.gcdsChange)}
               aria-invalid={hasError ? 'true' : 'false'}
               ref={element =>
                 (this.shadowElement = element as HTMLInputElement)

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -192,12 +192,12 @@ export class GcdsInput {
    */
   @Event() gcdsInput: EventEmitter;
 
-  private handleInput(e) {
+  private handleInput = (e, customEvent) => {
     const val = e.target && e.target.value;
     this.value = val;
     this.internals.setFormValue(val ? val : null);
 
-    this.gcdsInput.emit(this.value);
+    customEvent.emit(this.value);
   }
 
   /**
@@ -393,8 +393,8 @@ export class GcdsInput {
             name={name}
             onBlur={() => this.onBlur()}
             onFocus={() => this.gcdsFocus.emit()}
-            onInput={e => this.handleInput(e)}
-            onChange={e => this.handleInput(e)}
+            onInput={e => this.handleInput(e, this.gcdsInput)}
+            onChange={e => this.handleInput(e, this.gcdsChange)}
             aria-labelledby={`label-for-${inputId}`}
             aria-invalid={errorMessage ? 'true' : 'false'}
             maxlength={size}

--- a/packages/web/src/components/gcds-search/gcds-search.tsx
+++ b/packages/web/src/components/gcds-search/gcds-search.tsx
@@ -59,6 +59,11 @@ export class GcdsSearch {
    */
 
   /**
+   * Emitted when the search element has recieved input.
+   */
+  @Event() gcdsInput!: EventEmitter<string>;
+
+  /**
    * Emitted when the search input value has changed.
    */
   @Event() gcdsChange!: EventEmitter<string>;
@@ -83,11 +88,11 @@ export class GcdsSearch {
    */
   @State() lang: string;
 
-  private onInput = e => {
+  private handleInput = (e, customEvent) => {
     const input = e.target as HTMLInputElement;
     this.value = input.value;
 
-    this.gcdsChange.emit(this.value);
+    customEvent.emit(this.value);
   };
 
   /*
@@ -139,7 +144,7 @@ export class GcdsSearch {
             action={formAction}
             method={method}
             role="search"
-            onSubmit={e => emitEvent(e, this.gcdsSubmit)}
+            onSubmit={e => emitEvent(e, this.gcdsSubmit, this.value)}
             class="gcds-search__form"
           >
             <gcds-label
@@ -153,7 +158,8 @@ export class GcdsSearch {
               list="search-list"
               size={34}
               maxLength={170}
-              onInput={e => this.onInput(e)}
+              onInput={e => this.handleInput(e, this.gcdsInput)}
+              onChange={e => this.handleInput(e, this.gcdsChange)}
               onFocus={() => this.gcdsFocus.emit()}
               onBlur={() => this.gcdsBlur.emit()}
               {...attrsInput}

--- a/packages/web/src/components/gcds-search/readme.md
+++ b/packages/web/src/components/gcds-search/readme.md
@@ -25,6 +25,7 @@
 | `gcdsBlur`   | Emitted when the search input has lost focus.         | `CustomEvent<object>` |
 | `gcdsChange` | Emitted when the search input value has changed.      | `CustomEvent<string>` |
 | `gcdsFocus`  | Emitted when the search input value has gained focus. | `CustomEvent<object>` |
+| `gcdsInput`  | Emitted when the search element has recieved input.   | `CustomEvent<string>` |
 | `gcdsSubmit` | Emitted when the search form has submitted.           | `CustomEvent<object>` |
 
 

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -168,12 +168,12 @@ export class GcdsSelect {
    */
   @Event() gcdsInput: EventEmitter;
 
-  handleInput = e => {
+  private handleInput = (e, customEvent) => {
     const val = e.target && e.target.value;
     this.value = val;
     this.internals.setFormValue(val);
 
-    this.gcdsInput.emit(this.value);
+    customEvent.emit(this.value);
   };
 
   /**
@@ -385,8 +385,8 @@ export class GcdsSelect {
             id={selectId}
             onBlur={() => this.onBlur()}
             onFocus={() => this.gcdsFocus.emit()}
-            onInput={e => this.handleInput(e)}
-            onChange={e => this.handleInput(e)}
+            onInput={e => this.handleInput(e, this.gcdsInput)}
+            onChange={e => this.handleInput(e, this.gcdsChange)}
             aria-invalid={hasError ? 'true' : 'false'}
             ref={element => (this.shadowElement = element as HTMLSelectElement)}
           >

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -196,12 +196,12 @@ export class GcdsTextarea {
    */
   @Event() gcdsInput: EventEmitter;
 
-  handleInput(e) {
+  private handleInput = (e, customEvent) => {
     const val = e.target && e.target.value;
     this.value = val;
     this.internals.setFormValue(val ? val : null);
 
-    this.gcdsInput.emit(this.value);
+    customEvent.emit(this.value);
   }
 
   /**
@@ -380,8 +380,8 @@ export class GcdsTextarea {
             id={textareaId}
             onBlur={() => this.onBlur()}
             onFocus={() => this.gcdsFocus.emit()}
-            onInput={e => this.handleInput(e)}
-            onChange={e => this.handleInput(e)}
+            onInput={e => this.handleInput(e, this.gcdsInput)}
+            onChange={e => this.handleInput(e, this.gcdsChange)}
             aria-labelledby={`label-for-${textareaId}`}
             aria-invalid={errorMessage ? 'true' : 'false'}
             maxlength={characterCount ? characterCount : null}


### PR DESCRIPTION
# Summary | Résumé

Noticed with recent event refactor the `gcdsChange` event wasn't actually being emitted, the `gcdsInput` event was being emitted on the `onChange` event.
