### PR TITLE
refactor: revert style changes to error summary

### DIFF
--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
@@ -1,4 +1,4 @@
-@layer reset, default, focus, compact;
+@layer reset, default, compact;
 
 @layer reset {
   :host {
@@ -36,18 +36,12 @@
           &:not(:last-child) {
             padding: var(--gcds-error-summary-list-item-padding);
           }
+
+          gcds-link::part(link):not(:focus) {
+            color: var(--gcds-error-summary-link-color);
+          }
         }
       }
-    }
-  }
-}
-
-@layer focus {
-  :host .gcds-error-summary:is(:focus, :has(:focus-within)) {
-    border-color: var(--gcds-error-summary-focus-color);
-
-    gcds-heading {
-      color: var(--gcds-error-summary-focus-color);
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Revert style changes to error summary:

- Links are red with our regular focus state for links
- Border is red
- Focus does not focus border
- Remove focus text colour from heading when component is in focus

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/899)