### PR TITLE
refactor: separate the CDN upload process and add a retry script

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -11,10 +11,6 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  CDN_BUCKET: gc-design-system-production-cdn
-  CDN_REGION: ca-central-1
-
 jobs:
   publish-web:
     name: Publish @cdssnc/gcds-components
@@ -48,8 +44,6 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{ matrix.dist }}
-          # TODO: Remove for production
-          dry-run: true
 
       - name: Report deployment to Sentinel
         if: steps.publish.outputs.id != ''
@@ -108,8 +102,6 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{ matrix.dist }}
-          # TODO: Remove for production
-          dry-run: true
 
       - name: Report deployment to Sentinel
         if: steps.publish.outputs.id != ''

--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -48,32 +48,8 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{ matrix.dist }}
-
-      - name: Configure AWS credentials using OIDC
-        if: steps.publish.outputs.id != ''
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
-        with:
-          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
-          role-session-name: CDNPublish
-          aws-region: ${{ env.CDN_REGION }}
-
-      - name: Update CDN ${{ matrix.name }}
-        if: steps.publish.outputs.id != ''
-        run: |
-          PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
-
-          mkdir -p ./tmp \
-            && sleep 60 \
-            && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
-            && cd ./tmp/node_modules
-
-          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
-          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/${{ matrix.name }}@latest --delete
-          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
-          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ matrix.name }}@latest/package.json
-
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
-        working-directory: ${{ matrix.package }}
+          # TODO: Remove for production
+          dry-run: true
 
       - name: Report deployment to Sentinel
         if: steps.publish.outputs.id != ''
@@ -91,8 +67,8 @@ jobs:
           json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Publish ${{ matrix.name }} failed: <https://github.com/cds-snc/gcds-components/actions/workflows/compile-and-publish.yml|Publish packages>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}
 
-  publish-react-angular:
-    name: Publish @cdssnc/gcds-components-react and @cdssnc/gcds-components-angular
+  publish-react-angular-vue:
+    name: Publish @cdssnc/gcds-components-react, @cdssnc/gcds-components-angular, @cdssnc/gcds-components-vue
     needs: publish-web
     runs-on: ubuntu-latest
     strategy:
@@ -120,10 +96,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install monorepo (web, react, angular)
+      - name: Install monorepo (web, react, angular, vue)
         run: npm install
 
-      - name: Build gcds-components  (web, react, angular)
+      - name: Build gcds-components (web, react, angular, vue)
         run: npm run build
 
       - name: Publish ${{ matrix.name }}
@@ -132,31 +108,8 @@ jobs:
         with:
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{ matrix.dist }}
-
-      - name: Configure AWS credentials using OIDC
-        if: steps.publish.outputs.id != ''
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
-        with:
-          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
-          role-session-name: CDNPublish
-          aws-region: ${{ env.CDN_REGION }}
-
-      - name: Update CDN ${{ matrix.name }}
-        if: steps.publish.outputs.id != ''
-        run: |
-          PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
-          mkdir -p ./tmp \
-            && sleep 60 \
-            && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
-            && cd ./tmp/node_modules
-
-          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
-          aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/${{ matrix.name }}@latest --delete
-          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
-          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ matrix.name }}@latest/package.json
-
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
-        working-directory: ${{ matrix.package }}
+          # TODO: Remove for production
+          dry-run: true
 
       - name: Report deployment to Sentinel
         if: steps.publish.outputs.id != ''

--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -45,6 +45,9 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
           package: ${{ matrix.dist }}
 
+      - name: Sleep for 60 seconds to give more time for NPM to complete publishing before proceeding to publish the rest
+        run: sleep 60
+
       - name: Report deployment to Sentinel
         if: steps.publish.outputs.id != ''
         uses: cds-snc/sentinel-forward-data-action@main
@@ -53,7 +56,6 @@ jobs:
           log_type: CDS_Product_Deployment_Data
           log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
           log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
-
 
       - name: Slack notify on failure
         if: failure()

--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -11,6 +11,10 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  CDN_BUCKET: gc-design-system-production-cdn
+  CDN_REGION: ca-central-1
+
 jobs:
   publish-web:
     name: Publish @cdssnc/gcds-components

--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -11,10 +11,6 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  CDN_BUCKET: gc-design-system-production-cdn
-  CDN_REGION: ca-central-1
-
 jobs:
   publish-web:
     name: Publish @cdssnc/gcds-components

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -43,12 +43,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - name: Install jq and aws cli
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-          sudo apt-get install awscli -y
-
       - name: Make Upload to CDN script executable
         run: chmod +x ./utils/scripts/upload_to_cdn.sh
 

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -12,8 +12,7 @@ permissions:
   contents: read
 
 env:
-  # TODO: Replace with correct bucket name in production
-  CDN_BUCKET: gc-design-system-daine-scratch-cdn
+  CDN_BUCKET: gc-design-system-production-cdn
   CDN_REGION: ca-central-1
 
 jobs:
