### PR TITLE
ci: add react-ssr to release please grouping

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -58,6 +58,7 @@
       "components": [
         "gcds-components-angular",
         "gcds-components-react",
+        "gcds-components-react-ssr",
         "gcds-components-vue",
         "gcds-components"
       ]
@@ -68,6 +69,7 @@
         "gcds-components",
         "gcds-components-angular",
         "gcds-components-react",
+        "gcds-components-react-ssr",
         "gcds-components-vue"
 
       ]


### PR DESCRIPTION
# Summary | Résumé
Release please creates a different version for the react-ssr package, hopefully if we add it to the linked versions it'll be on the same version too.