### PR TITLE
chore(storybook): add custom copy code button to storybook code preview

### DIFF
--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -65,16 +65,13 @@
     left: 0 !important;
   }
 
-  .css-3s4ai0 {
-    padding-block-end: var(--gcds-spacing-550);
-  }
-
   .css-3s4ai0 .css-111a2cx {
     background-color: transparent !important;
   }
 
   .docs-story .docblock-code-toggle,
-  .css-3s4ai0 .css-lp0lj7 {
+  .css-3s4ai0 .css-lp0lj7,
+  .copy-code-btn {
     border: var(--gcds-button-border-width) solid currentColor !important;
     border-radius: var(--gcds-button-border-radius) !important;
     box-sizing: border-box;
@@ -328,22 +325,13 @@
 
   .copy-code-btn {
     cursor: pointer;
-    background-color: #262626 !important;
-    color: var(--gcds-text-light) !important;
+    background-color: transparent !important;
+    color: var(--gcds-button-secondary-default-text) !important;
     border: var(--gcds-button-border-width) solid currentColor !important;
-    border-radius: var(--gcds-button-border-radius) !important;
-    box-sizing: border-box;
-    font: var(--gcds-button-font) !important;
-    font-size: 0.875rem !important;
-    margin: 0 var(--gcds-spacing-150) var(--gcds-spacing-250)
-      var(--gcds-spacing-300) !important;
-    padding: var(--gcds-spacing-200) var(--gcds-spacing-150) !important;
-    transition: all 0.35s;
   }
 
   .copy-code-btn:hover:not(:focus) {
-    background-color: var(--gcds-bg-white) !important;
-    color: #262626 !important;
+    background-color: var(--gcds-button-secondary-hover-background) !important;
   }
 
   .copy-code-btn:first-letter {
@@ -484,69 +472,6 @@
     });
   }
 
-  // Add custom copy code buttons to code preview
-  window.addEventListener('load', function () {
-    setTimeout(() => {
-      const container = document.querySelector('.language-html');
-      const btnContainer = document.querySelector('.css-111a2cx');
-      const stringWeb = '<!-- Web component code (HTML, Angular, Vue) -->';
-      const stringReact = '<!-- React code -->';
-      const langFr = url.get('lang') && url.get('lang') === 'fr';
-
-      if (btnContainer) {
-        createBtn(stringWeb, stringReact, 'web component', 'composants web');
-        createBtn(stringReact, '', 'React', 'React');
-
-        function createBtn(startString, endString, textEn, textFr) {
-          const copyBtn = document.createElement('button');
-
-          copyBtn.textContent = langFr ? `Copier ${textFr}` : `Copy ${textEn}`;
-          copyBtn.classList.add('copy-code-btn');
-
-          copyBtn.addEventListener('click', function () {
-            const content = container.textContent;
-            const startIndex = content.indexOf(startString);
-            let extractedContent;
-
-            if (startIndex !== -1) {
-              if (endString) {
-                const endIndex = content.indexOf(endString, startIndex);
-
-                if (endIndex !== -1) {
-                  extractedContent = content
-                    .substring(startIndex + startString.length, endIndex)
-                    .trim();
-                } else {
-                  console.error('End string not found in the content.');
-                  return;
-                }
-              } else {
-                extractedContent = content
-                  .substring(startIndex + startString.length)
-                  .trim();
-              }
-
-              navigator.clipboard
-                .writeText(extractedContent)
-                .then(function () {
-                  copyBtn.textContent = langFr
-                    ? `${textFr} copiés`
-                    : `${textEn} copied`;
-                })
-                .catch(function (err) {
-                  console.error('Unable to copy content to clipboard: ', err);
-                });
-            } else {
-              console.error('Start string not found in the content.');
-            }
-          });
-
-          btnContainer.appendChild(copyBtn);
-        }
-      }
-    }, 200);
-  });
-
   function formatTable(table, lang) {
     // Format table header
     const tableHead = [...table.querySelectorAll('th')];
@@ -666,4 +591,123 @@
       }
     });
   }
