### PR TITLE
feat: Add dist-hyrdate-app output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 www/
 loader/
+hydrate/
 /tmp
 /out-tsc
 /bazel-out

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,7 +14,8 @@
   "unpkg": "dist/stencil-starter-project-name/stencil-starter-project-name.esm.js",
   "files": [
     "dist/",
-    "loader/"
+    "loader/",
+    "hydrate"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -34,6 +34,9 @@ export const config: Config = {
     {
       type: 'docs-readme',
     },
+    {
+      type: 'dist-hydrate-script',
+    },
   ],
   plugins: [
     postcss({


### PR DESCRIPTION
# Summary | Résumé

Add the `dist-hydrate-script` output to web components package. This will allow developers the tools to be able to render the Stencil web components on the server side in different frameworks available from `@cdssnc/gcds-components/hydrate`.
