### PR TITLE
build: Remove lerna and use npm workspace in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ng": "ng",
     "compile": "gulp compile",
-    "build": "npx lerna run build --concurrency=1",
+    "build": "npm run build --ws",
     "pretest": "npm run patch:stenciljs",
     "test": "npx lerna run test",
     "build-storybook": "npx lerna run build-storybook --scope=@cdssnc/gcds-components",
@@ -49,6 +49,7 @@
     "workbox-build": "^7.0.0"
   },
   "workspaces": [
+    "utils/angular-output-target",
     "packages/web",
     "packages/angular",
     "packages/react",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,8 +21,6 @@
     "access": "public"
   },
   "scripts": {
-    "postinstall": "cd ../../utils/angular-output-target && npm install",
-    "prebuild": "cd ../../utils/angular-output-target && npm run build",
     "build": "stencil build --docs",
     "postbuild": "node ./scripts/copyCSSFile.js",
     "start": "stencil build --dev --watch --serve",


### PR DESCRIPTION
# Summary | Résumé

Lerna has been causing an issue with build order by not building the packages in the correct order. Switch the main build script to use npm workspace build instead of Lerna to build in the proper order.
