### PR TITLE
fix: Fix typos in tokens

### DIFF
--- a/packages/web/src/components/gcds-grid/gcds-grid-col.css
+++ b/packages/web/src/components/gcds-grid/gcds-grid-col.css
@@ -32,7 +32,7 @@
       grid-column: span
         var(--gcds-grid-col-tablet, var(--gcds-grid-columns-default-tablet)) /
         span
-        var(---gcds-grid-col-tablet, var(--gcds-grid-columns-default-tablet));
+        var(--gcds-grid-col-tablet, var(--gcds-grid-columns-default-tablet));
     }
   }
 }

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
@@ -13,7 +13,7 @@
 @layer default {
   :host .gcds-nav-link {
     display: flex;
-    font: var(---gcds-nav-link-font);
+    font: var(--gcds-nav-link-font);
     text-decoration-style: solid;
     text-decoration-line: underline;
     text-decoration-color: currentColor;


### PR DESCRIPTION
# Summary | Résumé

The `gcds-nav-link` has a typo when setting the font property (`var(---gcds-nav-link-font)`). It should be `var(--gcds-nav-link-font)`.
