### PR TITLE
fix: Remove rxjs events to avoid duplicate custom events in Angular

### DIFF
--- a/packages/angular/src/lib/stencil-generated/angular-component-lib/utils.ts
+++ b/packages/angular/src/lib/stencil-generated/angular-component-lib/utils.ts
@@ -1,8 +1,10 @@
 /* eslint-disable */
 /* tslint:disable */
 /**
- * Custom modification
- * - Replaced import { fromEvent } from 'rxjs'; with import { EventEmitter } from '@angular/core';
+ * GCDS Modification
+ * Replaced 
+ *     import { fromEvent } from 'rxjs'; 
+ * From: https://github.com/ionic-team/stencil-ds-output-targets/blob/9524c1ce970770e01afb493c292f71a2fe61b14a/packages/angular-output-target/angular-component-lib/utils.ts#L3
  */
 import { EventEmitter } from '@angular/core';
 
@@ -39,8 +41,12 @@ export const proxyMethods = (Cmp: any, methods: string[]) => {
 };
 
 /**
- * Custom modification
- * - Replaced fromEvent from rxjs package with EventEmitter from @angular/core
+ * GCDS modification
+ * Replaced 
+ *   fromEvent(el, eventName)
+ * to
+ *   new EventEmitter()
+ * From: https://github.com/ionic-team/stencil-ds-output-targets/blob/9524c1ce970770e01afb493c292f71a2fe61b14a/packages/angular-output-target/angular-component-lib/utils.ts#L38
  */
 export const proxyOutputs = (instance: any, events: string[]) => {
   events.forEach((eventName) => (instance[eventName] = new EventEmitter()));

--- a/packages/angular/src/lib/stencil-generated/angular-component-lib/utils.ts
+++ b/packages/angular/src/lib/stencil-generated/angular-component-lib/utils.ts
@@ -1,6 +1,10 @@
 /* eslint-disable */
 /* tslint:disable */
-import { fromEvent } from 'rxjs';
+/**
+ * Custom modification
+ * - Replaced import { fromEvent } from 'rxjs'; with import { EventEmitter } from '@angular/core';
+ */
+import { EventEmitter } from '@angular/core';
 
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
@@ -34,8 +38,12 @@ export const proxyMethods = (Cmp: any, methods: string[]) => {
   });
 };
 
-export const proxyOutputs = (instance: any, el: any, events: string[]) => {
-  events.forEach((eventName) => (instance[eventName] = fromEvent(el, eventName)));
+/**
+ * Custom modification
+ * - Replaced fromEvent from rxjs package with EventEmitter from @angular/core
+ */
+export const proxyOutputs = (instance: any, events: string[]) => {
+  events.forEach((eventName) => (instance[eventName] = new EventEmitter()));
 };
 
 export const defineCustomElement = (tagName: string, customElement: any) => {

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -23,7 +23,7 @@ export class GcdsAlert {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsDismiss']);
+    proxyOutputs(this, ['gcdsDismiss']);
   }
 }
 
@@ -96,7 +96,7 @@ export class GcdsButton {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
+    proxyOutputs(this, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
   }
 }
 
@@ -156,7 +156,7 @@ export class GcdsCheckbox {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsClick', 'gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, ['gcdsClick', 'gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -250,7 +250,7 @@ export class GcdsDetails {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
+    proxyOutputs(this, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
   }
 }
 
@@ -332,7 +332,7 @@ export class GcdsFieldset {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsGroupError', 'gcdsGroupErrorClear', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, ['gcdsGroupError', 'gcdsGroupErrorClear', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -374,7 +374,7 @@ export class GcdsFileUploader {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -582,7 +582,7 @@ export class GcdsInput {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsInput', 'gcdsChange', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, ['gcdsFocus', 'gcdsBlur', 'gcdsInput', 'gcdsChange', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -675,7 +675,7 @@ export class GcdsLink {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
+    proxyOutputs(this, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
   }
 }
 
@@ -713,7 +713,7 @@ export class GcdsNavGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
+    proxyOutputs(this, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
   }
 }
 
@@ -751,7 +751,7 @@ export class GcdsNavLink {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
+    proxyOutputs(this, ['gcdsClick', 'gcdsFocus', 'gcdsBlur']);
   }
 }
 
@@ -788,7 +788,7 @@ export class GcdsPagination {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
+    proxyOutputs(this, ['gcdsFocus', 'gcdsBlur', 'gcdsClick']);
   }
 }
 
@@ -847,7 +847,7 @@ export class GcdsRadioGroup {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsChange', 'gcdsFocus', 'gcdsBlur']);
+    proxyOutputs(this, ['gcdsChange', 'gcdsFocus', 'gcdsBlur']);
   }
 }
 
