### PR TITLE
fix: error-message property blocking form submission.

### DIFF
--- a/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
+++ b/packages/web/src/components/gcds-checkbox/gcds-checkbox.tsx
@@ -245,7 +245,7 @@ export class GcdsCheckbox {
         this.validate();
       }
 
-      if (this.hasError) {
+      if (this.hasError && this.validateOn != 'other') {
         e.preventDefault();
       }
     }

--- a/packages/web/src/components/gcds-date-input/gcds-date-input.tsx
+++ b/packages/web/src/components/gcds-date-input/gcds-date-input.tsx
@@ -256,7 +256,7 @@ export class GcdsDateInput {
       }
 
       for (const key in this.hasError) {
-        if (this.hasError[key]) {
+        if (this.hasError[key] && this.validateOn != 'other') {
           e.preventDefault();
         }
       }

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -280,7 +280,7 @@ export class GcdsFileUploader {
         this.validate();
       }
 
-      if (this.hasError) {
+      if (this.hasError && this.validateOn != 'other') {
         e.preventDefault();
       }
     }

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -260,7 +260,7 @@ export class GcdsInput {
         this.validate();
       }
 
-      if (this.hasError) {
+      if (this.hasError && this.validateOn != 'other') {
         e.preventDefault();
       }
     }

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -245,7 +245,7 @@ export class GcdsSelect {
         this.validate();
       }
 
-      if (this.hasError) {
+      if (this.hasError && this.validateOn != 'other') {
         e.preventDefault();
       }
     }

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -243,7 +243,7 @@ export class GcdsTextarea {
         this.validate();
       }
 
-      if (this.hasError) {
+      if (this.hasError && this.validateOn != 'other') {
         e.preventDefault();
       }
     }


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/670, when a form component has a filled in `error-message` attribute it will prevent the form from being submitted. Allow bypassing this block by using `validate-on="other"`. This should allow teams using server side validation to use the form components normally.
