### PR TITLE
chore(storybook): card property typos in Storybook

### DIFF
--- a/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
@@ -39,6 +39,7 @@ export default {
       },
     },
     imgSrc: {
+      name: 'img-src',
       control: 'text',
       table: {
         type: { summary: 'string' },
@@ -46,6 +47,7 @@ export default {
       },
     },
     imgAlt: {
+      name: 'img-alt',
       control: 'text',
       table: {
         type: { summary: 'string' },
@@ -61,6 +63,7 @@ export default {
       },
     },
     titleElement: {
+      name: 'title-element',
       control: 'select',
       options: ['h3', 'h4', 'h5', 'h6', 'a'],
       table: {


### PR DESCRIPTION
# Summary | Résumé

Some properties for the card component were not rendering in the proper format (`imgAlt` instead of `img-alt`) on the Events & properties page in Storybook.
