### PR TITLE
chore(storybook): Fix display of property names in storybook

### DIFF
--- a/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
+++ b/packages/web/src/components/gcds-pagination/stories/gcds-pagination.stories.tsx
@@ -25,6 +25,7 @@ export default {
       },
     },
     nextHref: {
+      name: 'next-href',
       control: 'text',
       table: {
         type: { summary: 'string' },
@@ -32,6 +33,7 @@ export default {
       },
     },
     nextLabel: {
+      name: 'next-label',
       control: 'text',
       table: {
         type: { summary: 'string' },
@@ -39,6 +41,7 @@ export default {
       },
     },
     previousHref: {
+      name: 'previous-href',
       control: 'text',
       table: {
         type: { summary: 'string' },
@@ -46,6 +49,7 @@ export default {
       },
     },
     previousLabel: {
+      name: 'previous-label',
       control: 'text',
       table: {
         type: { summary: 'string' },
@@ -53,6 +57,7 @@ export default {
       },
     },
     totalPages: {
+      name: 'total-pages',
       control: 'text',
       table: {
         type: { summary: 'string' },
@@ -60,6 +65,7 @@ export default {
       },
     },
     currentPage: {
+      name: 'current-page',
       control: 'text',
       table: {
         type: { summary: 'string' },

--- a/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
+++ b/packages/web/src/components/gcds-signature/stories/gcds-signature.stories.tsx
@@ -14,6 +14,7 @@ export default {
       },
     },
     hasLink: {
+      name: 'has-link',
       control: { type: 'select' },
       options: [false, true],
       table: {


### PR DESCRIPTION
# Summary | Résumé

Noticed a couple properties in storybook were not displaying in the correct format in the signature and pagination. Switch from `propertyName` to `property-name` format.