@@ -884,7 +884,7 @@ export class GcdsSearch {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsInput', 'gcdsChange', 'gcdsFocus', 'gcdsBlur', 'gcdsSubmit']);
+    proxyOutputs(this, ['gcdsInput', 'gcdsChange', 'gcdsFocus', 'gcdsBlur', 'gcdsSubmit']);
   }
 }
 
@@ -930,7 +930,7 @@ export class GcdsSelect {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsChange', 'gcdsInput', 'gcdsFocus', 'gcdsBlur', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, ['gcdsChange', 'gcdsInput', 'gcdsFocus', 'gcdsBlur', 'gcdsError', 'gcdsValid']);
   }
 }
 
@@ -1091,7 +1091,7 @@ export class GcdsTextarea {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsError', 'gcdsValid']);
+    proxyOutputs(this, ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsError', 'gcdsValid']);
   }
 }
 

--- a/utils/angular-output-target/__tests__/generate-angular-component.spec.ts
+++ b/utils/angular-output-target/__tests__/generate-angular-component.spec.ts
@@ -68,7 +68,7 @@ export class MyComponent {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['my-output', 'my-other-output']);
+    proxyOutputs(this, ['my-output', 'my-other-output']);
   }
 }`);
     });
@@ -166,7 +166,7 @@ export class MyComponent {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['my-output', 'my-other-output']);
+    proxyOutputs(this, ['my-output', 'my-other-output']);
   }
 }`);
     });

--- a/utils/angular-output-target/angular-component-lib/utils.ts
+++ b/utils/angular-output-target/angular-component-lib/utils.ts
@@ -1,8 +1,10 @@
 /* eslint-disable */
 /* tslint:disable */
 /**
- * Custom modification
- * - Replaced import { fromEvent } from 'rxjs'; with import { EventEmitter } from '@angular/core';
+ * GCDS Modification
+ * Replaced 
+ *     import { fromEvent } from 'rxjs'; 
+ * From: https://github.com/ionic-team/stencil-ds-output-targets/blob/9524c1ce970770e01afb493c292f71a2fe61b14a/packages/angular-output-target/angular-component-lib/utils.ts#L3
  */
 import { EventEmitter } from '@angular/core';
 
@@ -39,8 +41,12 @@ export const proxyMethods = (Cmp: any, methods: string[]) => {
 };
 
 /**
- * Custom modification
- * - Replaced fromEvent from rxjs package with EventEmitter from @angular/core
+ * GCDS modification
+ * Replaced 
+ *   fromEvent(el, eventName)
+ * to
+ *   new EventEmitter()
+ * From: https://github.com/ionic-team/stencil-ds-output-targets/blob/9524c1ce970770e01afb493c292f71a2fe61b14a/packages/angular-output-target/angular-component-lib/utils.ts#L38
  */
 export const proxyOutputs = (instance: any, events: string[]) => {
   events.forEach((eventName) => (instance[eventName] = new EventEmitter()));

--- a/utils/angular-output-target/angular-component-lib/utils.ts
+++ b/utils/angular-output-target/angular-component-lib/utils.ts
@@ -1,6 +1,10 @@
 /* eslint-disable */
 /* tslint:disable */
-import { fromEvent } from 'rxjs';
+/**
+ * Custom modification
+ * - Replaced import { fromEvent } from 'rxjs'; with import { EventEmitter } from '@angular/core';
+ */
+import { EventEmitter } from '@angular/core';
 
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
@@ -34,8 +38,12 @@ export const proxyMethods = (Cmp: any, methods: string[]) => {
   });
 };
 
