### PR TITLE
chore: angular-output-target package build fix

### DIFF
--- a/utils/angular-output-target/package-lock.json
+++ b/utils/angular-output-target/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@stencil/angular-output-target",
       "version": "0.8.4",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@angular/core": "^16.2.12",

--- a/utils/angular-output-target/package.json
+++ b/utils/angular-output-target/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
+    "preinstall": "rm -rf node_modules",
     "prebuild": "rimraf ./dist && npm run test",
     "build": "tsc && npm run rollup",
     "watch": "tsc --watch",


### PR DESCRIPTION
# Summary | Résumé

Solve issue with the `angular-output-target` build workflow. Since https://github.com/cds-snc/gcds-components/commit/f00ae0f6d99b902aa5a65b1c63dcf807503fe2e9 running `npm install` in the project root had a chance to fail.
