### PR TITLE
fix(gcds-sr-only): Align with WCAG technique C7

### DIFF
--- a/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
+++ b/packages/web/src/components/gcds-sr-only/gcds-sr-only.css
@@ -10,10 +10,12 @@
 
 @layer default {
   :host {
-    display: inline-block;
-    width: 0;
-    height: 0;
-    margin: 0;
+    clip-path: inset(100%);
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
     overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
   }
 }

--- a/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.e2e.ts
+++ b/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.e2e.ts
@@ -8,4 +8,29 @@ describe('gcds-sr-only', () => {
     const element = await page.find('gcds-sr-only');
     expect(element).toHaveClass('hydrated');
   });
+  
+  it('Check that the element confines its display to a pixel and hides the text', async () => {
+    const page = await newE2EPage();
+    await page.setContent( `
+      <div style="padding: 20px; background-color:#8d201c; color:white">Hello</div>
+      <gcds-sr-only></gcds-sr-only>
+      <div style="padding: 20px; background-color:#2a7da6; color:white;">World</div>
+    `);
+
+    const sizingInfo = await page.evaluate( () => {
+      const elm = document.querySelector( 'gcds-sr-only' );
+      const rectPrevElm = elm.previousElementSibling.getBoundingClientRect();
+      const rectNextElm = elm.nextElementSibling.getBoundingClientRect();
+      return {
+        offsetHeight: elm.offsetHeight,
+        offsetWidth: elm.offsetWidth,
+        bottomPrevElm: rectPrevElm.bottom,
+        topNextElm: rectNextElm.top
+      }
+    });
+
+    expect( sizingInfo.bottomPrevElm ).toEqual( sizingInfo.topNextElm );
+    expect( sizingInfo.offsetHeight ).toBeGreaterThan( 0 );
+    expect( sizingInfo.offsetWidth ).toBeGreaterThan( 0 );
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

Align the style of `gcds-sr-only` with the [WCAG CSS technique C7](https://www.w3.org/WAI/WCAG22/Techniques/css/C7) and it avoid the 0 pixel technique because it is not recommended according to a [WebAim article about invisible content just for screen reader users](https://webaim.org/techniques/css/invisiblecontent/). 

It also remove the space taken by the component as it must be visually invisible but only visible to screen reader only.

# Test instructions | Instructions pour tester la modification

The following tests were automated and integrated to the unit testing of the `<gcds-sr-only>` component

## Component are visually invisible and don't interfere with visual design
1. Put the `<gcds-sr-only>` component in between 2 other visually rendered component.
2. **Expected:** The bottom of the preceding component and the top of the next one should be the same without any space in between.

| Current | With this fix |
| -------- | ------------ |
| You can observe it does takes an undesirable vertical space. | You can observe that vertical space is removed. |
| ![image](https://github.com/user-attachments/assets/f224d411-f835-459d-90b1-de366554f176) | ![image](https://github.com/user-attachments/assets/99ab5be5-9e48-4251-86c3-4eacfaa7f62f) |


## Ensure the screen reader content are at least one pixel size
1. Select the `<gcds-sr-only>` component in the DOM
2. **Expected:** The element properties `offsetWidth` and `offsetHeight` must be greater than 0.
