### PR TITLE
docs: Fix typo with main-container attribute in storybook

### DIFF
--- a/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
+++ b/packages/web/src/components/gcds-container/stories/gcds-container.stories.tsx
@@ -20,6 +20,7 @@ export default {
       },
     },
     mainContainer: {
+      name: 'main-container',
       control: { type: 'select' },
       options: [false, true],
       table: {


### PR DESCRIPTION
# Summary | Résumé

Fix typo in `gcds-container` properties in storybook. The `main-container` attribute was appearing as `mainContainer`.