@@ -54,10 +53,9 @@ jobs:
         run: chmod +x ./utils/scripts/upload_to_cdn.sh
 
       - name: Configure AWS credentials using OIDC
-        # TODO: Replace with correct role on production
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: arn:aws:iam::951846448183:role/daine-gcds-components-apply
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
           role-session-name: CDNPublish
           aws-region: ${{ env.CDN_REGION }}
 

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -28,7 +28,7 @@ jobs:
           exit 1
 
   upload-to-cdn:
-    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -17,16 +17,18 @@ env:
 
 jobs:
   unable-to-deploy:
-      if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-      runs-on: ubuntu-latest
-      steps:
-        - name: Exit and notify Slack if publishing failed and we can't upload to the CDN
-          run: |
-            json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Publishing workflow failed, unable to upload to CDN <https://github.com/cds-snc/gcds-components/actions/workflows/upload-cdn.yml|Upload packages to CDN>"}}]}'
-            curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}
-            exit 1
+    # If this was triggered by a workflow run ("Publish packages" as noted above) and the workflow run failed
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Exit and notify Slack if publishing failed and we can't upload to the CDN
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Publishing workflow failed, unable to upload to CDN <https://github.com/cds-snc/gcds-components/actions/workflows/upload-cdn.yml|Upload packages to CDN>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}
+          exit 1
 
   upload-to-cdn:
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -1,0 +1,74 @@
+name: Upload packages to CDN
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Publish packages"]
+    types:
+      - completed
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  # TODO: Replace with correct bucket name in production
+  CDN_BUCKET: gc-design-system-daine-scratch-cdn
+  CDN_REGION: ca-central-1
+
+jobs:
+  upload-to-cdn:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "web"
+            package: "@cdssnc/gcds-components"
+            dist: "./packages/web"
+
+          - name: "react"
+            package: "@cdssnc/gcds-components-react"
+            dist: "./packages/react"
+
+          - name: "angular"
+            package: "@cdssnc/gcds-components-angular"
+            dist: "./packages/angular/dist"
+
+          - name: "vue"
+            package: "@cdssnc/gcds-components-vue"
+            dist: "./packages/vue"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Install jq and aws cli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          sudo apt-get install awscli -y
+
+      - name: Make Upload to CDN script executable
+        run: chmod +x ./utils/scripts/upload_to_cdn.sh
+
+      - name: Configure AWS credentials using OIDC
+        # TODO: Replace with correct role on production
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: arn:aws:iam::951846448183:role/daine-gcds-components-apply
+          role-session-name: CDNPublish
+          aws-region: ${{ env.CDN_REGION }}
+
+      - name: Upload file to S3
+        run: ./utils/scripts/upload_to_cdn.sh ${{ matrix.package }}
+        env:
+          CDN_CLOUDFRONT_DIST_ID: ${{secrets.CDN_CLOUDFRONT_DIST_ID}}
+          PACKAGE_PATH: ${{ matrix.dist }}
+
+      - name: Slack notify on failure
+        if: failure()
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: CDN upload ${{ matrix.package }} failed: <https://github.com/cds-snc/gcds-components/actions/workflows/upload-cdn.yml|Upload packages to CDN>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -16,6 +16,16 @@ env:
   CDN_REGION: ca-central-1
 
 jobs:
+  unable-to-deploy:
+      if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+      runs-on: ubuntu-latest
+      steps:
+        - name: Exit and notify Slack if publishing failed and we can't upload to the CDN
+          run: |
+            json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Publishing workflow failed, unable to upload to CDN <https://github.com/cds-snc/gcds-components/actions/workflows/upload-cdn.yml|Upload packages to CDN>"}}]}'
+            curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}
+            exit 1
+
   upload-to-cdn:
     runs-on: ubuntu-latest
 

--- a/utils/scripts/upload_to_cdn.sh
+++ b/utils/scripts/upload_to_cdn.sh
@@ -1,16 +1,69 @@
 #!/bin/bash
 
-# Get the published package name
-PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
+PACKAGE_NAME=$1
 
-mkdir -p ./tmp \
-  && sleep 60 \
-  && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
-  && cd ./tmp/node_modules
+## Path to lerna.json
+LERNA_JSON="lerna.json"
 
-aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
-aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/${{ matrix.name }}@latest --delete
-aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
-aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ matrix.name }}@latest/package.json
+# Check if lerna.json exists
+if [ ! -f "$LERNA_JSON" ]; then
+  echo "lerna.json not found!"
+  exit 1
+fi
 
-aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
+echo "Current working directory: $(pwd)"
+
+## Read and process lerna.json using jq to get the package version
+PACKAGE_VERSION=$(jq -r '.version' $LERNA_JSON)
+
+echo "PACKAGE_VERSION: $PACKAGE_VERSION"
+echo "CDN_BUCKET: $CDN_BUCKET"
+echo "PACKAGE_PATH: $PACKAGE_PATH"
+echo "PACKAGE_NAME: $PACKAGE_NAME"
+
+# Get the published package name and version
+PUBLISHED_PACKAGE=$PACKAGE_NAME@$PACKAGE_VERSION
+
+# Install the package from npm
+install_package(){
+  echo "Installing package: $PUBLISHED_PACKAGE"
+  mkdir -p ./tmp \
+    && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
+    && cd ./tmp/node_modules
+}
+
+# Upload the package files to the CDN
+upload_to_cdn() {
+  echo "Uploading published package to CDN: $PUBLISHED_PACKAGE"
+  aws s3 sync ./$PACKAGE_NAME s3://$CDN_BUCKET/"$PUBLISHED_PACKAGE" --delete
+  aws s3 sync ./$PACKAGE_NAME s3://$CDN_BUCKET/$PACKAGE_NAME@latest --delete
+  aws s3api head-object --bucket $CDN_BUCKET --key "$PUBLISHED_PACKAGE"/package.json
+  aws s3api head-object --bucket $CDN_BUCKET --key $PACKAGE_NAME@latest/package.json
+
+  aws cloudfront create-invalidation --distribution-id $CDN_CLOUDFRONT_DIST_ID --paths "/*"
+}
+
+# Retry function
+retry() {
+  local retries=$1
+  local delay=$2
+  local count=0
+
+  while [[ $count -lt $retries ]]; do
+    # Upload the package to the CDN if the package is available and was installed
+    if install_package; then
+      upload_to_cdn
+      return 0
+    fi
+
+    count=$((count + 1))
+    echo "Retry $count/$retries failed. Retrying in $delay seconds..."
+    sleep $delay
+  done
+
+  echo "All $retries retries failed."
+  return 1
+}
+
+# Retry 3 times with a 5-second delay in between
+retry 3 5

--- a/utils/scripts/upload_to_cdn.sh
+++ b/utils/scripts/upload_to_cdn.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Get the published package name
+PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
+
+mkdir -p ./tmp \
+  && sleep 60 \
+  && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
+  && cd ./tmp/node_modules
+
+aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
+aws s3 sync ./${{ matrix.name }} s3://${{ env.CDN_BUCKET }}/${{ matrix.name }}@latest --delete
+aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
+aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ matrix.name }}@latest/package.json
+
+aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"


### PR DESCRIPTION
# Summary | Résumé
Refactor: separate the CDN upload process and add a retry to wait for npm publishing to complete 
_Fix for:_
- https://github.com/cds-snc/design-gc-conception/issues/907

This adds a `retry` functionality to the part where the files get uploaded to the CDN. The script usually fails if the package is not yet available on NPM, especially if it's a new package.

### New Github workflow file `upload-cdn.yml`
This separates the CDN upload part in a script called `upload_to_cdn.sh`, which runs on **new** the GitHub workflow file `upload-cdn.yml`.
- The workflow action runs after the `compile-and-publish.yml` workflow is completed.
- We can run it manually if we need to -- you can run it multiple times because it just updates the files based on the NPM version of the specified package.




## Tested with my scratch account at the moment
I ran our [terraform files](https://github.com/cds-snc/gcds-terraform) on my scratch account and linked our CDN to my custom domain.

Here are the links for quick testing, to make sure they do upload correctly:
  - [ ] https://cdn.ds.daine.app/@cdssnc/gcds-components@0.22.1/dist/gcds/gcds.css
  - [ ] https://cdn.ds.daine.app/@cdssnc/gcds-components@latest/dist/gcds/gcds.css
  - [ ] https://cdn.ds.daine.app/@cdssnc/gcds-components@0.22.1/dist/gcds/gcds.esm.js
  - [ ] https://cdn.ds.daine.app/@cdssnc/gcds-components@latest/dist/gcds/gcds.esm.js
  - [ ] https://cdn.ds.daine.app/@cdssnc/gcds-components@0.22.1/dist/gcds/gcds.js
  - [ ] https://cdn.ds.daine.app/@cdssnc/gcds-components@latest/dist/gcds/gcds.js

Testing `@latest` and `@0.22.1` are exactly the same:
```
$ wget https://cdn.ds.daine.app/@cdssnc/gcds-components@0.22.1/dist/gcds/gcds.css
$ wget https://cdn.ds.daine.app/@cdssnc/gcds-components@latest/dist/gcds/gcds.css
$ ls -alh
    38K 18 Jun 09:26 gcds.css
    38K 18 Jun 09:26 gcds.css.1
$ diff gcds.css gcds.css.1
// nothing; exactly the same
```


---

### S3 Bucket
```
gc-design-system-daine-scratch-cdn
@cds-snc/gcds-components@latest/
```

Confirmed: Contents are the same, file size is the same.