+
+  // ----- Custom copy code buttons -----
+
+  // Add custom copy code buttons to code preview
+  function createCopyBtn(toggleCode, startString, endString, textEn, textFr) {
+    const toggleCodeBtnParent = toggleCode.closest('.css-25bv1u');
+    const copyBtn = document.createElement('button');
+    const langFr = url.get('lang') && url.get('lang') === 'fr';
+
+    copyBtn.textContent = langFr ? `Copier ${textFr}` : `Copy ${textEn}`;
+    copyBtn.classList.add('copy-code-btn');
+
+    // Copy content to clipboard
+    function copyContent() {
+      // Get the content of the code block
+      const contentParent = toggleCode.closest('.sbdocs-preview');
+      const content = contentParent
+        ? contentParent.querySelector('.language-html').textContent
+        : '';
+      const start = content.indexOf(startString);
+      let code;
+
+      if (start !== -1) {
+        const end = endString
+          ? content.indexOf(endString, start)
+          : content.length;
+
+        // Extract the code from the content
+        if (end !== -1) {
+          code = content.substring(start + startString.length, end).trim();
+        } else {
+          console.error('End string not found in the content.');
+          return;
+        }
+
+        // Copy the extracted code to clipboard
+        navigator.clipboard
+          .writeText(code)
+          .then(() => {
+            // Update button text to indicate successful copy
+            copyBtn.textContent = langFr
+              ? `${textFr} copiés`
+              : `${textEn} copied`;
+          })
+          .catch(err => {
+            console.error('Unable to copy content to clipboard: ', err);
+          });
+      } else {
+        console.error('Start string not found in the content.');
+      }
+    }
+
+    copyBtn.addEventListener('click', function () {
+      copyContent();
+    });
+
+    // Append the copy button to the container
+    if (toggleCodeBtnParent) {
+      toggleCodeBtnParent.appendChild(copyBtn);
+    } else {
+      console.error('Parent container not found.');
+    }
+  }
+
+  // Display copy buttons based on toggle button state
+  function toggleCopyBtnsDisplay(toggleCode) {
+    // Define strings representing code blocks for web components and React
+    const stringWeb = '<!-- Web component code (HTML, Angular, Vue) -->';
+    const stringReact = '<!-- React code -->';
+
+    // Check if toggle button is in expanded state
+    if (toggleCode.classList.contains('docblock-code-toggle--expanded')) {
+      // If expanded, create copy buttons for web component and React code
+      createCopyBtn(
+        toggleCode,
+        stringWeb,
+        stringReact,
+        'web component',
+        'composants web',
+      );
+      createCopyBtn(toggleCode, stringReact, '', 'React', 'React');
+    } else {
+      // If not expanded, remove existing copy buttons
+      const copyBtns = document.querySelectorAll('.copy-code-btn');
+      copyBtns.forEach(btn => btn.remove());
+    }
+  }
+
+  // Add DOMContentLoaded event
+  function domContentLoadedHandler() {
+    setTimeout(() => {
+      const toggleCodes = document.querySelectorAll('.docblock-code-toggle');
+
+      if (toggleCodes.length > 0) {
+        // Toggle the display of copy buttons based on the toggle code button state
+        toggleCodes.forEach(toggleCode => {
+          toggleCopyBtnsDisplay(toggleCode);
+
+          // Add event listener for click event to each toggle code button
+          toggleCode.addEventListener('click', () => {
+            setTimeout(() => toggleCopyBtnsDisplay(toggleCode), 200);
+          });
+        });
+      }
+    }, 1000);
+
+    // Remove DOMContentLoaded event listener to avoid execution for each story on the page
+    document.removeEventListener('DOMContentLoaded', domContentLoadedHandler);
+  }
+
+  // Add event listener to execute domContentLoadedHandler function when DOM content is loaded
+  document.addEventListener('DOMContentLoaded', domContentLoadedHandler);
+
+  // Add event listener to execute domContentLoadedHandler for click events
+  document.addEventListener('click', function () {
+    document.addEventListener('DOMContentLoaded', domContentLoadedHandler);
+  });
+
+  // ----- End custom copy code buttons -----
 </script>

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -324,6 +324,7 @@
   /* ----- CUSTOM COPY CODE BTNS ----- */
 
   .copy-code-btn {
+    min-width: 11.35rem;
     cursor: pointer;
     background-color: transparent !important;
     color: var(--gcds-button-secondary-default-text) !important;

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -106,7 +106,8 @@
   }
 
   .docs-story .docblock-code-toggle:focus,
