### PR TITLE
feat: New gcds-page-feedback component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17443,6 +17443,11 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+      "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
+    },
     "node_modules/domutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
@@ -48541,7 +48546,8 @@
         "@storybook/addon-a11y": "^8.0.9",
         "@storybook/addons": "^7.6.17",
         "@storybook/test": "^8.0.9",
-        "@storybook/theming": "^8.0.9"
+        "@storybook/theming": "^8.0.9",
+        "dompurify": "^3.1.6"
       },
       "devDependencies": {
         "@axe-core/puppeteer": "^4.7.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -38,7 +38,8 @@
     "@storybook/addon-a11y": "^8.0.9",
     "@storybook/addons": "^7.6.17",
     "@storybook/test": "^8.0.9",
-    "@storybook/theming": "^8.0.9"
+    "@storybook/theming": "^8.0.9",
+    "dompurify": "^3.1.6"
   },
   "devDependencies": {
     "@axe-core/puppeteer": "^4.7.3",

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -836,6 +836,24 @@ export namespace Components {
          */
         "href": string;
     }
+    interface GcdsPageFeedback {
+        "action"?: string;
+        /**
+          * Optional contact us information
+         */
+        "contact"?: '';
+        "contactLink"?: '';
+        "feedbackForm"?: '';
+        /**
+          * Props
+         */
+        "notInPageDetailSection"?: boolean;
+        "section"?: '';
+        /**
+          * Optional configurable option for feedback categorization
+         */
+        "theme"?: '';
+    }
     interface GcdsPagination {
         /**
           * List display - Current page number
@@ -897,6 +915,10 @@ export namespace Components {
           * Options to render radio buttons
          */
         "options": string | Array<RadioObject>;
+        /**
+          * Value for the selected radio element.
+         */
+        "value"?: string;
     }
     interface GcdsSearch {
         /**
@@ -1598,6 +1620,12 @@ declare global {
         prototype: HTMLGcdsNavLinkElement;
         new (): HTMLGcdsNavLinkElement;
     };
+    interface HTMLGcdsPageFeedbackElement extends Components.GcdsPageFeedback, HTMLStencilElement {
+    }
+    var HTMLGcdsPageFeedbackElement: {
+        prototype: HTMLGcdsPageFeedbackElement;
+        new (): HTMLGcdsPageFeedbackElement;
+    };
     interface HTMLGcdsPaginationElementEventMap {
         "gcdsFocus": void;
         "gcdsBlur": void;
@@ -1783,6 +1811,7 @@ declare global {
         "gcds-link": HTMLGcdsLinkElement;
         "gcds-nav-group": HTMLGcdsNavGroupElement;
         "gcds-nav-link": HTMLGcdsNavLinkElement;
+        "gcds-page-feedback": HTMLGcdsPageFeedbackElement;
         "gcds-pagination": HTMLGcdsPaginationElement;
         "gcds-phase-banner": HTMLGcdsPhaseBannerElement;
         "gcds-radio-group": HTMLGcdsRadioGroupElement;
@@ -2780,6 +2809,24 @@ declare namespace LocalJSX {
          */
         "onGcdsFocus"?: (event: GcdsNavLinkCustomEvent<void>) => void;
     }
+    interface GcdsPageFeedback {
+        "action"?: string;
+        /**
+          * Optional contact us information
+         */
+        "contact"?: '';
+        "contactLink"?: '';
+        "feedbackForm"?: '';
+        /**
+          * Props
+         */
+        "notInPageDetailSection"?: boolean;
+        "section"?: '';
+        /**
+          * Optional configurable option for feedback categorization
+         */
+        "theme"?: '';
+    }
     interface GcdsPagination {
         /**
           * List display - Current page number
@@ -2865,6 +2912,10 @@ declare namespace LocalJSX {
           * Options to render radio buttons
          */
         "options": string | Array<RadioObject>;
+        /**
+          * Value for the selected radio element.
+         */
+        "value"?: string;
     }
     interface GcdsSearch {
         /**
@@ -3234,6 +3285,7 @@ declare namespace LocalJSX {
         "gcds-link": GcdsLink;
         "gcds-nav-group": GcdsNavGroup;
         "gcds-nav-link": GcdsNavLink;
+        "gcds-page-feedback": GcdsPageFeedback;
         "gcds-pagination": GcdsPagination;
         "gcds-phase-banner": GcdsPhaseBanner;
         "gcds-radio-group": GcdsRadioGroup;
@@ -3281,6 +3333,7 @@ declare module "@stencil/core" {
             "gcds-link": LocalJSX.GcdsLink & JSXBase.HTMLAttributes<HTMLGcdsLinkElement>;
             "gcds-nav-group": LocalJSX.GcdsNavGroup & JSXBase.HTMLAttributes<HTMLGcdsNavGroupElement>;
             "gcds-nav-link": LocalJSX.GcdsNavLink & JSXBase.HTMLAttributes<HTMLGcdsNavLinkElement>;
+            "gcds-page-feedback": LocalJSX.GcdsPageFeedback & JSXBase.HTMLAttributes<HTMLGcdsPageFeedbackElement>;
             "gcds-pagination": LocalJSX.GcdsPagination & JSXBase.HTMLAttributes<HTMLGcdsPaginationElement>;
             "gcds-phase-banner": LocalJSX.GcdsPhaseBanner & JSXBase.HTMLAttributes<HTMLGcdsPhaseBannerElement>;
             "gcds-radio-group": LocalJSX.GcdsRadioGroup & JSXBase.HTMLAttributes<HTMLGcdsRadioGroupElement>;

--- a/packages/web/src/components/gcds-alert/gcds-alert.css
+++ b/packages/web/src/components/gcds-alert/gcds-alert.css
@@ -26,8 +26,11 @@
     container: component alert / inline-size;
     font: var(--gcds-alert-font);
     color: var(--gcds-alert-text);
-    padding: var(--gcds-alert-padding);
-    border-inline-start: var(--gcds-alert-border-width) solid transparent;
+
+	gcds-container {
+      padding: var(--gcds-alert-padding);
+      border-inline-start: var(--gcds-alert-border-width) solid transparent;
+	}
 
     .alert__content {
       flex: 1 1 auto;
@@ -89,9 +92,11 @@
 @layer role {
   :host .gcds-alert {
     &.alert--role-danger {
-      background-color: var(--gcds-alert-danger-background);
-      border-color: var(--gcds-alert-danger-icon);
-      color: var(--gcds-alert-danger-text);
+	  gcds-container {
+        background-color: var(--gcds-alert-danger-background);
+        border-color: var(--gcds-alert-danger-icon);
+        color: var(--gcds-alert-danger-text);
+	  }
 
       .alert__icon {
         color: var(--gcds-alert-danger-icon);
@@ -99,9 +104,12 @@
     }
 
     &.alert--role-info {
-      background-color: var(--gcds-alert-info-background);
-      border-color: var(--gcds-alert-info-icon);
-      color: var(--gcds-alert-info-text);
+	  
+	  gcds-container {
+		background-color: var(--gcds-alert-info-background);
+		border-color: var(--gcds-alert-info-icon);
+		color: var(--gcds-alert-info-text);
+	  }
 
       .alert__icon {
         color: var(--gcds-alert-info-icon);
@@ -109,9 +117,11 @@
     }
 
     &.alert--role-success {
-      background-color: var(--gcds-alert-success-background);
-      border-color: var(--gcds-alert-success-icon);
-      color: var(--gcds-alert-success-text);
+	  gcds-container {
+        background-color: var(--gcds-alert-success-background);
+        border-color: var(--gcds-alert-success-icon);
+        color: var(--gcds-alert-success-text);
+	  }
 
       .alert__icon {
         color: var(--gcds-alert-success-icon);
@@ -119,9 +129,11 @@
     }
 
     &.alert--role-warning {
-      background-color: var(--gcds-alert-warning-background);
-      border-color: var(--gcds-alert-warning-icon);
-      color: var(--gcds-alert-warning-text);
+	  gcds-container {
+        background-color: var(--gcds-alert-warning-background);
+        border-color: var(--gcds-alert-warning-icon);
+        color: var(--gcds-alert-warning-text);
+	  }
 
       .alert__icon {
         color: var(--gcds-alert-warning-icon);

--- a/packages/web/src/components/gcds-alert/readme.md
+++ b/packages/web/src/components/gcds-alert/readme.md
@@ -26,6 +26,10 @@
 
 ## Dependencies
 
+### Used by
+
+ - [gcds-page-feedback](../gcds-page-feedback)
+
 ### Depends on
 
 - [gcds-container](../gcds-container)
@@ -36,6 +40,7 @@
 graph TD;
   gcds-alert --> gcds-container
   gcds-alert --> gcds-icon
+  gcds-page-feedback --> gcds-alert
   style gcds-alert fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-button/readme.md
+++ b/packages/web/src/components/gcds-button/readme.md
@@ -33,6 +33,7 @@
 
 ### Used by
 
+ - [gcds-page-feedback](../gcds-page-feedback)
  - [gcds-search](../gcds-search)
 
 ### Depends on
@@ -43,6 +44,7 @@
 ```mermaid
 graph TD;
   gcds-button --> gcds-icon
+  gcds-page-feedback --> gcds-button
   gcds-search --> gcds-button
   style gcds-button fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/web/src/components/gcds-container/gcds-container.css
+++ b/packages/web/src/components/gcds-container/gcds-container.css
@@ -178,6 +178,16 @@
 }
 
 @layer size {
+  :host([size=sm]) {
+	width: fit-content;
+  }
+  
+  @media only screen and (width <= 37rem) {
+	:host([size=sm]) {
+	  width: unset;
+	}
+  }
+  
   :host .gcds-container {
     &.size-xl {
       max-width: var(--gcds-container-size-xl);
@@ -193,7 +203,11 @@
 
     &.size-sm {
       max-width: var(--gcds-container-size-sm);
-    }
+
+	  @media only screen and (width > 37rem) {
+		min-width: var(--gcds-container-size-sm);
+      }
+	}
 
     &.size-xs {
       max-width: var(--gcds-container-size-xs);

--- a/packages/web/src/components/gcds-container/gcds-container.tsx
+++ b/packages/web/src/components/gcds-container/gcds-container.tsx
@@ -88,7 +88,8 @@ export class GcdsContainer {
     const Tag = tag;
 
     return (
-      <Host>
+      <Host
+		size={size}>
         <Tag
           class={`
             gcds-container

--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.tsx
@@ -312,7 +312,7 @@ export class GcdsFieldset {
           tabindex="-1"
           ref={element => (this.shadowElement = element as HTMLElement)}
         >
-          <legend id={`legend-${fieldsetId}`}>
+          <legend id={`legend-${fieldsetId}`} part="legend">
             {legend}
             {required ? (
               <span class="legend__required">({i18n[lang].required})</span>

--- a/packages/web/src/components/gcds-fieldset/readme.md
+++ b/packages/web/src/components/gcds-fieldset/readme.md
@@ -47,6 +47,7 @@ Type: `Promise<void>`
 ### Used by
 
  - [gcds-date-input](../gcds-date-input)
+ - [gcds-page-feedback](../gcds-page-feedback)
 
 ### Depends on
 
@@ -62,6 +63,7 @@ graph TD;
   gcds-error-message --> gcds-text
   gcds-error-message --> gcds-icon
   gcds-date-input --> gcds-fieldset
+  gcds-page-feedback --> gcds-fieldset
   style gcds-fieldset fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/components/gcds-icon/readme.md
+++ b/packages/web/src/components/gcds-icon/readme.md
@@ -28,6 +28,7 @@
  - [gcds-file-uploader](../gcds-file-uploader)
  - [gcds-link](../gcds-link)
  - [gcds-nav-group](../gcds-nav-group)
+ - [gcds-page-feedback](../gcds-page-feedback)
  - [gcds-pagination](../gcds-pagination)
  - [gcds-search](../gcds-search)
  - [gcds-topic-menu](../gcds-topic-menu)
@@ -41,6 +42,7 @@ graph TD;
   gcds-file-uploader --> gcds-icon
   gcds-link --> gcds-icon
   gcds-nav-group --> gcds-icon
+  gcds-page-feedback --> gcds-icon
   gcds-pagination --> gcds-icon
   gcds-search --> gcds-icon
   gcds-topic-menu --> gcds-icon

--- a/packages/web/src/components/gcds-page-feedback/ajax/custom-feedback-alternate.html
+++ b/packages/web/src/components/gcds-page-feedback/ajax/custom-feedback-alternate.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<div data-feedback-form-action="oh-yeah-give-me-that-feedback.html"></div>
+<gcds-select
+	select-id="custom-feedback-select"
+	label="ALT Choose your favorite pets"
+	name="feedback-select-pets"
+	default-value="Pets lists"
+	required
+  >
+	<option value="dog">Dog</option>
+	<option value="cat">Cat</option>
+	<option value="bird">Bird</option>
+	<option value="fish">Fish</option>
+  </gcds-select>
+  <gcds-textarea
+	textarea-id="custom-feedback-textarea"
+	name="custom123"
+	label="ALT Why not?">
+  </gcds-textarea>
+  <label>Try traditional input (required): 
+	<input type="text" name="test" required>
+  </label>
+  <gcds-radio-group
+	name="custom-feedback-radio"
+	options='[
+	  { "label": "ALT No", "id": "custom-feedback-radio-1", "hint": "hoey", "value": "no" },
+	  { "label": "ALT Yes", "id": "custom-feedback-radio-2", "hint": "hoey d", "value": "yes" }
+	]'>
+  </gcds-radio-group>
+</html>

--- a/packages/web/src/components/gcds-page-feedback/ajax/custom-feedback.html
+++ b/packages/web/src/components/gcds-page-feedback/ajax/custom-feedback.html
@@ -1,0 +1,27 @@
+<gcds-radio-group
+  name="custom-feedback-radio"
+  options='[
+	{ "label": "No", "id": "custom-feedback-radio-1", "hint": "hoey", "value": "no" },
+	{ "label": "Yes", "id": "custom-feedback-radio-2", "hint": "hoey d", "value": "yes" }
+  ]'>
+</gcds-radio-group>
+<gcds-select
+  select-id="custom-feedback-select"
+  label="Choose your favorite pets"
+  name="feedback-select-pets"
+  default-value="Pets lists"
+  required
+  data-feedback-form-action="submit-here.html"
+>
+  <option value="dog">Dog</option>
+  <option value="cat">Cat</option>
+  <option value="bird">Bird</option>
+  <option value="fish">Fish</option>
+</gcds-select><gcds-textarea
+  textarea-id="custom-feedback-textarea"
+  name="custom123"
+  label="Why not?">
+</gcds-textarea>
+<label>Try traditional input (required): 
+  <input type="text" name="test" required>
+</label>

--- a/packages/web/src/components/gcds-page-feedback/gcds-page-feedback.css
+++ b/packages/web/src/components/gcds-page-feedback/gcds-page-feedback.css
@@ -1,0 +1,91 @@
+@layer reset, default, largeView, mediumView, smallView;
+
+@layer reset {
+  :host {
+    display: block;
+  }
+}
+
+@layer default {
+  :host .page-feedback__intro, :host .page-feedback__get-feedback, :host .page-feedback__confirmation {
+    &.d-none {
+      display: none;
+    }
+	
+	--gcds-fieldset-font-desktop: var(--gcds-label-font-desktop);
+	--gcds-fieldset-font-mobile:  var(--gcds-label-font-desktop);
+	
+  }
+  
+  /* Add a spacing of 9 px between both gcds-button */
+  @media only screen and (width >= 30rem) {
+    :host gcds-fieldset gcds-button+gcds-button {
+	  margin-left: 9px;
+    }
+  }
+  
+  :host gcds-fieldset .page-feedback__btn-group {
+	text-align: right;
+  }
+  
+  :host gcds-button::part(button) {
+	font-family: Lato, sans-serif;
+  }
+  
+  :host gcds-fieldset::part(legend) {
+	width: 100%;
+	float:left;
+	margin-top: 12px!important;
+  }
+  
+  
+  :host .gcds-page-feedback:not(.confirmed) {
+	background-color: #f5f5f5;
+	border: 1px solid #e3e3e3;
+	border-radius: 4px;
+  }
+  
+  
+  :host gcds-details {
+	margin-bottom: 7px;
+  }
+  
+  /* for testing only */
+  :host hr {
+	margin-top: 100px;
+  }
+  
+}
+
+@layer largeView {
+
+  :host {
+	@media only screen and (width >= 62rem) {
+	  gcds-fieldset::part(legend) {
+		width: 66.66%;
+	  }
+	}
+  }
+}
+
+@layer mediumView {
+  :host {
+	@media only screen and (width >= 48rem) {
+	  gcds-fieldset::part(legend) {
+		width: 75;
+	  }
+	}
+  }
+}
+
+
+@layer smallView {
+  :host {
+	@media only screen and (width >= 30rem) {
+	  gcds-fieldset::part(legend) {
+		width: 58.33%;
+	  }
+    }
+  }
+}
+

--- a/packages/web/src/components/gcds-page-feedback/gcds-page-feedback.tsx
+++ b/packages/web/src/components/gcds-page-feedback/gcds-page-feedback.tsx
@@ -1,0 +1,649 @@
+import { Component, Element, Host, Watch, Prop, State, h, Listen } from '@stencil/core';
+import { assignLanguage, observerConfig } from '../../utils/utils';
+import i18n from './i18n/i18n';
+import DOMPurify from 'dompurify';
+
+@Component({
+  tag: 'gcds-page-feedback',
+  styleUrl: 'gcds-page-feedback.css',
+  shadow: true,
+})
+export class GcdsPageFeedback {
+  @Element() el: HTMLElement;
+
+  /**
+   * Props
+   */
+  @Prop({ mutable: true }) notInPageDetailSection?: boolean = false;
+
+  
+  /**
+   * Language of rendered component
+   */
+  @State() lang: string;
+  
+  /*
+   * Observe lang attribute change
+   */
+  updateLang() {
+    const observer = new MutationObserver(mutations => {
+      if (mutations[0].oldValue != this.el.lang) {
+	    this.lang = this.el.lang;
+	  }
+	});
+	observer.observe(this.el, observerConfig);
+  }
+
+  /**
+   * Optional configurable option for feedback categorization
+   */
+  @Prop({ mutable: true }) theme?: '';
+  @Prop({ mutable: true }) section?: '';
+
+  /**
+   * Optional contact us information
+   */
+  @Prop({ mutable: true }) contact?: '';
+  @Prop({ mutable: true }) contactLink?: '';
+
+
+  /*
+   * Custom form personalization and custom form reset feature
+   */
+  #feedbackFormHTML = "" as string;
+  #feedbackFormFragment = new DocumentFragment();
+  #sanitizeOptions = {
+	CUSTOM_ELEMENT_HANDLING: {
+	  tagNameCheck: /^gcds-/, // only allow GCDS custom elements
+	  attributeNameCheck: /.+/, // allow all attributes
+	  allowCustomizedBuiltInElements: false // customized built-ins are not allowed yet
+	}
+  };
+
+  @State() submissionURL: string = "";
+
+  @Prop() action?: string;
+  validateActionUrl() {
+	this.submissionURL = this.action;
+  }
+  @Prop({ mutable: true }) feedbackForm?: '';
+  @Watch('feedbackForm')
+  validateFeedbackForm() {
+
+	// Check if we need to load an external feedback form
+    if ( this.feedbackForm ) {
+	
+	  // Check if there is not user configured form, if so we abort the external fetch
+	  const slotFeedbackFormInjected = this.el.querySelector( 'div[slot=feedback-form]' );
+	  if ( slotFeedbackFormInjected && !slotFeedbackFormInjected.hasAttribute( 'data-ajaxed-from' ) ) {
+		console.error( 'A custom feedback form are already set, unable to override via ajax' );
+		return;
+	  }
+	  
+	  // Fetch the file
+	  fetch( this.feedbackForm, {
+		method: 'get'
+	  }).then( ( response ) => {
+	  
+		// If we get a 404, let's abort and use default feedback form
+		if (!response.ok) {
+		  this.feedbackForm = '';
+		  throw new Error( "404 - file not found" );
+		}
+		
+		// Let's process the received response body
+		return response.text();
+	  })
+	  .then( ( responseText ) => {
+
+		// Create the slot container and parsing the response text
+		const divSlotCustomForm = document.createElement('div');
+		divSlotCustomForm.slot = 'feedback-form';
+		divSlotCustomForm.dataset.ajaxedFrom = this.feedbackForm;
+		divSlotCustomForm.innerHTML = DOMPurify.sanitize( responseText, this.#sanitizeOptions ); // Insert sanitized HTML only
+
+		// Extract the custom action from the fetched HTML fragment
+		const elmWithActionURL = divSlotCustomForm.querySelector( '[data-feedback-form-action]' ) as HTMLElement;
+
+		// Remove the submission URL not manually overridden 
+		if ( !this.action ) {
+		  this.submissionURL = "";
+		}
+
+		// Set the submission URL if not specified
+		if ( !this.submissionURL && elmWithActionURL ) {
+		  this.submissionURL = elmWithActionURL.dataset.feedbackFormAction;
+		}
+		
+		// Abort if there no custom form action url at this step
+		if ( !this.submissionURL ) {
+		  console.error( 'A custom feedback form action URL is required' );
+		  return;
+		}
+
+		// Remove, if existing, the div slot with the custom form
+		slotFeedbackFormInjected && slotFeedbackFormInjected.remove();
+		
+		// Add the new div slot to this element
+		this.el.append( divSlotCustomForm );
+		
+		// Reset and keep a clean copy of the custom form
+		if ( this.#feedbackFormFragment.childElementCount > 0 ) {
+		  this.#feedbackFormFragment = new DocumentFragment();
+		}
+		this.#feedbackFormFragment.append( divSlotCustomForm.cloneNode( true ) );
+	  });
+	}
+  }
+
+  
+  /*
+   * In-page operation to gather some metadata required by the page feedback tool
+   */
+  #pageTitle = '';
+  #pageLanguage = '';
+  #pageOppLangUrl = '';
+  #submissionPage = '';
+  #institution = '';
+
+  // Get opposite page language defined in the current page
+  #getOppositeLangLocation() {
+	let elmLinkOppLang;
+	
+	// First: use explicit and first <gcds-lang-toggle>
+	elmLinkOppLang = document.querySelector( "gcds-lang-toggle[href]" );
+	if ( elmLinkOppLang ) {
+	  return elmLinkOppLang.href;
+	}
+
+	// Second: Custom opposite page variant via the "gcds-header [slot=toggle]"
+	// Waiting for a valid use case prior to support it.
+	
+	// Third, use <gcds-header>
+	elmLinkOppLang = document.querySelector( "gcds-header[lang-href]" );
+	if ( elmLinkOppLang ) {
+	  return elmLinkOppLang.langHref;
+	}
+
+	// Fourth, in-page co-existing with GCWeb
+	elmLinkOppLang = document.querySelector( "#wb-lng ul li:first-child a[lang]" );
+	if ( elmLinkOppLang ) {
+	  return elmLinkOppLang.href;
+	}
+	
+	// Fifth, from the alternate link metadata
+	elmLinkOppLang = document.querySelector( 'link[rel=alternate][href]' );
+	if ( elmLinkOppLang ) {
+	  return elmLinkOppLang.href;
+	}
+
+	// There no opposite language location found
+	return '';
+  }
+  
+  // Get the institution name
+  #getInstitutionName() {
+	let elmInstitutionInfo;
+	
+	// First: Dublin Core meta element via HTML or RDFa or HTML author
+	elmInstitutionInfo = document.querySelector( "meta[name='dcterm.creator'],meta[property='dcterm:creator'],meta[name=author]" );
+  	if ( elmInstitutionInfo ) {
+	  return elmInstitutionInfo.content;
+	}
+	
+	// JSON-LD only if default context are schema.org vocabulary and assuming the root type is a Thing that do represent the current web page content
+	const jsonLD = this.#getInPageJsonLD();
+	if ( jsonLD[ '@context' ] ) {
+	  const creator = jsonLD[ 'creator' ] || jsonLD[ 'author' ];
+	  if ( creator && typeof creator === 'string' ) {
+		return creator;
+	  }
+	}
+  
+	// RDFa, assuming its an implementation that use schema.org as the default vocabulary
+	elmInstitutionInfo = document.querySelector( '[typeof~="WebPageElement"]:not(:has([typeof])) [property~="creator"],[typeof~="WebPage"]:not(:has([typeof])) [property~="author"]' );
+	if ( elmInstitutionInfo ) {
+	  return elmInstitutionInfo.textContent;
+	}
+
+	// There no institution defined
+	return '';
+  }
+  
+  // Get page title
+  #getPageTitle() {
+	let elmPageTitle;
+	
+  	// RDFa, assuming its an implementation that use schema.org default vocabulary
+	elmPageTitle = document.querySelector( '[typeof~="WebPageElement"]:not(:has([typeof])) [property~="name"],[typeof~="WebPage"]:not(:has([typeof])) [property~="name"]' );
+	if ( elmPageTitle ) {
+	  return elmPageTitle.textContent;
+	}
+
+  	// JSON-LD only if default context are schema.org vocabulary and assuming the root type is a Thing that do represent the current web page content
+	const jsonLD = this.#getInPageJsonLD();
+	if ( jsonLD[ '@context' ] && jsonLD[ 'name' ] ) {
+	  return jsonLD[ 'name' ];
+	}
+  
+	// GCDS heading level 1 or the first h1
+	elmPageTitle = document.querySelector( 'gcds-heading[tag=h1],h1' );
+	if ( elmPageTitle ) {
+	  return elmPageTitle.textContent;
+	}
+	
+	// Document title
+	return document.title;
+  }
+  
+  // Get the in page JSON-LD
+  //  note: this only support one instance of JSON-LD, should we support multiple instance of it?
+  #inPageJsonLD = {};
+  #shouldResetNextCall = false;
+  #getInPageJsonLD( resetOnNextCall = false ) {
+	
+	// Get the information only if required, otherwise return the last known state
+	if ( this.#shouldResetNextCall ) {
+	  this.#shouldResetNextCall = false; // To avoid recursive call  
+	  const elmJsonLD = document.querySelector( 'script[type="application/ld+json"]' ) as HTMLElement;
+	  if ( elmJsonLD ) {
+		try {
+		  const jsonLD = JSON.parse( elmJsonLD.innerText );
+		  
+		  // For now, only support schema.org context
+		  if ( this.#inPageJsonLD["@context"] && this.#inPageJsonLD["@context"].match( /^https?:\/\/schema.org\/?$/ ) ) {
+			this.#inPageJsonLD = jsonLD;
+		  } else {
+			this.#inPageJsonLD = {};
+		  }
+		} catch (e) {
+		  this.#inPageJsonLD = {};
+		}
+	  }
+	}
+	
+	// Forcing a reset on the next function call
+	if ( resetOnNextCall ) {
+	  this.#shouldResetNextCall = true;
+	}
+	
+	// Return the JSON-LD
+	return this.#inPageJsonLD;
+  }
+  
+  // private function to retrieve page metadata
+  #getPageMetadata() {
+
+  	// Get lang attribute
+	this.lang = assignLanguage(this.el);
+	
+	// Get page properties
+	this.#getInPageJsonLD( true );
+	this.#pageTitle = this.#getPageTitle();
+	this.#pageLanguage = document.documentElement.lang;
+	this.#pageOppLangUrl = this.#getOppositeLangLocation();
+	this.#submissionPage = document.location.href;
+	this.#institution = this.#getInstitutionName();
+  }
+  
+  
+  /*
+   * Monitor page history and reset the page feedback form when it changes
+   */
+  // Listen to history push and reset the PFT to its intro state
+  #historyPushNative;
+  #historyPush = (state, unused, url) => {
+	this.currentStep = this.#stepPFT.introQuestion;
+	this.#historyPushNative.call(window.history, state, unused, url);
+	this.#getPageMetadata();
+	this.#restoreFeedbackForm();
+  };
+  
+  // Listen to history back and reset the PFT to its intro state
+  @Listen('popstate', { target: 'window'})
+  popstateListener(ev) {
+	this.currentStep = this.#stepPFT.introQuestion;
+	this.#getPageMetadata();
+  }
+
+  
+  /*
+   * Called once just after the component is first connected to the DOM
+   */
+  componentWillLoad() {
+	
+	// Get the current page metadata
+	this.#getPageMetadata();
+	
+	// Listen on history push (To test, run this in the browser console > history.pushState({},"", "page-feedback.html")
+	this.#historyPushNative = history.pushState;
+	history.pushState = this.#historyPush;
+
+	// Check if we need to load an external feedback form
+    this.feedbackForm && this.validateFeedbackForm();
+	this.action && this.validateActionUrl();
+  }
+  
+
+  /*
+   * Feedback form step management
+   */
+  
+  // Step enumeration of this page feedback form
+  #stepPFT = { 
+	introQuestion: 0,
+	customFeedback: 1,
+	confirmation: 2
+  };
+  
+  // Define the current view of rendered component
+  @State() currentStep: number = this.#stepPFT.introQuestion;
+
+  // Step yes - User said that he found what he was looking for - Submit feedback
+  #stepFoundLookingFor( ev ) {
+
+	// TODO: Use the new feat(gcds-button): from Github PR #635
+	// Workaround because we can't set value on button, neither associate the internal button with the web form.
+	const formHiddenInput = document.createElement('input');
+	formHiddenInput.type = "hidden";
+	formHiddenInput.name = "helpful";
+	formHiddenInput.value = "Yes-Oui";
+	
+	ev.target.parentElement.appendChild( formHiddenInput );
+	
+	const data = new URLSearchParams( new FormData( formHiddenInput.form ) as any );
+	
+	// Send the feedback, the response don't really matter, we always show a successful message
+	fetch( formHiddenInput.form.action, {
+	  method: formHiddenInput.form.method || 'post',
+	  body: data
+	}).then( () => {
+	  
+	  // Remove it to not have duplicate in SPA application
+	  formHiddenInput.remove();
+	});
+	
+	this.currentStep = this.#stepPFT.confirmation;
+  }
+  
+  // Step no - User didn't found what he was looking for - Show feedback form.
+  #stepNotFoundLookingFor( ev ) {
+	this.currentStep = this.#stepPFT.customFeedback;
+  }
+  
+  // Send feedback - Step 1 of 2; Get and validate gcds form inputs
+  #stepSendFeedback( ev ) {
+	
+	const parentElementTarget = ev.target.parentElement;
+	const slotFeedbackForm = this.el.querySelector( '[slot=feedback-form]' );
+
+	// Check if the custom field are valid
+	let invalidFields, validFields;
+	if ( this.submissionURL && slotFeedbackForm ) {
+	  invalidFields = slotFeedbackForm.querySelectorAll( ':invalid' );
+	  validFields = slotFeedbackForm.querySelectorAll( ':valid' );
+
+	  
+	  // Before to continue, we need to check the validation state of every GCDS field that do have a validate method.
+	  let validationPromises = [];
+	  let gcdsInputsValidation = [];
+	  for( let i = 0; i !== validFields.length; i++ ) {
+		const inputField = validFields[ i ];
+		if ( inputField.nodeName.startsWith( "GCDS-" ) && inputField.validate ) {
+		  validationPromises.push( inputField.validate() );
+		  gcdsInputsValidation.push( inputField );
+		}
+	  }
+	  
+	  if ( !validationPromises.length ) {
+
+		// Continue the process
+		this.#sendFeedbackFieldValidated( parentElementTarget, validFields, invalidFields );
+	  }
+	  
+	  Promise.allSettled( validationPromises )
+		.then( (results) => {
+		  
+		  // Ensure that all Promise was fulfilled
+		  for( let i = 0; i !== results.length; i++ ) {
+			const resultPromise = results[ i ];
+			
+			// Move the focus on the first rejected
+			if ( resultPromise.status === 'rejected' ) {
+			  gcdsInputsValidation[ i ].focus();
+			  return;
+			}
+		  }
+		  
+		  // GCDS validation pass, let continue
+		  this.#sendFeedbackFieldValidated( parentElementTarget, validFields, invalidFields );
+		  
+		});
+	  
+	} else {
+	  this.#sendFeedbackFieldValidated( parentElementTarget, validFields, invalidFields );
+	}
+  }
+
+  // Send feedback - Step 2 of 2; Validate native form input, encode the form value and sending it
+  #sendFeedbackFieldValidated( parentElementTarget, validFields, invalidFields ) {
+  
+ 
+	// Check if there is any native input field that are invalid.
+	if ( invalidFields && invalidFields.length ) {
+	  
+	  // Only check the first one.
+	  const field  = invalidFields[ 0 ] as HTMLInputElement;
+	  field.reportValidity();
+	  
+	  // The user has been advised of the error by the browser
+	  return;
+	}
+	
+	// TODO: Use the new feat(gcds-button): from Github PR #635
+	// Workaround because we can't set value on button, neither associate the internal button with the web form.
+	const formHiddenInput = document.createElement('input');
+	formHiddenInput.type = "hidden";
+	formHiddenInput.name = "helpful";
+	formHiddenInput.value = "No-Non";
+
+	parentElementTarget.appendChild( formHiddenInput );
+
+	// URL Encode the form data
+	const data = new URLSearchParams( new FormData( formHiddenInput.form ) as any );
+	
+	// Check and add name/value of additional web form elements
+	if ( validFields && validFields.length ) {
+	  for( let i = 0; i !== validFields.length; i++ ) {
+		const inputField = validFields[ i ];
+		data.append( inputField.name, inputField.value );
+	  }
+	}
+	
+	// Send the feedback, the response don't really matter, we always show a successful message
+	fetch( formHiddenInput.form.action, {
+	  method: formHiddenInput.form.method || 'post',
+	  body: data
+	}).then( () => {
+	  
+	  // Remove it to not have duplicate in SPA application
+	  formHiddenInput.remove();
+	  this.#restoreFeedbackForm();
+	});
+	
+	// Change the step
+	this.currentStep = this.#stepPFT.confirmation;
+  }
+  
+  // Reset the custom form if applicable because those field are not hard linked with the form in the shadow dom
+  #restoreFeedbackForm() {
+	if ( this.#feedbackFormFragment.childElementCount > 0 ) {
+	  const slotFeedbackForm = this.el.querySelector( '[slot=feedback-form]' );
+	  slotFeedbackForm.remove();
+	  this.el.append( this.#feedbackFormFragment );
+	}
+  }
+
+  // Reset the PFT state
+  resetPFT( ev ) {
+	this.#restoreFeedbackForm();
+	this.currentStep = this.#stepPFT.introQuestion;
+  }
+  
+  
+  /*
+   * Render function
+   */
+  // Form feedback
+  private get renderFormFeedback() {
+	const lang = this.lang;
+	const slotFeedbackForm = this.el.querySelector( '[slot=feedback-form]' ) as HTMLElement;
+	const customAction = this.submissionURL;
+	
+	if ( slotFeedbackForm && customAction ) {
+	  
+	  // Reset our internal document fragment
+	  if ( this.#feedbackFormFragment.childElementCount > 0 ) {
+		this.#feedbackFormFragment = new DocumentFragment();
+	  }
+	  
+	  // Keep a copy of the current Feedback form to restore on page navigation
+	  this.#feedbackFormFragment.append( slotFeedbackForm.cloneNode( true ) );
+	  
+	  // Return the slot
+	  return <slot name="feedback-form"></slot>;
+	
+	} else {
+	  
+	  // Default feedback form
+	  return (
+		<gcds-textarea
+		  textareaId="gc-pft-prblm"
+		  label={i18n[lang]['details']}
+		  name="details"
+		  hint={i18n[lang]['detailsHint']}
+		  character-count="300"
+		>
+		</gcds-textarea>
+	  );
+	}
+  }
+  
+  // Contact us link
+  private get renderContact() {
+	const { lang, contactLink, contact } = this;
+	
+	if ( contact && contactLink ) {
+	  return (
+		<gcds-details detailsTitle={i18n[lang]['urgentHelp']}>
+		  <gcds-link href={ contactLink }>{ contact }</gcds-link>
+		</gcds-details>
+	  );
+	} else {
+	  return null;
+	}
+  }
+  
+  // Main render function
+  render() {
+    const { lang, theme, section, notInPageDetailSection } =
+      this,
+	  isConfirmedStep = this.currentStep === this.#stepPFT.confirmation;
+
+    return (
+      <Host>
+		<section> {/* to be removed and replaced by 'tag=section' in the gcds-container when alert styling is fixed */}
+        <gcds-container class={`
+			gcds-page-feedback
+		    ${ isConfirmedStep ? 'confirmed' : '' }
+		  `}
+		  tag="div" 
+		  padding={ !isConfirmedStep ? '300' : null }
+		  size="sm"
+		>
+		  <gcds-sr-only tag={!notInPageDetailSection ? 'h3' : 'h2'}>
+			{i18n[lang]['heading']}
+		  </gcds-sr-only>
+
+		  <form 
+			id={ this.action ? 'pft' + this.action : null }
+			action={ !this.submissionURL ? 'http://localhost:3333/submit': this.submissionURL }
+			data-action="https://feedback-retroaction.canada.ca/api/QueueProblemForm" method="post">
+			
+			{/* Hidden field*/}
+			<input type="hidden" name="pageTitle" value={this.#pageTitle} />
+			<input type="hidden" name="language" value={this.#pageLanguage} />
+			<input type="hidden" name="submissionPage" value={this.#submissionPage} />
+			<input type="hidden" name="oppositelang" value={this.#pageOppLangUrl} />
+			<input type="hidden" name="themeopt" value={theme} />
+			<input type="hidden" name="sectionopt" value={section} />
+			<input type="hidden" name="institutionopt" value={this.#institution} />
+			
+			{/* Step 1 - Seek feedback */}
+			<gcds-fieldset
+			  class={`
+			    page-feedback__intro
+				${this.currentStep !== this.#stepPFT.introQuestion ? 'd-none': ''}
+			  `}
+			  fieldsetId="gcds-pft-question"
+			  legend={i18n[lang]['headline']}
+			>
+			  <div class="page-feedback__btn-group">
+				<gcds-button size="small" onGcdsClick={ev => this.#stepFoundLookingFor(ev)}>{i18n[lang]['yes']}</gcds-button>
+				<gcds-button size="small" onGcdsClick={ev => this.#stepNotFoundLookingFor(ev)}>{i18n[lang]['no']}</gcds-button>
+			  </div>
+			</gcds-fieldset>
+
+
+			
+			{/* Step 2 - Get feedback */}
+			  <div
+				class={`
+				  page-feedback__get-feedback
+				  ${this.currentStep !== this.#stepPFT.customFeedback ? 'd-none': ''}
+			  `}>
+				
+				{ this.currentStep === this.#stepPFT.customFeedback ? (
+				    <gcds-sr-only role="status">{i18n[lang]['tellUs']}</gcds-sr-only>
+				 ) : null }
+				
+				{ this.renderContact }
+				
+				<div class="page-feedback__details">
+				  {/* Reset the feedback field when submission completed*/}
+				  {/* !isConfirmedStep ? ( this.renderDescription ) : null */ }
+				  { this.currentStep === this.#stepPFT.customFeedback ? ( this.renderFormFeedback ) : null }
+				</div>
+			  
+				<gcds-button onGcdsClick={ev => this.#stepSendFeedback(ev)}>{i18n[lang]['submit']}</gcds-button>
+
+			  </div>
+ 		  </form>
+
+        </gcds-container>
+		  {/* Step 3 - Confirmation feedback submitted */}
+		  {/* Note: this alert is outside the gcds-container because of a styling conflict. When the style conflict is resolved, the explicit section can be removed and the gcds-container tag can be set to the value "section"
+		  */}
+		  { isConfirmedStep ? (
+			<div class="page-feedback__confirmation">
+		      <gcds-alert
+			    alertRole="success"
+			    heading="Submitted"
+				container="sm"
+				isFixed
+		      >
+			    <p>{i18n[lang]['thanks']}</p>
+		      </gcds-alert>		
+			</div>
+		  ) : null }
+		  </section>
+		  {/*
+			The following elements (hr, gcds-button) are only there to facilitate development, those need to be removed
+		  */}
+		   <hr />
+		  <gcds-button onGcdsClick={ev => this.resetPFT(ev)}>RESET the previous PFT</gcds-button>
+		   <hr />
+      </Host>
+    );
+  }
+}

--- a/packages/web/src/components/gcds-page-feedback/i18n/i18n.js
+++ b/packages/web/src/components/gcds-page-feedback/i18n/i18n.js
@@ -1,0 +1,28 @@
+const I18N = {
+  en: {
+    heading: "Give feedback about this page",
+	headline: "Did you find what you were looking for?",
+	tellUs: "Tell us why below:",
+	details: "Please provide more details",
+	detailsHint: "You will not receive a reply. Don't include personal information (telephone, email, SIN, financial, medical, or work details).",
+	urgentHelp: "Need urgent help with a problem? Contact us",
+	thanks: "Thank you for your feedback.",
+	submit: "Submit",
+	yes: "Yes",
+	no: "No"
+  },
+  fr: {
+    heading: "Donnez votre rétroaction sur cette page",
+	headline: "Avez-vous trouvé ce que vous cherchiez?",
+	tellUs: "Dites nous pourquoi ci-dessous&nbsp;:",
+	details: "Veuillez fournir plus de détails",
+	detailsHint: "Vous ne recevrez pas de réponse. N'incluez pas de renseignements personnels (téléphone, courriel, NAS, renseignements financiers, médicaux ou professionnels).",
+	urgentHelp: "Besoin d’aide urgente pour résoudre un problème? Communiquez avec nous",
+	thanks: "Merci de vos commentaires.",
+	submit: "Soumettre",
+	yes: "Oui",
+	no: "Non"
+  }
+};
+
+export default I18N;

--- a/packages/web/src/components/gcds-page-feedback/readme.md
+++ b/packages/web/src/components/gcds-page-feedback/readme.md
@@ -1,0 +1,64 @@
+# gcds-text
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property         | Attribute         | Description                                                                                                         | Type                                                                                                                                         | Default     |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `characterLimit` | `character-limit` | Sets the line length to a maximum amount of characters per line to ensure a comfortable, accessible reading length. | `boolean`                                                                                                                                    | `true`      |
+| `display`        | `display`         | Specifies the display behaviour of the text.                                                                        | `"block" \| "flex" \| "inline" \| "inline-block" \| "inline-flex" \| "none"`                                                                 | `'block'`   |
+| `marginBottom`   | `margin-bottom`   | Adds margin below the text.                                                                                         | `"0" \| "100" \| "1000" \| "150" \| "200" \| "250" \| "300" \| "400" \| "450" \| "50" \| "500" \| "550" \| "600" \| "700" \| "800" \| "900"` | `'400'`     |
+| `marginTop`      | `margin-top`      | Adds margin above the text.                                                                                         | `"0" \| "100" \| "1000" \| "150" \| "200" \| "250" \| "300" \| "400" \| "450" \| "50" \| "500" \| "550" \| "600" \| "700" \| "800" \| "900"` | `'0'`       |
+| `size`           | `size`            | Sets the appropriate HTML tags for the selected size.                                                               | `"body" \| "caption"`                                                                                                                        | `'body'`    |
+| `textRole`       | `text-role`       | Sets the main style of the text.                                                                                    | `"light" \| "primary" \| "secondary"`                                                                                                        | `'primary'` |
+
+
+## Shadow Parts
+
+| Part     | Description |
+| -------- | ----------- |
+| `"text"` |             |
+
+
+## Dependencies
+
+### Depends on
+
+- [gcds-sr-only](../gcds-sr-only)
+- [gcds-fieldset](../gcds-fieldset)
+- [gcds-button](../gcds-button)
+- [gcds-textarea](../gcds-textarea)
+- [gcds-icon](../gcds-icon)
+- [gcds-alert](../gcds-alert)
+
+### Graph
+```mermaid
+graph TD;
+  gcds-page-feedback --> gcds-sr-only
+  gcds-page-feedback --> gcds-fieldset
+  gcds-page-feedback --> gcds-button
+  gcds-page-feedback --> gcds-textarea
+  gcds-page-feedback --> gcds-icon
+  gcds-page-feedback --> gcds-alert
+  gcds-fieldset --> gcds-hint
+  gcds-fieldset --> gcds-error-message
+  gcds-hint --> gcds-text
+  gcds-error-message --> gcds-text
+  gcds-error-message --> gcds-icon
+  gcds-button --> gcds-icon
+  gcds-textarea --> gcds-label
+  gcds-textarea --> gcds-hint
+  gcds-textarea --> gcds-error-message
+  gcds-textarea --> gcds-text
+  gcds-alert --> gcds-container
+  gcds-alert --> gcds-icon
+  style gcds-page-feedback fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/web/src/components/gcds-radio-group/gcds-radio-group.tsx
+++ b/packages/web/src/components/gcds-radio-group/gcds-radio-group.tsx
@@ -66,6 +66,11 @@ export class GcdsRadioGroup {
   @Prop({ reflect: true, mutable: false }) name!: string;
 
   /**
+   * Value for the selected radio element.
+   */
+  @Prop({ mutable: true }) value?: string;
+
+  /**
    * Specifies if the radio is invalid.
    */
   @State() hasError: boolean;
@@ -138,6 +143,7 @@ export class GcdsRadioGroup {
   }
 
   private onChange = e => {
+	this.value = e.target.value;
     this.gcdsChange.emit(e.target.value);
     this.internals.setFormValue(e.target.value, 'checked');
 

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -205,7 +205,7 @@ export class GcdsSelect {
 
   private onBlur = () => {
     if (this.validateOn === 'blur') {
-      this.validate();
+      this.validate().catch( ()=> { /* do nothing */ });
     }
 
     this.gcdsBlur.emit();
@@ -222,6 +222,7 @@ export class GcdsSelect {
         id: `#${this.selectId}`,
         message: `${this.label} - ${this.errorMessage}`,
       });
+	  throw new Error( `Validation of: ${this.label} - ${this.errorMessage}` );
     } else {
       this.errorMessage = '';
       this.gcdsValid.emit({ id: `#${this.selectId}` });

--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
@@ -10,10 +10,12 @@
 
 @layer default {
   :host {
-    display: inline-block;
-    width: 0;
-    height: 0;
-    margin: 0;
+	/* reference: https://webaim.org/techniques/css/invisiblecontent/ */
+    position: absolute;
+	left: -10000px;
+	top:auto;
+	width: 1px;
+	height: 1px;
     overflow: hidden;
   }
 }

--- a/packages/web/src/components/gcds-sr-only/readme.md
+++ b/packages/web/src/components/gcds-sr-only/readme.md
@@ -20,6 +20,7 @@
  - [gcds-file-uploader](../gcds-file-uploader)
  - [gcds-footer](../gcds-footer)
  - [gcds-lang-toggle](../gcds-lang-toggle)
+ - [gcds-page-feedback](../gcds-page-feedback)
  - [gcds-search](../gcds-search)
  - [gcds-stepper](../gcds-stepper)
  - [gcds-topic-menu](../gcds-topic-menu)
@@ -31,6 +32,7 @@ graph TD;
   gcds-file-uploader --> gcds-sr-only
   gcds-footer --> gcds-sr-only
   gcds-lang-toggle --> gcds-sr-only
+  gcds-page-feedback --> gcds-sr-only
   gcds-search --> gcds-sr-only
   gcds-stepper --> gcds-sr-only
   gcds-topic-menu --> gcds-sr-only

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -358,7 +358,7 @@ export class GcdsTextarea {
     }
 
     return (
-      <Host>
+      <Host name={name}>
         <div
           class={`gcds-textarea-wrapper ${disabled ? 'gcds-disabled' : ''} ${
             hasError ? 'gcds-error' : ''

--- a/packages/web/src/components/gcds-textarea/readme.md
+++ b/packages/web/src/components/gcds-textarea/readme.md
@@ -52,6 +52,10 @@ Type: `Promise<void>`
 
 ## Dependencies
 
+### Used by
+
+ - [gcds-page-feedback](../gcds-page-feedback)
+
 ### Depends on
 
 - [gcds-label](../gcds-label)
@@ -69,6 +73,7 @@ graph TD;
   gcds-hint --> gcds-text
   gcds-error-message --> gcds-text
   gcds-error-message --> gcds-icon
+  gcds-page-feedback --> gcds-textarea
   style gcds-textarea fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
     />
+	<meta name="dcterm.creator" content="ABC corp.">
     <title>Stencil Component Starter</title>
 
     <!-- Utility framework -->
@@ -106,10 +107,70 @@
 
       <hr class="my-550" />
 
+	  <gcds-page-feedback></gcds-page-feedback>
+	  
+	  
+	  <gcds-grid columns="1fr" columns-tablet="10fr 2fr" columns-desktop="8fr 4fr">
+		<gcds-page-feedback></gcds-page-feedback>
+		<gcds-link href="#chat">Chatbot</gcds-link>
+	  </gcds-grid>
+	  
+	  
+	  <h2>With contact us link</h2>
+	  
+	  <gcds-page-feedback not-in-page-detail-section contact="ABC123 corp" contact-link="#helloworld"></gcds-page-feedback>
+	  
+	  
+	  <gcds-grid columns="1fr" columns-tablet="10fr 2fr" columns-desktop="8fr 4fr">
+		<gcds-page-feedback contact="ABC123 corp" contact-link="#helloworld"></gcds-page-feedback>
+		<gcds-link href="#chat">Chatbot</gcds-link>
+	  </gcds-grid>
+	  
+	  <h2>With custom feedback form</h2>
+	  
+	  <gcds-page-feedback action="helloworld">
+		<div slot="feedback-form">
+		  <gcds-select
+			select-id="custom-feedback-select"
+			label="Choose your favorite color"
+			name="custom-feedback-select"
+			default-value="Color lists"
+			required
+		  >
+			<option value="blue">Blue</option>
+			<option value="red">Red</option>
+			<option value="green">Green</option>
+			<option value="yellow">Yellow</option>
+		  </gcds-select>
+		  <gcds-textarea
+			textarea-id="custom-feedback-textarea"
+			name="custom123"
+			label="Why?">
+		  </gcds-textarea>
+		  <label>Try (required): 
+			<input type="text" name="test" required>
+		  </label>
+		  <gcds-radio-group
+			name="custom-feedback-radio"
+			options='[
+			  { "label": "No", "id": "custom-feedback-radio-1", "hint": "hoey", "value": "no" },
+			  { "label": "Yes", "id": "custom-feedback-radio-2", "hint": "hoey d", "value": "yes" }
+			]'>
+		  </gcds-radio-group>
+		</div>
+	  </gcds-page-feedback>
+	  
+	  
+	  
+	  <gcds-page-feedback feedback-form="../src/components/gcds-page-feedback/ajax/custom-feedback.html" theme="yep" section="test">
+	  </gcds-page-feedback>
+	  
+	  
+	  
       <!-- ------------- Alerts ------------- -->
 
       <gcds-heading tag="h2">Alerts</gcds-heading>
-      <gcds-alert heading="Success alert" alert-role="success">
+      <gcds-alert heading="Success alert" alert-role="success" container="sm" is-fixed>
         <p>Example content</p>
       </gcds-alert>
       <gcds-alert heading="Info alert" alert-role="info">


### PR DESCRIPTION

**This is a work in progress**, further changes, code review, writing test, documentation, stories, detaching changes in another PR... are on it's way. The main intent with this draft PR is to give you an early opportunity to see my progress and to benefit from your early feedback if you have some.

Also, I created and published a working demo here: https://duboisp.github.io/gcds-components/src/index.html

# Summary | Résumé

This add to GCDS a new Page Feedback Tool component to collect in-page user feedback which are going to be compatible with the current way that DTO are collecting feedback on Canada.ca. It does also provide a very similar but different user experience when compared with the current Canada.ca implementation that leverage the WET-BOEW/GCWeb framework.

However, considering all the override complexity (which was kind of almost exponential, up to be impossible without a lot of rewrite), this page feedback tool are not compliant with the DTO design specification as specified here: https://design.canada.ca/common-design-patterns/page-feedback.html . IMHO this GCDS Page Feedback Tool proposal are going to provide an equivalent behaviour, an equivalent structure, an equivalent style and the same technical user feedback information which, in my opinion, would meet the desired user experience and desired outcome expressed by the page feedback tool DTO guidance.

It does support a few way to customize the feedback form (inline `<slot>` and via fetch), a way to customize the form submission end point and it should technically work well with a single page application.

It is primarily designed to be located inside the page details section, along where is located the date modified which is the footer of the main page section.

# Test instructions | Instructions pour tester la modification

I am going to create more refined example with every configurable possibility via the story book.

Note: The button "RESET the previous PFT" is only there to facilitate development and for quick testing. The intend is to remove it along with its preceding and succeeding horizontal line.

**Positive feedback**
1. Click "Yes"
2. See your browser console/network tab, you will see a 404 post request containing the collected data.
3. An success alert is displayed regardless of the submission result.
4. Click on the "RESET the previous PFT" to restart the process without reloading the page.

**Negative feedback**
1. Click "No"
2. Fill up the feedback form
3. Click "Submit"
4. An success alert is displayed regardless of the submission result.
5. Click on the "RESET the previous PFT" to restart the process without reloading the page.

**Single page application**
1. Start to provide feedback (filling the form or seing the success alert)
2. Either following way, the PFT should reset. In your browser console, run:
   * `history.pushState({},"", "page-feedback.html");`
   * `history.back();` (You should have pushed a state before)

**Override the default form submission end point**
1. Add or update the attribute `action` on the `<gcds-page-feedback>` component by using the live browser DOM editor.
2. Specify a end point where you do want the feedback form to be submitted
3. You can validate that override by looking at the browser console or the network tab, you should see the specified location along with the form data.

**Override of the feedback form on runtime**
1. Add or update the attribute `feedback-form` on the `<gcds-page-feedback>` component by using the live browser DOM editor.
2. Specify a custom submission end point by either:
   a. via the `<gcds-page-feedback>` component : Configure the attribute `action` with the end point URL
   b. via the fetched html fragment: Add anywhere an attribute named `data-feedback-form-action` containing the end point URL
   c. There is a test file located here `../src/components/gcds-page-feedback/ajax/custom-feedback-alternate.html` in my working demo
3. The feedback form would update automatically.

Note: It also work if the custom feedback form contain field requiring validation. It is also compatible with native HTML form field and GCDS form capable component.

**Responsive**
1. Resize the width of the test page
2. The page feedback form should adapt.

# Known issue

* There is a rendering issue with the gcds-alert when it is placed inside a container or a grid. The content of the alert are linearised when it shouldn't.
* When closing the gcds-alert by using the keyboard, the user lost its location because the focus are lost and need to navigate through the whole page.

