### PR TITLE
fix: change fieldset legend required to span

### DIFF
--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -309,7 +309,7 @@ export class GcdsFieldset {
           <legend id={`legend-${fieldsetId}`}>
             {legend}
             {required ? (
-              <strong class="legend__required">({i18n[lang].required})</strong>
+              <span class="legend__required">({i18n[lang].required})</span>
             ) : null}
           </legend>
 

--- a/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
+++ b/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.spec.tsx
@@ -31,9 +31,9 @@ describe('gcds-fieldset', () => {
           <fieldset class="gcds-fieldset" aria-labelledby="legend-field" id="field" tabindex="-1">
             <legend id="legend-field">
               Fieldset legend
-              <strong class="legend__required">
+              <span class="legend__required">
                 (required)
-              </strong>
+              </span>
             </legend>
             <slot></slot>
           </fieldset>


### PR DESCRIPTION
# Summary | Résumé

Teeny tiny PR to update the fieldset legend required from a `strong` tag to a `span` tag since it won't be bold moving forward anymore.