### PR TITLE
fix: misaligned of FR theme and topic menu button (bug)

### DIFF
--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
@@ -10,7 +10,7 @@
 
 @layer default {
   :host {
-    display: block;
+    display: inline-block;
     width: 0;
     height: 0;
     margin: 0;


### PR DESCRIPTION
# Summary | Résumé

The French theme and topic menu button was split into two lines because the host element of the screenreader-only component was set to `display: block;`. Fixed it and it should display on one line now, like the EN menu button.

[Bug report](https://github.com/cds-snc/gcds-components/issues/534)