### PR TITLE
fix(ssr): render issues

### DIFF
--- a/packages/react-ssr/lib/client/index.ts
+++ b/packages/react-ssr/lib/client/index.ts
@@ -2,11 +2,18 @@
 
 import { PropsWithChildren } from 'react';
 
-// Must go in a client component
-// > Otherwise will error:
-// > Attempted to call the default export of ... from the server but it's on the client.
-// > It's not possible to invoke a client function from the server, it can only be rendered
-// > as a Component or passed to props of a Client Component.
+/**
+ * GcdsWrapper for GCDS Components used in React with SSR
+ * @param children These are the nodes to render in SSR
+ * @returns The rendered nodes
+ *
+ * Notes from https://github.com/luwes/wesc/blob/main/src/dom/react/index.js
+ * // Must go in a client component
+ * // > Otherwise will error:
+ * // > Attempted to call the default export of ... from the server but it's on the client.
+ * // > It's not possible to invoke a client function from the server, it can only be rendered
+ * // > as a Component or passed to props of a Client Component.
+ */
 export function GcdsWrapper({ children }: PropsWithChildren) {
   if (typeof window === 'undefined') {
     // eslint-disable-next-line import/no-unresolved
@@ -17,6 +24,14 @@ export function GcdsWrapper({ children }: PropsWithChildren) {
 }
 
 /* eslint-disable */
+/**
+ * From https://github.com/luwes/wesc/blob/main/src/dom/react/index.js
+ * Resolve vdom tree and create node copies because the original objects are immutable in dev.
+ *
+ * @param  {Array|object}  children
+ * @param  {Array}         result
+ * @return {Array}
+ */
 function resolve(children: any, result: any[] = []) {
   const nodes: any[] = [].concat(children ?? []);
 
@@ -42,7 +57,15 @@ function resolve(children: any, result: any[] = []) {
         resolve(node.type(node.props), result);
       }
     } else if (typeof node.type === 'object' && typeof node.type.render === 'function') {
-      resolve(node.type.render(node.props), result);
+      if (node.ref || /^(.)*(forwardedRef)(.)*/.test(node.type.render.toString())) {
+        // Function component with a forwardedRef
+        if(process.env.NODE_ENV == "development") {
+          console.log("Found a forwardedRef but unable to render it.")
+        }
+      } else {
+        // Function component
+        resolve(node.type.render(node.props), result);
+      }
     }
   }
 

--- a/packages/react-ssr/lib/client/index.ts
+++ b/packages/react-ssr/lib/client/index.ts
@@ -22,7 +22,7 @@ function resolve(children: any, result: any[] = []) {
 
   for (const node of nodes) {
     if (typeof node === 'string') {
-      result.push(node);
+      result.push([node]);
     } else if (typeof node.type === 'string') {
       const copy = { ...node, props: { ...node.props } };
       if (copy.props.children) {

--- a/packages/react-ssr/lib/server.ts
+++ b/packages/react-ssr/lib/server.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+/**
+ * Define client-only functions, objects and variables, so they don't cause any
+ * undefined errors when rendering from the server side
+ */
 
 // Original code from https://github.com/luwes/wesc
 


### PR DESCRIPTION
# Summary
_Fix a render issue on a node that's just a string_
Found a render issue when I'm using the PhaseBanner inside the Header component
```
 ⨯ TypeError: Cannot read properties of null (reading 'useContext')
    at resolve (../../gcds-components/packages/react-ssr/dist/esm/lib/client/index.js:43:31)
    at resolve (../../gcds-components/packages/react-ssr/dist/esm/lib/client/index.js:28:13)
    at resolve (../../gcds-components/packages/react-ssr/dist/esm/lib/client/index.js:43:13)
    at eval (../../gcds-components/packages/react-ssr/dist/esm/lib/client/index.js:7:385)
digest: "3024408193"
```
Also found a render issue if you attempted to add a component that uses forwardRefs like the Link component from NextJS. Didn't find a fix for it, but I added the conditional logic to handle it once we have the fix so it's easier to go back to.