### PR TITLE
chore(storybook): add description to slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46149,7 +46149,7 @@
         "@types/jest": "^26.0.9",
         "jest": "^26.3.0",
         "np": "^6.0.2",
-        "prettier": "2.7.1",
+        "prettier": "2.8.8",
         "rimraf": "^4.2.0",
         "rollup": "^2.23.1",
         "ts-jest": "^26.2.0"
@@ -47482,9 +47482,9 @@
       }
     },
     "utils/angular-output-target/node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -543,6 +543,7 @@
       )}-property`;
       for (let x = 0; x < tr.children.length; x++) {
         // Format first cell
+        // Add id attribute, translate required title
         if (x == 0) {
           tr.children[x].setAttribute('id', propertyId);
           if (
@@ -557,23 +558,42 @@
               .setAttribute('title', 'Obligatoire');
           }
         }
-        // Format third cell
-        if (tr.children[x].innerText === '-') {
-          let span = document.createElement('span');
-          span.setAttribute('class', 'sr-only');
 
-          if (lang === 'en') {
-            tr.children[x].setAttribute('title', 'No default value');
-            span.innerText = 'No default value';
-            tr.children[x].append(span);
-          } else {
-            tr.children[x].setAttribute('title', 'Aucune valeur par défaut');
-            tr.children[x].setAttribute('lang', 'fr');
-            span.innerText = 'Aucune valeur par défaut';
-            tr.children[x].append(span);
+        // Format second cell
+        // Format slot description, add lang attribute
+        if (x == 1) {
+          const tableCell = tr.children[x];
+          if (tableCell.children.length > 1) {
+            const slotDesc = tableCell.children[0].querySelector('span');
+            const langStrings = slotDesc.innerText.split(' | ');
+            slotDesc.setAttribute('lang', lang);
+            slotDesc.innerText = lang === "en" ? langStrings[0] : langStrings[1];
           }
         }
+
+
+        // Format third cell
+        // Add hidden text to default value
+        if (x == 2) {
+          if (tr.children[x].innerText === '-') {
+            let span = document.createElement('span');
+            span.setAttribute('class', 'sr-only');
+  
+            if (lang === 'en') {
+              tr.children[x].setAttribute('title', 'No default value');
+              span.innerText = 'No default value';
+              tr.children[x].append(span);
+            } else {
+              tr.children[x].setAttribute('title', 'Aucune valeur par défaut');
+              tr.children[x].setAttribute('lang', 'fr');
+              span.innerText = 'Aucune valeur par défaut';
+              tr.children[x].append(span);
+            }
+          }
+        }
+
         // Format last cell
+        // Fix form inputs
         if (x === 3) {
           if (tr.children[x].querySelector('select')) {
             tr.children[x]

--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -262,6 +262,12 @@
     background-color: var(--gcds-color-grayscale-700) !important;
   }
 
+  .docblock-argstable input,
+  .docblock-argstable textarea,
+  .docblock-argstable .css-obbby0 {
+    min-width: 13rem !important;
+  }
+
   /* Props table focus styles - form elements */
   .css-6wu5zk:focus-within {
     overflow: visible !important;

--- a/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
+++ b/packages/web/src/components/gcds-breadcrumbs/stories/gcds-breadcrumbs.stories.tsx
@@ -14,16 +14,6 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    href: {
-      control: 'text',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: '-' },
-      },
-      type: {
-        required: true,
-      },
-    },
     ...langProp,
 
     // Slots
@@ -33,6 +23,7 @@ export default {
       },
       table: {
         category: 'Slots | Fentes',
+        disable: true,
       },
     },
   },
@@ -44,20 +35,16 @@ const Template = args =>
 <gcds-breadcrumbs ${args.hideCanadaLink ? `hide-canada-link` : null} ${
     args.lang != 'en' ? `lang="${args.lang}"` : null
   }>
-  <gcds-breadcrumbs-item href="${args.href}">Home page</gcds-breadcrumbs-item>
-  <gcds-breadcrumbs-item href="${
-    args.href
-  }">Parent page link</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="#">Home page</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="#">Parent page link</gcds-breadcrumbs-item>
 </gcds-breadcrumbs>
 
 <!-- React code -->
 <GcdsBreadcrumbs ${args.hideCanadaLink ? `hideCanadaLink` : null} ${
     args.lang != 'en' ? `lang="${args.lang}"` : null
   }>
-  <GcdsBreadcrumbsItem href="${args.href}">Home page</GcdsBreadcrumbsItem>
-  <GcdsBreadcrumbsItem href="${
-    args.href
-  }">Parent page link</GcdsBreadcrumbsItem>
+  <GcdsBreadcrumbsItem href="#">Home page</GcdsBreadcrumbsItem>
+  <GcdsBreadcrumbsItem href="#">Parent page link</GcdsBreadcrumbsItem>
 </GcdsBreadcrumbs>
 `.replace(/ null/g, '');
 