-  .css-3s4ai0 .css-lp0lj7:focus {
+  .css-3s4ai0 .css-lp0lj7:focus,
+  .copy-code-btn:focus {
     background-color: var(--gcds-focus-background) !important;
     border-color: var(--gcds-focus-background) !important;
     color: var(--gcds-focus-text) !important;
@@ -323,6 +324,37 @@
     margin: 0 0 var(--gcds-spacing-300) !important;
   }
 
+  /* ----- CUSTOM COPY CODE BTNS ----- */
+
+  .copy-code-btn {
+    cursor: pointer;
+    background-color: #262626 !important;
+    color: var(--gcds-text-light) !important;
+    border: var(--gcds-button-border-width) solid currentColor !important;
+    border-radius: var(--gcds-button-border-radius) !important;
+    box-sizing: border-box;
+    font: var(--gcds-button-font) !important;
+    font-size: 0.875rem !important;
+    margin: 0 var(--gcds-spacing-150) var(--gcds-spacing-250)
+      var(--gcds-spacing-300) !important;
+    padding: var(--gcds-spacing-200) var(--gcds-spacing-150) !important;
+    transition: all 0.35s;
+  }
+
+  .copy-code-btn:hover:not(:focus) {
+    background-color: var(--gcds-bg-white) !important;
+    color: #262626 !important;
+  }
+
+  .copy-code-btn:first-letter {
+    text-transform: uppercase;
+  }
+
+  /* Hide default Storybook copy btn */
+  .css-lp0lj7 {
+    display: none !important;
+  }
+
   /* ----- COMPONENT SPECIFIC ----- */
 
   /* gcds-button */
@@ -451,6 +483,69 @@
       }
     });
   }