-export const proxyOutputs = (instance: any, el: any, events: string[]) => {
-  events.forEach((eventName) => (instance[eventName] = fromEvent(el, eventName)));
+/**
+ * Custom modification
+ * - Replaced fromEvent from rxjs package with EventEmitter from @angular/core
+ */
+export const proxyOutputs = (instance: any, events: string[]) => {
+  events.forEach((eventName) => (instance[eventName] = new EventEmitter()));
 };
 
 export const defineCustomElement = (tagName: string, customElement: any) => {

--- a/utils/angular-output-target/src/generate-angular-component.ts
+++ b/utils/angular-output-target/src/generate-angular-component.ts
@@ -52,7 +52,7 @@ export const createAngularComponentDefinition = (
   }
 
   /**
-   * Custom modification
+   * GCDS modification
    * - Added conditional to add outputs
    */
   if (hasOutputs) {
@@ -72,9 +72,11 @@ export const createAngularComponentDefinition = (
    * uses the inputs property to define the inputs of the component instead of
    * having to use the @Input decorator (and manually define the type and default value).
    * 
-   * Custom modifications
-   * - Add hasOutputs logic to render outputs
-   * - Modify proxyOutouts to remove second parameter "this.el"
+   * GCDS modifications
+   * - Added `hasOutputs` logic to render outputs
+   * - Modified proxyOutputs to remove second parameter `this.el`
+   *      proxyOutputs(this, this.el, [${formattedOutputs}]);`
+   *   From: https://github.com/ionic-team/stencil-ds-output-targets/blob/9524c1ce970770e01afb493c292f71a2fe61b14a/packages/angular-output-target/src/generate-angular-component.ts#L82
    */
   const output = `@ProxyCmp({${proxyCmpOptions.join(',')}\n})
 @Component({

--- a/utils/angular-output-target/src/generate-angular-component.ts
+++ b/utils/angular-output-target/src/generate-angular-component.ts
@@ -51,6 +51,10 @@ export const createAngularComponentDefinition = (
     proxyCmpOptions.push(`\n  methods: [${formattedMethods}]`);
   }
 
+  /**
+   * Custom modification
+   * - Added conditional to add outputs
+   */
   if (hasOutputs) {
     proxyCmpOptions.push(`\n  outputs: [${formattedOutputs}]`);
   }
@@ -67,6 +71,10 @@ export const createAngularComponentDefinition = (
    * Angular does not complain about the inputs property. The output target
    * uses the inputs property to define the inputs of the component instead of
    * having to use the @Input decorator (and manually define the type and default value).
+   * 
+   * Custom modifications
+   * - Add hasOutputs logic to render outputs
+   * - Modify proxyOutouts to remove second parameter "this.el"
    */
   const output = `@ProxyCmp({${proxyCmpOptions.join(',')}\n})
 @Component({
@@ -83,7 +91,7 @@ export class ${tagNameAsPascal} {
     this.el = r.nativeElement;${
       hasOutputs
         ? `
-    proxyOutputs(this, this.el, [${formattedOutputs}]);`
+    proxyOutputs(this, [${formattedOutputs}]);`
         : ''
     }
   }


### PR DESCRIPTION
# Summary | Résumé

With the `v0.22.0` release of the `@cdssnc/gcds-components-angular`, `@Outputs` were added to the generated angular components. Unfortunately this was now causing custom events like `gcdsClick` to be emitted twice.

To fix, I removed Stencil's implementation of events from `rxjs` to remove the duplicate emitted events.

## Example angular component

```
import {Component} from '@angular/core';

@Component({
  selector: 'app-click-me-gcds',
  template: ` <gcds-button type="button" (gcdsClick)="onClickMe()">Click me!</gcds-button>
    <gcds-pagination type="list" current-page="3" total-pages="20" (gcdsClick)="onClick($event)"></gcds-pagination>
`,
})
export class ClickMeGcdsComponent {
  clickMessage = '';

  onClickMe() {
    console.log('clicked')
  }
  onClick(event: any) {
    event.preventDefault();
    console.log(event.detail)
  }
}
```

Previously the `gcdsClick` would be emitted twice when either the button or pagination links were clicked. Now only one event is emitted.