### PR TITLE
fix(gcds-error-summary): focusing gcds element from manual error-links list

### DIFF
--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.tsx
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.tsx
@@ -150,11 +150,7 @@ export class GcdsErrorSummary {
 
     let target = `[for=${id.replace('#', '')}]`;
 
-    if (element.nodeName == 'FIELDSET') {
-      target = `#legend-${id.replace('#', '')}`;
-    }
-
-    element.closest('form').querySelector(target).scrollIntoView();
+    element.closest('form').querySelector(target)?.scrollIntoView();
     element.focus();
   }
 


### PR DESCRIPTION
# Summary | Résumé

As highlighted in https://github.com/cds-snc/gcds-components/issues/664, GC Design System form elements were not focusing when error links were clicked from manually entered list with `error-links` property. Modified logic to not call `scrollIntoView()` if no label is found, this logic is meant for non-gcds form elements.
