### PR TITLE
refactor: update logic check on when to run upload-to-cdn

### DIFF
--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -28,7 +28,8 @@ jobs:
           exit 1
 
   upload-to-cdn:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Runs on manual triggers (workflow_dispatch), or if the workflow run "Publish packages" was successful
+    if: ${{ github.event_name != 'workflow_run' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
# Summary | Résumé
This is an update to the previous PR #563:
- #563 

To make sure the `github.event.workflow_run.conclusion` check doesn't fail, add an additional check that the event name is `workflow_run`.

I tested this gh action on my own repo
- ✅ [Run is triggered by a workflow (publish packages)](https://github.com/daine/gcds-components/actions/runs/9589823863)
- ✅ [Run is triggered manually (workflow_dispatch)](https://github.com/daine/gcds-components/actions/runs/9589902265)

Both ran successfully