### PR TITLE
fix: update small design misalignments in various components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,9 +2819,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.15.0.tgz",
-      "integrity": "sha512-gTrjdgOMcUHnB7EGmuNvm2hxOze2IHY2VaSLkMXnfYA4m8TCF6rrWkXtJiVYMKnkyKQIgHUDPmzIdCfxyrqaEg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.15.1.tgz",
+      "integrity": "sha512-SjKPqX1C6QfY3z4hwkmDU/ayp8/KED6OpAf+Jd5UcHsK4VzPgDYMC4PSWq8w4NiGV6bFd9adlz1/JrQrVBMNIw==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -48548,7 +48548,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.15.0",
+        "@cdssnc/gcds-tokens": "^1.15.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",
@@ -49614,7 +49614,7 @@
         "ts-jest": "^26.2.0"
       },
       "peerDependencies": {
-        "@stencil/core": "4.11.0"
+        "@stencil/core": ">=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0"
       }
     },
     "utils/angular-output-target/node_modules/@jest/console": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,9 +2819,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.15.1.tgz",
-      "integrity": "sha512-SjKPqX1C6QfY3z4hwkmDU/ayp8/KED6OpAf+Jd5UcHsK4VzPgDYMC4PSWq8w4NiGV6bFd9adlz1/JrQrVBMNIw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.16.0.tgz",
+      "integrity": "sha512-fYitZ3CWpu6v4UOY2D2qSR0tcExys8yY5qeEwLb07UoiGPUt/oS+26TXgvcRZ04QbNLNzev2kziSe9Q4cLKUkA==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -48548,7 +48548,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.15.1",
+        "@cdssnc/gcds-tokens": "^1.16.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.15.1",
+    "@cdssnc/gcds-tokens": "^1.16.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.15.0",
+    "@cdssnc/gcds-tokens": "^1.15.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
+++ b/packages/web/src/components/gcds-breadcrumbs/gcds-breadcrumbs-item.css
@@ -1,4 +1,4 @@
-@layer reset, default, hover, focus;
+@layer reset, default, hover, focus, mobile;
 
 @layer reset {
   :host(.gcds-breadcrumbs-item) {
@@ -30,6 +30,24 @@
     gcds-link::part(link) {
       margin: var(--gcds-breadcrumbs-item-margin);
       padding: var(--gcds-breadcrumbs-item-link-padding);
+    }
+  }
+}
+
+/* Note: mobile specific style decision */
+@layer mobile {
+  @media screen and (max-width: 30rem) {
+    :host(.gcds-breadcrumbs-item) {
+      display: block;
+
+      &:before {
+        top: var(--gcds-breadcrumbs-mobile-item-arrow-top);
+      }
+
+      gcds-link::part(link) {
+        margin: var(--gcds-breadcrumbs-mobile-item-margin);
+        padding: var(--gcds-breadcrumbs-mobile-item-padding);
+      }
     }
   }
 }

