### PR TITLE
build: Fix npm build on MS window native

### DIFF
--- a/packages/react-ssr/scripts/build.ts
+++ b/packages/react-ssr/scripts/build.ts
@@ -30,7 +30,11 @@ const createReactWrapperModules = async ({ entryPoints, distRoot }) => {
     const enums = parseEnums(componentsTypeSource);
 
     let i = 0;
-    for (const importPath of entryPoints) {
+    for (let importPath of entryPoints) {
+
+      // Build on Window: File prefix required
+      importPath = importPath.replace( /^[A-Z]:\\/, 'file://$&' );
+
       const component = await import(importPath);
 
       let defineFunctionName = 'd';

--- a/utils/angular-output-target/__tests__/generate-value-accessors.spec.ts
+++ b/utils/angular-output-target/__tests__/generate-value-accessors.spec.ts
@@ -41,6 +41,6 @@ export class TextValueAccessor extends ValueAccessor {
     super(el);
   }
 }`;
-    expect(finalText.trim()).toEqual(exptectedOutput.trim().replace(/\n/g, EOL));
+    expect(finalText.trim().replace(/\r/g, "").replace(/\n/g, EOL)).toEqual(exptectedOutput.trim().replace(/\n/g, EOL));
   });
 });


### PR DESCRIPTION
# Summary | Résumé

This fixes the installation and build scripts when executed directly on the MS Windows operating system.

# Test instructions | Instructions pour tester la modification

1. Clone the repository on a Windows workstation where only NodeJS 18/20 is installed.
2. run `npm install`:
  * **Without** the fix: The installation build stops during the test execution of `generate-value-accessors.spec.ts``.
  * **With** the fix: The installation will proceed and successfully finish as expected.
3. run `npm run build`:
  * **Without** the fix: The build fails for `react-ssr`, stating that local file systems imported starting with `c:/` must be prefixed with the `file://` URI scheme.
  * **With** the fix: The build will proceed and successfully finish as expected.

With this proposed fix, I was able to successfully use Node 20 for my setup on my MS Windows computer and also on my Armbian computer. I only tested the web package and the Storybook locally, and both worked as expected. I did not check if the Angular, ReactJS, and VueJS builds were working as expected.
