### PR TITLE
chore: Add sleep to CDN publish of angular, react and vue packages

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -146,6 +146,7 @@ jobs:
         run: |
           PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
           mkdir -p ./tmp \
+            && sleep 60 \
             && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
             && cd ./tmp/node_modules
 


### PR DESCRIPTION
# Summary | Résumé

To follow process of the web component package, add a sleep command to the CDN publish of the other packages.