--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
@@ -51,7 +51,7 @@ export class GcdsDateModified {
         <dl class="gcds-date-modified">
           <dt>
             <gcds-text display="inline" margin-bottom="0">
-              {type === 'version' ? 'Version ' : i18n[lang].term}
+              {type === 'version' ? i18n[lang].version : i18n[lang].date}
             </gcds-text>
           </dt>
           <dd>

--- a/packages/web/src/components/gcds-date-modified/i18n/i18n.js
+++ b/packages/web/src/components/gcds-date-modified/i18n/i18n.js
@@ -1,9 +1,11 @@
 const I18N = {
   en: {
-    term: 'Date modified:',
+    date: 'Date modified:',
+    version: 'Version ',
   },
   fr: {
-    term: 'Date de modification :',
+    date: 'Date de modification :',
+    version: 'Version ',
   },
 };
 

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -39,10 +39,13 @@
       padding: var(--gcds-details-summary-padding);
       color: var(--gcds-details-default-text);
       font: var(--gcds-details-font);
+      text-align: left;
       text-decoration-style: solid;
       text-decoration-line: underline;
       text-decoration-color: currentColor;
-      text-decoration-thickness: var(--gcds-details-default-decoration-thickness);
+      text-decoration-thickness: var(
+        --gcds-details-default-decoration-thickness
+      );
       text-underline-offset: 0.2em;
       transition:
         background-color 0.15s ease-in-out,

--- a/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
+++ b/packages/web/src/components/gcds-error-message/stories/gcds-error-message.stories.tsx
@@ -53,7 +53,7 @@ const TemplatePlayground = args => `
 export const Default = Template.bind({});
 Default.args = {
   messageId: 'message-default',
-  default: 'Error message or validation message.',
+  default: 'Error message.',
 };
 
 // ------ Error message events & props ------
@@ -61,7 +61,7 @@ Default.args = {
 export const Props = Template.bind({});
 Props.args = {
   messageId: 'message-props',
-  default: 'Error message or validation message.',
+  default: 'Error message.',
 };
 
 // ------ Error message playground ------
@@ -69,5 +69,5 @@ Props.args = {
 export const Playground = TemplatePlayground.bind({});
 Playground.args = {
   messageId: 'message-playground',
-  default: 'Error message or validation message.',
+  default: 'Error message.',
 };

--- a/packages/web/src/components/gcds-label/gcds-label.css
+++ b/packages/web/src/components/gcds-label/gcds-label.css
@@ -31,6 +31,7 @@
     }
 
     .label--required {
+      font-weight: var(--gcds-label-required-font-weight);
       margin: var(--gcds-label-required-margin) !important;
     }
   }

--- a/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
+++ b/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
@@ -177,9 +177,9 @@ export class GcdsSideNav {
           <h2 class="gcds-side-nav__heading">{label}</h2>
           <ul>
             <gcds-nav-group
-              menuLabel="Menu"
-              closeTrigger={lang == 'fr' ? 'Fermer' : 'Close'}
-              openTrigger="Menu"
+              menuLabel={I18N[lang].menuLabel}
+              closeTrigger={I18N[lang].closeTrigger}
+              openTrigger={I18N[lang].menuLabel}
               class="gcds-mobile-nav"
               ref={element =>
                 (this.mobile = element as HTMLGcdsNavGroupElement)

--- a/packages/web/src/components/gcds-side-nav/i18n/i18n.js
+++ b/packages/web/src/components/gcds-side-nav/i18n/i18n.js
@@ -1,9 +1,13 @@
 const I18N = {
   en: {
+    closeTrigger: 'Close',
+    menuLabel: 'Menu',
     navLabel:
       ' - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu.',
   },
   fr: {
+    closeTrigger: 'Fermer',
+    menuLabel: 'Menu',
     navLabel:
       " - Utiliser la touche d'entrée pour sélectionner un élément du menu et voyager à la page indiquée. Utiliser les flèches gauches et droites pour naviguer entre les éléments et les sous-éléments du menu. Ouvrir les sous-éléments du menu avec la flèche droite lorsqu'il sont disponible. Fermer le menu avec la flèche gauche ou la touche d'échappement.",
   },

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
@@ -180,9 +180,9 @@ export class GcdsTopNav {
           <nav aria-label={`${label}${I18N[lang].navLabel}`}>
             <ul class="gcds-top-nav__container">
               <gcds-nav-group
-                menuLabel="Menu"
-                closeTrigger={lang == 'fr' ? 'Fermer' : 'Close'}
-                openTrigger="Menu"
+                menuLabel={I18N[lang].menuLabel}
+                closeTrigger={I18N[lang].closeTrigger}
+                openTrigger={I18N[lang].menuLabel}
                 class="gcds-mobile-nav gcds-mobile-nav-topnav"
                 ref={element =>
                   (this.mobile = element as HTMLGcdsNavGroupElement)

--- a/packages/web/src/components/gcds-top-nav/i18n/i18n.js
+++ b/packages/web/src/components/gcds-top-nav/i18n/i18n.js
@@ -1,9 +1,13 @@
 const I18N = {
   en: {
+    closeTrigger: 'Close',
+    menuLabel: 'Menu',
     navLabel:
       ' - Use the enter key to select a menu item and travel to its page. Use the left and right arrow keys to navigate between menu and submenu items. Use the right arrow key to open submenus when they are available. Use the left arrow or escape keys to close a menu.',
   },
   fr: {
+    closeTrigger: 'Fermer',
+    menuLabel: 'Menu',
     navLabel:
       " - Utiliser la touche d'entrée pour sélectionner un élément du menu et voyager à la page indiquée. Utiliser les flèches gauches et droites pour naviguer entre les éléments et les sous-éléments du menu. Ouvrir les sous-éléments du menu avec la flèche droite lorsqu'il sont disponible. Fermer le menu avec la flèche gauche ou la touche d'échappement.",
   },


### PR DESCRIPTION
# Summary | Résumé

Update small design misalignments in various components:

- Update Storybook error message text to match docs site
- Move integrated content for date-modified, side-nav, and top-nav components into their i18n files
- Update required label to use regular font weight
- Style breadcrumbs as list for smaller screens
- Always left-align button text in details summary