### PR TITLE
chore: Add logic to prevent flash on prop change in storybook

### DIFF
--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -730,6 +730,15 @@
     }, 100);
   }
 
+  // Add min-height to frame to help prevent flash when component props are modified
+  const frameSize = setInterval(() => {
+    const docsStory = document.querySelector('[data-name="Props"]');
+    if (docsStory && docsStory.clientHeight > 0) {
+      docsStory.setAttribute('style', `min-height: ${docsStory.clientHeight}px;`);
+      clearInterval(frameSize);
+    }
+  }, 200);
+
   // Add event listener to execute domContentLoadedHandler function when DOM content is loaded
   document.addEventListener('DOMContentLoaded', domContentLoadedHandler);
 


### PR DESCRIPTION
# Summary | Résumé

Add some logic to add a `min-height` to storybook frame to hopefully prevent large flashes when component re-renders. Seen when viewing components through the iframe view (`/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-input--events-properties&lang=en`). 
