### PR TITLE
Update issues contribute to next drop down menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributions.yml
+++ b/.github/ISSUE_TEMPLATE/contributions.yml
@@ -42,7 +42,6 @@ body:
       label: Which component or pattern is this contribution for? | Quel composant ou quelle configuration cette contribution vise-t-elle?
       options:
         - Data Table | Tableau de données
-        - Image | Image
         - Tags | Étiquettes
     validations:
       required: true


### PR DESCRIPTION
Update the "Contribute to next priorities" issues page in Github to reflect what is listed on the Get Involved page.  

Offer "data table" and "tag"; remove "image"

