### PR TITLE
chore(storybook): Add prop template to gcds-radio-group

### DIFF
--- a/packages/web/src/components/gcds-radio-group/stories/gcds-radio-group.stories.tsx
+++ b/packages/web/src/components/gcds-radio-group/stories/gcds-radio-group.stories.tsx
@@ -150,6 +150,16 @@ Error.args = {
   lang: 'en',
 };
 
+export const Props = Template.bind({});
+Props.args = {
+  name: 'radioDefault',
+  options: `[
+    { "label": "Label for radio 1", "id": "radio1", "value": "radio1", "hint": "Description or example to make the option clearer."},
+    { "label": "Label for radio 2", "id": "radio2", "value": "radio2", "hint": "Description or example to make the option clearer."}
+  ]`,
+  lang: 'en',
+};
+
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   name: 'radio',


### PR DESCRIPTION
# Summary | Résumé

Add prop template to render events and properties for `gcds-radio-group` in storybook.