@@ -66,10 +53,8 @@ const TemplatePlayground = args => `
   ${args.hideCanadaLink ? `hide-canada-link` : null}
   ${args.lang != 'en' ? `lang="${args.lang}"` : null}
 >
-  <gcds-breadcrumbs-item href="${args.href}">Home page</gcds-breadcrumbs-item>
-  <gcds-breadcrumbs-item href="${
-    args.href
-  }">Parent page link</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="#">Home page</gcds-breadcrumbs-item>
+  <gcds-breadcrumbs-item href="#">Parent page link</gcds-breadcrumbs-item>
 </gcds-breadcrumbs>
 `;
 
@@ -78,7 +63,6 @@ const TemplatePlayground = args => `
 export const Default = Template.bind({});
 Default.args = {
   hideCanadaLink: false,
-  href: '#',
   lang: 'en',
 };
 
@@ -87,7 +71,6 @@ Default.args = {
 export const WithoutCanadaLink = Template.bind({});
 WithoutCanadaLink.args = {
   hideCanadaLink: true,
-  href: '#',
   lang: 'en',
 };
 
@@ -96,7 +79,6 @@ WithoutCanadaLink.args = {
 export const Props = Template.bind({});
 Props.args = {
   hideCanadaLink: false,
-  href: '#',
   lang: 'en',
   default: '',
 };
@@ -106,7 +88,6 @@ Props.args = {
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   hideCanadaLink: false,
-  href: '#',
   lang: 'en',
   default: '',
 };

--- a/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
+++ b/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
@@ -98,6 +98,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
+++ b/packages/web/src/components/gcds-button/stories/gcds-button.stories.js
@@ -98,7 +98,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
@@ -77,6 +77,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
+++ b/packages/web/src/components/gcds-card/stories/gcds-card.stories.tsx
@@ -77,7 +77,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Include additional elements.',
+      description:
+        'Include additional elements. | Ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
+++ b/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
@@ -90,6 +90,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
+++ b/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
@@ -90,7 +90,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
+++ b/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
@@ -20,7 +20,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
+++ b/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
@@ -20,6 +20,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
+++ b/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
@@ -28,6 +28,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
+++ b/packages/web/src/components/gcds-details/stories/gcds-details.stories.tsx
@@ -28,7 +28,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
+++ b/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
@@ -20,7 +20,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
+++ b/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
@@ -20,6 +20,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
+++ b/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
@@ -153,7 +153,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
+++ b/packages/web/src/components/gcds-grid/stories/gcds-grid.stories.tsx
@@ -153,6 +153,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
+++ b/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
@@ -52,6 +52,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Use this slot to add a menu to the header.',
       table: {
         category: 'Slots | Fentes',
       },
@@ -60,6 +61,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Use this slot to add breadcrumbs to the header.',
       table: {
         category: 'Slots | Fentes',
       },
@@ -68,6 +70,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Use this slot to add a search to the header.',
       table: {
         category: 'Slots | Fentes',
       },
@@ -76,6 +79,8 @@ export default {
       control: {
         type: 'text',
       },
+      description:
+        'Use this slot to add a different language toggle to the header.',
       table: {
         category: 'Slots | Fentes',
       },
@@ -84,6 +89,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Use this slot to add a banner to the header.',
       table: {
         category: 'Slots | Fentes',
       },
@@ -93,6 +99,8 @@ export default {
       control: {
         type: 'text',
       },
+      description:
+        'Use this slot to add a different skip-to-nav link to the header.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
+++ b/packages/web/src/components/gcds-header/stories/gcds-header.stories.tsx
@@ -52,7 +52,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Use this slot to add a menu to the header.',
+      description:
+        "Use this slot to add a menu to the header. | À utiliser pour ajouter un menu à l'en-tête.",
       table: {
         category: 'Slots | Fentes',
       },
@@ -61,7 +62,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Use this slot to add breadcrumbs to the header.',
+      description:
+        "Use this slot to add breadcrumbs to the header. | À utiliser pour ajouter un chemin de navigation à l'en-tête.",
       table: {
         category: 'Slots | Fentes',
       },
@@ -70,7 +72,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Use this slot to add a search to the header.',
+      description:
+        "Use this slot to add a search to the header. | À utiliser pour ajouter une recherche à l'en-tête.",
       table: {
         category: 'Slots | Fentes',
       },
@@ -80,7 +83,7 @@ export default {
         type: 'text',
       },
       description:
-        'Use this slot to add a different language toggle to the header.',
+        "Use this slot to add a different language toggle to the header. | À utiliser pour ajouter une bascule de langue différente à l'en-tête.",
       table: {
         category: 'Slots | Fentes',
       },
@@ -89,7 +92,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Use this slot to add a banner to the header.',
+      description:
+        "Use this slot to add a banner to the header. | À utiliser pour ajouter une bannière à l'en-tête.",
       table: {
         category: 'Slots | Fentes',
       },
@@ -100,7 +104,7 @@ export default {
         type: 'text',
       },
       description:
-        'Use this slot to add a different skip-to-nav link to the header.',
+        "Use this slot to add a different skip-to-nav link to the header. | À utiliser pour ajouter un lien « passer à la navigation » à l'en-tête.",
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
+++ b/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
@@ -81,6 +81,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
+++ b/packages/web/src/components/gcds-heading/stories/gcds-heading.stories.tsx
@@ -81,7 +81,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
+++ b/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
@@ -83,6 +83,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
+++ b/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
@@ -83,7 +83,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
+++ b/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
@@ -29,7 +29,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
+++ b/packages/web/src/components/gcds-nav-link/stories/gcds-nav-link.stories.tsx
@@ -29,6 +29,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
+++ b/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
@@ -20,7 +20,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
+++ b/packages/web/src/components/gcds-sr-only/stories/gcds-sr-only.stories.tsx
@@ -20,6 +20,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
+++ b/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
@@ -102,7 +102,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content or include additional elements.',
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
+++ b/packages/web/src/components/gcds-text/stories/gcds-text.stories.tsx
@@ -102,6 +102,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content or include additional elements.',
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
+++ b/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
@@ -39,7 +39,8 @@ export default {
       control: {
         type: 'text',
       },
-      description: 'Customize the content for the home link.',
+      description:
+        "Customize the content for the home link. | Personnalisez le contenu du lien d'accueil.",
       table: {
         category: 'Slots | Fentes',
       },

--- a/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
+++ b/packages/web/src/components/gcds-top-nav/stories/gcds-top-nav.stories.tsx
@@ -39,6 +39,7 @@ export default {
       control: {
         type: 'text',
       },
+      description: 'Customize the content for the home link.',
       table: {
         category: 'Slots | Fentes',
       },


### PR DESCRIPTION
# Summary | Résumé

Adding descriptions to the slots in Storybook to make it easier to understand what to use them for.
What do you think about this @daine @ethanWallace ?

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/862)