### PR TITLE
docs: add fr translation for issue templates (contribution, feature request and bug report)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,6 +51,7 @@ body:
       render: shell
       placeholder: |
         System, Environment, Browsers. At minimum, tell us if you are using a framework and what version.
+        
         Système, environnement, navigateurs. Au minimum, dites-nous si vous utilisez une infrastructure et si oui, indiquez sa version.
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,9 @@ body:
   - type: checkboxes
     attributes:
       label: Prerequisites | Prérequis
-      description: Please ensure you have completed all of the following. | Assurez-vous de respecter les mesures suivantes.
+      description: |
+        Please ensure you have completed all of the following.
+        Assurez-vous de respecter les mesures suivantes.
       options:
         - label: I have read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md). | J’ai lu les [Lignes directrices sur les contributions](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md).
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,59 +1,82 @@
-name: 🐛 Bug Report
-description: Create a report to help us improve GC Design System
+name: 🐛 Bug Report | Rapport de bogue
+description: Create a report to help us improve GC Design System | Remplissez un rapport de bogue pour nous aider à améliorer Système de design GC.
 title: 'bug: '
 body:
   - type: checkboxes
     attributes:
-      label: Prerequisites
-      description: Please ensure you have completed all of the following.
+      label: Prerequisites | Prérequis
+      description: Please ensure you have completed all of the following. | Assurez-vous de respecter les mesures suivantes.
       options:
-        - label: I have read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md).
+        - label: I have read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md). | J’ai lu les [Lignes directrices sur les contributions](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md).
           required: true
