### PR TITLE
chore: add HTML to storybook code preview

### DIFF
--- a/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
@@ -40,7 +40,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-breadcrumbs ${args.hideCanadaLink ? `hide-canada-link` : null} ${
     args.lang != 'en' ? `lang="${args.lang}"` : null
   }>

--- a/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
+++ b/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
@@ -133,7 +133,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-button ${args.type != 'button' ? `type="${args.type}"` : null} ${
     args.buttonRole != 'primary' ? `button-role="${args.buttonRole}"` : null
   } ${args.buttonId ? `button-id="${args.buttonId}"` : null} ${

--- a/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
@@ -83,7 +83,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-card
   card-title="${args.cardTitle}"
   ${args.href ? `href="${args.href}"` : null}

--- a/packages/web/src/components/gcds-checkbox/stories/gcds-checkbox.stories.tsx
+++ b/packages/web/src/components/gcds-checkbox/stories/gcds-checkbox.stories.tsx
@@ -119,7 +119,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-checkbox
   checkbox-id="${args.checkboxId}"
   label="${args.label}"

--- a/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
+++ b/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
@@ -99,7 +99,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-container ${args.size != 'full' ? `size="${args.size}"` : null} ${
     args.border ? 'border' : null
   } ${args.centered ? 'centered' : null} ${

--- a/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
+++ b/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
@@ -29,7 +29,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-date-modified ${args.type != 'date' ? `type="${args.type}"` : null} ${
     args.lang != 'en' ? `lang="${args.lang}"` : null
   }>

--- a/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
+++ b/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
@@ -37,7 +37,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-details details-title="${args.detailsTitle}" ${args.open ? `open` : null}>
   ${args.default}
 </gcds-details>

--- a/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
+++ b/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
@@ -29,7 +29,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-error-message message-id="${args.messageId}">
   ${args.default}
 </gcds-error-message>

--- a/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
+++ b/packages/web/src/components/gcds-error-summary/stories/gcds-error-summary.stories.tsx
@@ -35,7 +35,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-error-summary
   ${args.listen && !args.errorLinks ? `listen` : null}
   ${args.errorLinks ? `error-links='${args.errorLinks}'` : null}

--- a/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
+++ b/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
@@ -88,7 +88,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-fieldset
   fieldset-id="${args.fieldsetId}"
   legend="${args.legend}"

--- a/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
+++ b/packages/web/src/components/gcds-file-uploader/stories/gcds-file-uploader.stories.tsx
@@ -127,7 +127,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-file-uploader
   uploader-id="${args.uploaderId}"
   label="${args.label}"

--- a/packages/web/src/components/gcds-footer/stories/gcds-footer.stories.tsx
+++ b/packages/web/src/components/gcds-footer/stories/gcds-footer.stories.tsx
@@ -45,7 +45,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-footer
   ${args.display != 'compact' ? `display="${args.display}"` : null}
   ${

--- a/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
+++ b/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
@@ -162,7 +162,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-grid ${args.tag != 'div' ? `tag="${args.tag}"` : null} ${
     args.container != 'full' ? `container="${args.container}"` : null
   } ${

--- a/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
+++ b/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
@@ -102,7 +102,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-header
   lang-href="${args.langHref}"
   skip-to-href="${args.skipToHref}"

--- a/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
+++ b/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
@@ -90,7 +90,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-heading tag="${args.tag}" ${
     !args.characterLimit ? `character-limit="${args.characterLimit}"` : null
   } ${args.marginTop ? `margin-top="${args.marginTop}"` : null} ${

--- a/packages/web/src/components/gcds-icon/stories/gcds-icon.stories.tsx
+++ b/packages/web/src/components/gcds-icon/stories/gcds-icon.stories.tsx
@@ -113,7 +113,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-icon ${args.label ? `label="${args.label}"` : null} name="${args.name}" ${
     args.iconStyle != 'solid' ? `icon-style="${args.iconStyle}"` : null
   } ${args.marginLeft ? `margin-left="${args.marginLeft}"` : null} ${

--- a/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
+++ b/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
@@ -144,7 +144,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-input
   input-id="${args.inputId}"
   label="${args.label}"

--- a/packages/web/src/components/gcds-lang-toggle/stories/gcds-lang-toggle.stories.tsx
+++ b/packages/web/src/components/gcds-lang-toggle/stories/gcds-lang-toggle.stories.tsx
@@ -22,7 +22,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-lang-toggle href="${args.href}" ${
     args.lang != 'en' ? `lang="${args.lang}"` : null
   }>

--- a/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
+++ b/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
@@ -93,7 +93,7 @@ export default {
 const Template = args =>
   `
 This is an example of
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-link ${args.display != 'inline' ? `display="${args.display}"` : null} ${
     args.href ? `href="${args.href}"` : null
   } ${args.variant != 'default' ? `variant="${args.variant}"` : null} ${

--- a/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
+++ b/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
@@ -50,7 +50,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-nav-group
   menu-label="${args.menuLabel}"
   open-trigger="${args.openTrigger}"

--- a/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
+++ b/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
@@ -38,7 +38,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-nav-link
   href="${args.href}"
   ${args.current ? `current` : null}

--- a/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
+++ b/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
@@ -81,7 +81,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-pagination
   ${args.display != 'list' ? `display="${args.display}"` : null}
   label="${args.label}"

--- a/packages/web/src/components/gcds-radio-group/stories/gcds-radio-group.stories.tsx
+++ b/packages/web/src/components/gcds-radio-group/stories/gcds-radio-group.stories.tsx
@@ -70,7 +70,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-radio-group
   name="${args.name}"
   options='${args.options}'

--- a/packages/web/src/components/gcds-search/stories/gcds-search.stories.tsx
+++ b/packages/web/src/components/gcds-search/stories/gcds-search.stories.tsx
@@ -51,7 +51,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-search
   ${args.action != '/sr/srb.html' ? `action="${args.action}"` : null}
   ${args.method != 'get' ? `method="${args.method}"` : null}

--- a/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
+++ b/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
@@ -120,7 +120,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-select
   select-id="${args.selectId}"
   label="${args.label}"

--- a/packages/web/src/components/gcds-side-nav/stories/gcds-side-nav.stories.tsx
+++ b/packages/web/src/components/gcds-side-nav/stories/gcds-side-nav.stories.tsx
@@ -30,7 +30,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-side-nav
   label="${args.label}"
   ${args.lang != 'en' ? `lang="${args.lang}"` : null}

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -35,7 +35,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-signature ${args.type != 'signature' ? `type="${args.type}"` : null} ${
     args.hasLink != false ? `has-link="${args.hasLink}"` : null
   } ${args.variant != 'colour' ? `variant="${args.variant}"` : null} ${

--- a/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
+++ b/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
@@ -29,7 +29,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-sr-only ${args.tag != 'p' ? `tag="${args.tag}"` : null}>
   ${args.default}
 </gcds-sr-only>

--- a/packages/web/src/components/gcds-stepper/stories/gcds-stepper.stories.tsx
+++ b/packages/web/src/components/gcds-stepper/stories/gcds-stepper.stories.tsx
@@ -33,7 +33,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-stepper current-step="${args.currentStep}" total-steps="${
     args.totalSteps
   }" ${args.lang != 'en' ? `lang="${args.lang}"` : null}>

--- a/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
+++ b/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
@@ -111,7 +111,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-text ${
     args.textRole != 'primary' ? `text-role="${args.textRole}"` : null
   } ${args.size != 'body' ? `size="${args.size}"` : null} ${

--- a/packages/web/src/components/gcds-textarea/stories/gcds-textarea.stories.tsx
+++ b/packages/web/src/components/gcds-textarea/stories/gcds-textarea.stories.tsx
@@ -136,7 +136,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-textarea
   textarea-id="${args.textareaId}"
   label="${args.label}"

--- a/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
+++ b/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
@@ -48,7 +48,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-top-nav
   label="${args.label}"
   alignment="${args.alignment}"

--- a/packages/web/src/components/gcds-topic-menu/stories/gcds-topic-menu.stories.tsx
+++ b/packages/web/src/components/gcds-topic-menu/stories/gcds-topic-menu.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-topic-menu ${args.home ? `home` : null} ${
     args.lang != 'en' ? `lang="${args.lang}"` : null
   }>

--- a/packages/web/src/components/gcds-verify-banner/stories/gcds-verify-banner.stories.tsx
+++ b/packages/web/src/components/gcds-verify-banner/stories/gcds-verify-banner.stories.tsx
@@ -28,7 +28,7 @@ export default {
 
 const Template = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-verify-banner ${
     args.container != 'xl' ? `container="${args.container}"` : null
   } ${args.isFixed ? `is-fixed` : null} ${


### PR DESCRIPTION
# Summary | Résumé

When we show the Storybook code preview of the components, it notes Angular & Vue together and then React. Adding HTML to the web components as well to help bring some clarity.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/862)

Note: I will add the rest of the Zenhub ticket in a different PR but I wanted to get this out the door since it's an easy fix and some of the other ticket items will need some exploration.