### PR TITLE
fix: Safari a11y issues with links and nav group focus

### DIFF
--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -39,8 +39,10 @@
       padding: var(--gcds-details-summary-padding);
       color: var(--gcds-details-default-text);
       font: var(--gcds-details-font);
-      text-decoration: underline
-        var(--gcds-details-default-decoration-thickness);
+      text-decoration-style: solid;
+      text-decoration-line: underline;
+      text-decoration-color: currentColor;
+      text-decoration-thickness: var(--gcds-details-default-decoration-thickness);
       text-underline-offset: 0.2em;
       transition:
         background-color 0.15s ease-in-out,

--- a/packages/web/src/components/gcds-link/gcds-link.css
+++ b/packages/web/src/components/gcds-link/gcds-link.css
@@ -14,9 +14,9 @@
   :host .gcds-link {
     cursor: pointer;
     color: var(--gcds-link-default);
-    text-decoration: underline currentColor
-      var(--gcds-link-decoration-thickness);
-    text-underline-offset: var(--gcds-link-underline-offset);
+    text-decoration-style: solid;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: var(--gcds-link-decoration-thickness);
     transition: all 0.35s;
   }
 }

--- a/packages/web/src/components/gcds-link/gcds-link.css
+++ b/packages/web/src/components/gcds-link/gcds-link.css
@@ -17,6 +17,7 @@
     text-decoration-style: solid;
     text-decoration-color: currentColor;
     text-decoration-thickness: var(--gcds-link-decoration-thickness);
+    text-underline-offset: var(--gcds-link-underline-offset);
     transition: all 0.35s;
   }
 }

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -75,7 +75,7 @@ export class GcdsNavGroup {
       this.navStyle === 'dropdown' &&
       this.open
     ) {
-      this.toggleNav();
+      setTimeout(() => this.toggleNav(), 200)
     }
   }
 

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -75,7 +75,7 @@ export class GcdsNavGroup {
       this.navStyle === 'dropdown' &&
       this.open
     ) {
-      setTimeout(() => this.toggleNav(), 200)
+      setTimeout(() => this.toggleNav(), 200);
     }
   }
 

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
@@ -14,8 +14,10 @@
   :host .gcds-nav-link {
     display: flex;
     font: var(---gcds-nav-link-font);
-    text-decoration: underline solid currentColor
-      var(--gcds-nav-link-default-decoration-thickness);
+    text-decoration-style: solid;
+    text-decoration-line: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: var(--gcds-nav-link-default-decoration-thickness);
     text-underline-offset: var(--gcds-nav-link-default-underline-offset);
     color: var(--gcds-nav-link-default-text);
     margin-block-end: var(--gcds-nav-link-margin);

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -678,19 +678,19 @@
 
       <gcds-heading tag="h2">Side navigation</gcds-heading>
       <gcds-side-nav class="mt-700" label="Sidenav">
-        <gcds-nav-link href="#red">Installation</gcds-nav-link>
-        <gcds-nav-link href="#red" current>Foundations</gcds-nav-link>
-        <gcds-nav-link href="#red">Components</gcds-nav-link>
+        <gcds-nav-link href="#installation">Installation</gcds-nav-link>
+        <gcds-nav-link href="#foundations" current>Foundations</gcds-nav-link>
+        <gcds-nav-link href="#components">Components</gcds-nav-link>
         <gcds-nav-group menu-label="Contact submenu" open-trigger="Contact">
-          <gcds-nav-link href="#red">Site</gcds-nav-link>
-          <gcds-nav-link href="#red">GitHub</gcds-nav-link>
+          <gcds-nav-link href="#site1">Site</gcds-nav-link>
+          <gcds-nav-link href="#github1">GitHub</gcds-nav-link>
           <gcds-nav-group
             menu-label="Sub level submenu"
             open-trigger="Sub level"
           >
-            <gcds-nav-link href="#red">Site</gcds-nav-link>
-            <gcds-nav-link href="#red">GitHub</gcds-nav-link>
-            <gcds-nav-link href="#red">Slack</gcds-nav-link>
+            <gcds-nav-link href="#site2">Site</gcds-nav-link>
+            <gcds-nav-link href="#github2">GitHub</gcds-nav-link>
+            <gcds-nav-link href="#slack">Slack</gcds-nav-link>
           </gcds-nav-group>
         </gcds-nav-group>
       </gcds-side-nav>
@@ -701,17 +701,17 @@
 
       <gcds-heading tag="h2">Top navigation</gcds-heading>
       <gcds-top-nav label="topbar" alignment="right" lang="en">
-        <gcds-nav-link href="#red" slot="home">Home</gcds-nav-link>
-        <gcds-nav-link href="#red">Installation</gcds-nav-link>
-        <gcds-nav-link href="#red">Foundations</gcds-nav-link>
-        <gcds-nav-link href="#red" current>Components</gcds-nav-link>
+        <gcds-nav-link href="#home" slot="home">Home</gcds-nav-link>
+        <gcds-nav-link href="#install">Installation</gcds-nav-link>
+        <gcds-nav-link href="#foundations">Foundations</gcds-nav-link>
+        <gcds-nav-link href="#components" current>Components</gcds-nav-link>
         <gcds-nav-group
           menu-label="Contact us submenu"
           open-trigger="Contact us"
         >
-          <gcds-nav-link href="#red">Form</gcds-nav-link>
-          <gcds-nav-link href="#red">GitHub</gcds-nav-link>
-          <gcds-nav-link href="#red">Slack</gcds-nav-link>
+          <gcds-nav-link href="#form">Form</gcds-nav-link>
+          <gcds-nav-link href="#github">GitHub</gcds-nav-link>
+          <gcds-nav-link href="#slack">Slack</gcds-nav-link>
         </gcds-nav-group>
       </gcds-top-nav>
 


### PR DESCRIPTION
# Summary | Résumé

FIx a couple issues related to how Safari renders and handles focus.

## Links not rendering with underline https://github.com/cds-snc/gcds-components/issues/576

Safari does not accept the `text-decoration` shorthand so switched to using all properties.

## Unable to click nested links in a top-nav nav-group https://github.com/cds-snc/gcds-components/issues/577

Safari handles focus a little differently from other browsers so the dropdown logic logic would fire before the `nav-link` click event could be called. Added a small timeout to the `focusout` listener function to allow the `gcds-nav-link` click to go through.