### PR TITLE
fix: add mobile font size to search component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,9 +2819,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.18.1.tgz",
-      "integrity": "sha512-Jez9wNLMD/Vb7lO/b6EUdioeaz7KXc8M733NPBBlOys7B8HOqVLbWs+bTIaIxm5/478E5LaQyKjHzjrmkrQl+g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.19.0.tgz",
+      "integrity": "sha512-isTvzHbogMkvO4PXlgv/dc8fkUSIk8/oWDSfEWtJEci3CLaQVi5Gi4Gt7s4MhNt/gTcW5k/+4l2VmJJKk7HSHw==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -48548,7 +48548,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.18.1",
+        "@cdssnc/gcds-tokens": "^1.19.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.18.1",
+    "@cdssnc/gcds-tokens": "^1.19.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-search/gcds-search.css
+++ b/packages/web/src/components/gcds-search/gcds-search.css
@@ -36,7 +36,10 @@
       width: 100%;
       height: auto;
       min-height: var(--gcds-search-min-width-and-height);
-      font: var(--gcds-search-font);
+      font: var(--gcds-search-font-desktop);
+      @media only screen and (width < 48em) {
+        font: var(--gcds-search-font-mobile);
+      }
       padding: var(--gcds-search-padding) !important;
       background-color: var(--gcds-search-default-background);
       color: var(--gcds-search-default-text);


### PR DESCRIPTION
# Summary | Résumé
Adds mobile font size to the Search component

Replaces default font size on the Search component with desktop (default) and mobile values

Fix for:
- https://github.com/cds-snc/design-gc-conception/issues/1134

~‼️ Needs tokens from https://github.com/cds-snc/gcds-tokens/pull/321~
Tokens are now added in the latest version `1.19.0`