+
+  // Add custom copy code buttons to code preview
+  window.addEventListener('load', function () {
+    setTimeout(() => {
+      const container = document.querySelector('.language-html');
+      const btnContainer = document.querySelector('.css-111a2cx');
+      const stringWeb = '<!-- Web component code (HTML, Angular, Vue) -->';
+      const stringReact = '<!-- React code -->';
+      const langFr = url.get('lang') && url.get('lang') === 'fr';
+
+      if (btnContainer) {
+        createBtn(stringWeb, stringReact, 'web component', 'composants web');
+        createBtn(stringReact, '', 'React', 'React');
+
+        function createBtn(startString, endString, textEn, textFr) {
+          const copyBtn = document.createElement('button');
+
+          copyBtn.textContent = langFr ? `Copier ${textFr}` : `Copy ${textEn}`;
+          copyBtn.classList.add('copy-code-btn');
+
+          copyBtn.addEventListener('click', function () {
+            const content = container.textContent;
+            const startIndex = content.indexOf(startString);
+            let extractedContent;
+
+            if (startIndex !== -1) {
+              if (endString) {
+                const endIndex = content.indexOf(endString, startIndex);
+
+                if (endIndex !== -1) {
+                  extractedContent = content
+                    .substring(startIndex + startString.length, endIndex)
+                    .trim();
+                } else {
+                  console.error('End string not found in the content.');
+                  return;
+                }
+              } else {
+                extractedContent = content
+                  .substring(startIndex + startString.length)
+                  .trim();
+              }
+
+              navigator.clipboard
+                .writeText(extractedContent)
+                .then(function () {
+                  copyBtn.textContent = langFr
+                    ? `${textFr} copiés`
+                    : `${textEn} copied`;
+                })
+                .catch(function (err) {
+                  console.error('Unable to copy content to clipboard: ', err);
+                });
+            } else {
+              console.error('Start string not found in the content.');
+            }
+          });
+
+          btnContainer.appendChild(copyBtn);
+        }
+      }
+    }, 200);
+  });
 
   function formatTable(table, lang) {
     // Format table header

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -600,8 +600,10 @@
     const toggleCodeBtnParent = toggleCode.closest('.css-25bv1u');
     const copyBtn = document.createElement('button');
     const langFr = url.get('lang') && url.get('lang') === 'fr';
+    const defaultBtnContent = langFr ? `Copier ${textFr}` : `Copy ${textEn}`;
+    const copiedBtnContent = langFr ? `${textFr} copiés` : `${textEn} copied`;
 
-    copyBtn.textContent = langFr ? `Copier ${textFr}` : `Copy ${textEn}`;
+    copyBtn.textContent = defaultBtnContent;
     copyBtn.classList.add('copy-code-btn');
 
     // Copy content to clipboard
@@ -632,9 +634,12 @@
           .writeText(code)
           .then(() => {
             // Update button text to indicate successful copy
-            copyBtn.textContent = langFr
-              ? `${textFr} copiés`
-              : `${textEn} copied`;
+            copyBtn.textContent = copiedBtnContent;
+
+            // Revert button text to default after 1.5 seconds
+            setTimeout(() => {
+              copyBtn.textContent = defaultBtnContent;
+            }, 1500);
           })
           .catch(err => {
             console.error('Unable to copy content to clipboard: ', err);

--- a/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
+++ b/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
@@ -165,7 +165,7 @@ const Template = args =>
 `.replace(/ null/g, '');
 
 const TemplatePreview = () => `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-button>Submit</gcds-button>
 <gcds-button button-role="secondary">Cancel</gcds-button>
 <gcds-button button-role="danger">Delete</gcds-button>
@@ -177,7 +177,7 @@ const TemplatePreview = () => `
 `;
 
 const TemplateTypes = () => `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-button>Button</gcds-button>
 <gcds-button type="link">Link</gcds-button>
 <gcds-button type="reset">Reset</gcds-button>
@@ -191,7 +191,7 @@ const TemplateTypes = () => `
 `;
 
 const TemplateRoles = () => `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-button>Primary</gcds-button>
 <gcds-button button-role="secondary">Secondary</gcds-button>
 <gcds-button button-role="danger">Danger</gcds-button>
@@ -204,7 +204,7 @@ const TemplateRoles = () => `
 
 const TemplateTwoButtons = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-button ${
     args.buttonRole != 'primary' ? `button-role="${args.buttonRole}"` : null
   } ${args.btnOneSize != 'regular' ? `size="${args.btnOneSize}"` : null} ${
@@ -239,7 +239,7 @@ const TemplateTwoButtons = args =>
 
 const TemplateBtnIcon = args =>
   `
-<!-- Web component code (Angular, Vue) -->
+<!-- Web component code (HTML, Angular, Vue) -->
 <gcds-button>
   ${args.default} <gcds-icon name="${args.iconName}"></gcds-icon>
 </gcds-button>


### PR DESCRIPTION
# Summary | Résumé

Adding custom copy code buttons to our Storybook code preview - one for the web component code and one for the React component code. Users are never going to need to copy both web and React, this gives them the option to choose.

I looked into separating the web components and React code preview into two. It would involve having 2 separate iframes with two separate property tables for which we would have to display tabs (or something similar) on the live demo section on our code page. We could look into doing that when we redesign the site, but it seems out of scope as a quick fix since it would require writing new stories for all components, design input, etc.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/862)