-        - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
+        - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md). | J’accepte de me conformer au [Code de conduite](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
           required: true
-        - label: I have searched for [existing issues](https://github.com/cds-snc/gcds-components/issues) that already report this problem, without success.
+        - label: I have searched for [existing issues](https://github.com/cds-snc/gcds-components/issues) that already report this problem, without success. | J’ai vérifié parmi [les tickets (issues) existants](https://github.com/cds-snc/gcds-components/issues) que ce sujet n’avait pas déjà été soumis.
           required: true
   - type: input
     attributes:
-      label: GC Design System Components Package and Version
-      description: "The version number of GC Design System Components where the issue is occurring. Example: gcds-components@x.x.x, gcds-components-react@x.x.x, gcds-components-angular@x.x.x. If the issue exists in figma, please type in 'figma'"
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Current Behavior
-      description: A clear description of what the bug is and how it manifests. Please provide screenshots as necessary.
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Expected Behavior
-      description: A clear description of what you expected to happen.
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: System Info
+      label: GC Design System Components Package and Version | Paquet et version des composants de Système de design GC
       description: |
-        Please provide any additional information, such as npm version, browser(s), frameworks, and version(s) as well
-      render: shell
-      placeholder: System, Environment, Browsers. At minimum, tell us if you are using a framework and what version.
+        The version number of GC Design System Components where the issue is occurring. Example: gcds-components@x.x.x, gcds-components-react@x.x.x, gcds-components-angular@x.x.x. If the issue exists in figma, please type in 'figma'.
+        
+        Numéro de version des composants de Système de design GC où vous rencontrez le problème. Exemple : gcds-components@x.x.x, gcds-components-react@x.x.x, gcds-components-angular@x.x.x. Si le problème se trouve dans Figma, écrivez « Figma »."
+    validations:
+      required: true
   - type: textarea
     attributes:
-      label: Steps to Reproduce
-      description: Please explain the steps required to duplicate this issue.
+      label: Current Behavior | Comportement observé
+      description: |
+        A clear description of what the bug is and how it manifests. Please provide screenshots as necessary.
+        
+        Une description claire du bogue et de la façon dont il se manifeste. Ajoutez des captures d’écran si nécessaire.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior | Comportement attendu
+      description: |
+        A clear description of what you expected to happen.
+        
+        Une description claire de ce qui devrait se produire selon vous.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: System Info | Information sur le système
+      description: |
+        Please provide any additional information, such as npm version, browser(s), frameworks, and version(s) as well.
+        
+        Ajoutez des renseignements additionnels comme la version npm, le navigateur, l’infrastructure et sa version.
+    
+      render: shell
+      placeholder: |
+        System, Environment, Browsers. At minimum, tell us if you are using a framework and what version.
+        Système, environnement, navigateurs. Au minimum, dites-nous si vous utilisez une infrastructure et si oui, indiquez sa version.
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce | Étapes pour reproduire le bogue
+      description: |
+        Please explain the steps required to duplicate this issue.
+
+        Expliquez les étapes permettant de reproduire le problème.
     validations:
       required: true
   - type: input
     attributes:
-      label: Code Reproduction URL
+      label: "Code Reproduction URL | URL de reproduction du code"
       description: |
         Please reproduce this issue in a blank environment and provide a link to the repo. You may use https://stackblitz.com/ or https://codesandbox.io/ to create a reproduction.
         This is the best way to ensure this issue is triaged quickly.
+        
+        Reproduisez le problème dans un environnement vierge et fournissez le lien du référentiel. Vous pouvez utiliser https://stackblitz.com/ ou https://codesandbox.io/ pour créer la reproduction. 
+        C’est la meilleure façon de s’assurer que le problème est traité rapidement.
       placeholder: https://github.com/...
     validations:
       required: false
   - type: textarea
     attributes:
-      label: Additional Information
-      description: List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc.
+      label: Additional Information | Informations supplémentaires
+      description: |
+        List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc.
+
+        Fournissez toute autre information utile. Exemple : traces d’appels (stack traces), problèmes connexes, suggestions de correctif, liens Stack Overflow, liens de forum, etc."

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -82,4 +82,4 @@ body:
       description: |
         List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc.
 
-        Fournissez toute autre information utile. Exemple : traces d’appels (stack traces), problèmes connexes, suggestions de correctif, liens Stack Overflow, liens de forum, etc."
+        Fournissez toute autre information utile. Exemple : traces d’appels (stack traces), problèmes connexes, suggestions de correctif, liens Stack Overflow, liens de forum, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
       description: |
         The version number of GC Design System Components where the issue is occurring. Example: gcds-components@x.x.x, gcds-components-react@x.x.x, gcds-components-angular@x.x.x. If the issue exists in figma, please type in 'figma'.
         
-        Numéro de version des composants de Système de design GC où vous rencontrez le problème. Exemple : gcds-components@x.x.x, gcds-components-react@x.x.x, gcds-components-angular@x.x.x. Si le problème se trouve dans Figma, écrivez « Figma »."
+        Numéro de version des composants de Système de design GC où vous rencontrez le problème. Exemple : gcds-components@x.x.x, gcds-components-react@x.x.x, gcds-components-angular@x.x.x. Si le problème se trouve dans Figma, écrivez « Figma ».
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/contributions.yml
+++ b/.github/ISSUE_TEMPLATE/contributions.yml
@@ -28,7 +28,9 @@ body:
   - type: checkboxes
     attributes:
       label: Prerequisites | Prérequis
-      description: Complete all of the following. | Assurez-vous de respecter les mesures suivantes.
+      description: |
+        Complete all of the following.
+        Assurez-vous de respecter les mesures suivantes.
       options:
         - label: I've read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md). | J’ai lu les [Lignes directrices sur les contributions](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md)
           required: true

--- a/.github/ISSUE_TEMPLATE/contributions.yml
+++ b/.github/ISSUE_TEMPLATE/contributions.yml
@@ -1,10 +1,10 @@
 name: 👷 Contribute to next priorities | Contribuer aux prochaines priorités
-description: Help us with our work on our next priorities | Participez à nos travaux sur nos prochaines priorités
+description: Help us with our work on our next priorities | Participez à nos travaux sur nos prochaines priorités.
 title: 'contribution: '
 body:
   - type: markdown
     attributes:
-      value: "## Thank you for contributing to our project! | Merci de participer à notre projet!"
+      value: "## Thank you for contributing to our project!"
   - type: markdown
     attributes:
       value: |
@@ -15,12 +15,16 @@ body:
           - **code**: prototype code or production code; share your implementations of the relevant component or pattern in services
   - type: markdown
     attributes:
+      value: "## Merci de participer à notre projet!"
+  - type: markdown
+    attributes:
       value: |
         - Avant que nous entamions le développement de ces composants ou configurations, nous souhaitons nous assurer que la communauté du GC a eu l’occasion de soumettre des contributions qui peuvent éclairer et accélérer la conception et le développement.
         - Voici les types de contributions que nous recherchons :
           - **Exemples de designs** : captures d’écran, prototypes, liens vers des services en ligne.
           - **Résultats de recherche** : recherches exploratoires, exemple de cas d’utilisation ou tests d’utilisabilité d’un prototype ou d’un service.
           - **Code** : code de prototype ou de production, ou implémentations du produit.
+
   - type: checkboxes
     attributes:
       label: Prerequisites | Prérequis

--- a/.github/ISSUE_TEMPLATE/contributions.yml
+++ b/.github/ISSUE_TEMPLATE/contributions.yml
@@ -1,10 +1,10 @@
-name: 👷 Contribute to next priorities
-description: Help us with our work on our next priorities 
+name: 👷 Contribute to next priorities | Contribuer aux prochaines priorités
+description: Help us with our work on our next priorities | Participez à nos travaux sur nos prochaines priorités
 title: 'contribution: '
 body:
   - type: markdown
     attributes:
-      value: "## Thank you for contributing to our project!"
+      value: "## Thank you for contributing to our project! | Merci de participer à notre projet!"
   - type: markdown
     attributes:
       value: |
@@ -13,28 +13,36 @@ body:
           - **examples of designs**: screenshots, prototypes, links to live services
           - **research findings**: tell or show us your discovery, your use case, or how your relevant prototype or service has been tested with people using the service
           - **code**: prototype code or production code; share your implementations of the relevant component or pattern in services
+  - type: markdown
+    attributes:
+      value: |
+        - Avant que nous entamions le développement de ces composants ou configurations, nous souhaitons nous assurer que la communauté du GC a eu l’occasion de soumettre des contributions qui peuvent éclairer et accélérer la conception et le développement.
+        - Voici les types de contributions que nous recherchons :
+          - **Exemples de designs** : captures d’écran, prototypes, liens vers des services en ligne.
+          - **Résultats de recherche** : recherches exploratoires, exemple de cas d’utilisation ou tests d’utilisabilité d’un prototype ou d’un service.
+          - **Code** : code de prototype ou de production, ou implémentations du produit.
   - type: checkboxes
     attributes:
-      label: Prerequisites
-      description: Complete all of the following.
+      label: Prerequisites | Prérequis
+      description: Complete all of the following. | Assurez-vous de respecter les mesures suivantes.
       options:
-        - label: I've read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md).
+        - label: I've read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md). | J’ai lu les [Lignes directrices sur les contributions](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md)
           required: true
-        - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
+        - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md). | J’accepte de me conformer au [Code de conduite](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
           required: true
   - type: dropdown
     id: contribution-type
     attributes:
-      label: Which component or pattern is this contribution for?
+      label: Which component or pattern is this contribution for? | Quel composant ou quelle configuration cette contribution vise-t-elle?
       options:
-        - Data Table
-        - Image
-        - Tags
+        - Data Table | Tableau de données
+        - Image | Image
+        - Tags | Étiquettes
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe your contribution.
-      description: Attach screenshots, or a detailed description of your contribution.
+      label: Describe your contribution. | Décrivez votre contribution
+      description: Attach screenshots, or a detailed description of your contribution. | Ajoutez des captures d’écran ou des descriptions détaillées.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,43 +1,70 @@
-name: 💡 Feature Request
-description: Suggest an idea for GC Design System Components
+name: 💡 Feature Request | Demander une fonctionnalité
+description: Suggest an idea for GC Design System Components | Suggérez une idée pour Système de design GC.
 title: 'feat: '
 body:
   - type: checkboxes
     attributes:
-      label: Prerequisites
-      description: Complete all of the following.
+      label: Prerequisites | Prérequis
+      description: |
+        Complete all of the following.
+        Assurez-vous de respecter les mesures suivantes.
+
       options:
-        - label: I've read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md).
+        - label: I've read the [Contributing Guidelines](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md). | J’ai lu les [Lignes directrices sur les contributions](https://github.com/cds-snc/gcds-components/blob/main/CONTRIBUTING.md).
           required: true
-        - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
+        - label: I agree to follow the [Code of Conduct](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md). | J’accepte de me conformer au [Code de conduite](https://github.com/cds-snc/gcds-components/blob/main/CODE_OF_CONDUCT.md).
           required: true
-        - label: I've searched for [existing issues](https://github.com/cds-snc/gcds-components/issues) that already report this problem, without success.
+        - label: I've searched for [existing issues](https://github.com/cds-snc/gcds-components/issues) that already report this problem, without success. | J’ai vérifié parmi les [tickets (issues) existants](https://github.com/cds-snc/gcds-components/issues) que ce sujet n’avait pas déjà été soumis.
           required: true
   - type: textarea
     attributes:
-      label: Describe the feature request.
-      description: A clear and concise description of what the proposed new feature does that's distinct from existing gcds-components.
+      label: Describe the feature request. | Décrivez la fonctionnalité demandée
+      description: |
+        A clear and concise description of what the proposed new feature does that's distinct from existing gcds-components.
+
+        Une description claire et concise de ce que la fonctionnalité proposée permet de faire, et que les composants actuels ne permettent pas.
+
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe the use case.
-      description: A clear and concise use case for what problem this feature would solve for most Government of Canada services or products.
+      label: Describe the use case. | Décrivez les cas d’utilisation
+      description: |
+        A clear and concise use case for what problem this feature would solve for most Government of Canada services or products.
+
+        Une description claire et concise du type de problème rencontré par la plupart des services et produits du gouvernement du Canada que cette fonctionnalité résoudrait. 
+
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe the preferred solution.
-      description: A clear and concise description of how you want this feature to be added to gcds-components.
+      label: Describe the preferred solution. | Décrivez la solution souhaitée
+      description: |
+        A clear and concise description of how you want this feature to be added to gcds-components.
+
+        Une description claire et concise de la façon dont vous voudriez voir cette fonctionnalité s’intégrer aux composants de Système de design GC.
+
   - type: textarea
     attributes:
-      label: Describe all alternatives.
-      description: A clear and concise description of any alternative solutions or features you have considered.
+      label: Describe all alternatives. | Décrivez toutes les solutions possibles
+      description: |
+        A clear and concise description of any alternative solutions or features you have considered.
+
+        Une description claire et concise de toutes les autres solutions ou fonctionnalités que vous avez envisagées.
+
   - type: textarea
     attributes:
-      label: Provide related code or examples.
-      description: Provide some sample code and/or screenshots to illustrate the feature request with examples.
+      label: Provide related code or examples. | Fournissez du code ou des exemples pertinents
+      description: |
+        Provide some sample code and/or screenshots to illustrate the feature request with examples.
+
+        Fournissez des exemples de code ou des captures d’écran qui illustrent la demande de fonctionnalité.
+
   - type: textarea
     attributes:
-      label: Add other relevant resources.
-      description: Include any other information relevant to your request, like stack traces, related issues, suggestions how to implement, Stack Overflow links, forum links, etc.
+      label: Add other relevant resources. | Ajoutez toute autre ressource utile
+      description: |
+        Include any other information relevant to your request, like stack traces, related issues, suggestions how to implement, Stack Overflow links, forum links, etc.
+
+        Ajoutez toute autre information utile à votre demande. Exemple : traces d’appels (stack traces), problèmes connexes, suggestions d’implémentation, liens Stack Overflow, liens de forum, etc.
+


### PR DESCRIPTION
# Summary | Résumé
Updates the issue templates for bug reports and contribution templates
[Translation docs here](https://docs.google.com/document/d/1nqGUV0p8PLAj63qW7O2V5qJfo0hChfKdQUtjieoJhB0/edit)

Updates:
- https://github.com/cds-snc/design-gc-conception/issues/709



## Common issues
The description appears at the top. The "If this doesn't look right, [choose a different type.](https://github.com/daine/issue_tests/issues/new/choose)" portion is added on by github, not us. I tried to add:
> Si ce n’est pas ce que vous souhaitez faire, [choisissez un autre formulaire](https://github.com/cds-snc/gcds-components/issues/new/choose).

but it doesn't look great because it also gets added on the "Choose issue type page", and the link doesn't show up as well on both pages because it doesn't accept markdown format on that field (description).

🦉 **This issue repeats on all the other form templates. Is this okay?**
- [ ] This is fine
- [ ] This needs to be changed


## Choose an issue template
We can only update the title and the description for these items. Everything else is handled by github. The description appears once again on the actual issue template (see common issues above).
<kbd>
<img width="1285" alt="Screenshot 2024-05-22 at 10 14 21 AM" src="https://github.com/cds-snc/gcds-components/assets/916044/2c5fb4f3-1685-495f-9be1-4646cc090604">
</kbd>


## Feature request issue template
<kbd>
<img alt="github com_daine_issue_tests_issues_new_assignees= labels= projects= template=feature_request yml title=feat%3A+(iPad Pro)" src="https://github.com/cds-snc/gcds-components/assets/916044/7614a00c-1339-4913-932c-5252d16eb925"/>
</kbd>

## Bug report issue template


<kbd>
<img alt="github com_daine_issue_tests_issues_new_choose(iPad Pro) (1)" src="https://github.com/cds-snc/gcds-components/assets/916044/d0c1c372-2941-4590-81da-9caa6c7c84c9"/>
</kbd>

## Contributions issue template

<kbd>
<img alt="github com_daine_issue_tests_issues_new_choose(iPad Pro) (2)" src="https://github.com/cds-snc/gcds-components/assets/916044/72c33661-14eb-4705-94a9-1a6c40c2f7e8"/>
</kbd>
