### PR TITLE
fix: Update available options in select if changed

### DIFF
--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -285,6 +285,24 @@ export class GcdsSelect {
   }
 
   /*
+   * Observe passed options and update if change
+   */
+  observeOptions() {
+    const config = {
+      attributes: false,
+      childList: true,
+      characterData: true,
+      subtree: true,
+    };
+    const observer = new MutationObserver(() => {
+      this.options = Array.from(this.el.children);
+      // Reset value to null to prevent unwanted selection
+      this.value = null;
+    });
+    observer.observe(this.el, config);
+  }
+
+  /*
    * Observe lang attribute change
    */
   updateLang() {
@@ -331,6 +349,10 @@ export class GcdsSelect {
         }
       });
     }
+  }
+
+  async componentDidLoad() {
+    this.observeOptions();
   }
 
   componentWillUpdate() {


### PR DESCRIPTION
# Summary | Résumé

Add `mutationObserver` to `gcds-select` to observe if passed `<options>` have been changed. This allows the select component to keep the same behaviour as the HTML select.

[Example of issue using React](https://stackblitz.com/edit/vitejs-vite-rldmhu?file=src%2FApp.tsx)

https://github.com/cds-snc/gcds-components/issues/643