### PR TITLE
refactor: adjust details font sizes and summary + panel padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2819,11 +2819,10 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.19.1.tgz",
-      "integrity": "sha512-PaJq3wUI8qjfjdWCbkWKHPibY6Tg/yS5EGoXVX+HKYrPIdNYPF3cYxHO/agfGVIHRVO/dfxhiHBG7RPRS0Hvgw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-1.20.1.tgz",
+      "integrity": "sha512-E6+od9ttOvkHv+IrLsDQjKqKCznFWGxR38fR80vpP9VAZfE56q8JbrDzOAE++R0pQayOsmJ+2eDDca/JjoOBSA==",
+      "dev": true
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -47186,7 +47185,7 @@
     },
     "packages/react-ssr": {
       "name": "@cdssnc/gcds-components-react-ssr",
-      "version": "0.26.3",
+      "version": "0.26.3-canary.0",
       "license": "MIT",
       "dependencies": {
         "@cdssnc/gcds-components": "^0.26.3",
@@ -48550,7 +48549,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^1.19.1",
+        "@cdssnc/gcds-tokens": "^1.20.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^1.19.1",
+    "@cdssnc/gcds-tokens": "^1.20.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-details/gcds-details.css
+++ b/packages/web/src/components/gcds-details/gcds-details.css
@@ -38,7 +38,7 @@
       position: relative;
       padding: var(--gcds-details-summary-padding);
       color: var(--gcds-details-default-text);
-      font: var(--gcds-details-font);
+      font: var(--gcds-details-font-desktop);
       text-align: left;
       text-decoration-style: solid;
       text-decoration-line: underline;
@@ -50,6 +50,10 @@
       transition:
         background-color 0.15s ease-in-out,
         color 0.15s ease-in-out;
+
+      @media only screen and (width < 48em) {
+        font: var(--gcds-details-font-mobile);
+      }
 
       &:before {
         position: absolute;
@@ -71,19 +75,33 @@
         display: none;
       }
 
-      &[aria-expanded='true']::before {
+      &[aria-expanded='true']:before {
         transform: rotate(90deg);
       }
     }
 
     .details__panel {
+      position: relative;
       margin: var(--gcds-details-panel-margin);
       padding: var(--gcds-details-panel-padding);
-      border-inline-start: var(--gcds-details-panel-border-width) solid
-        var(--gcds-details-panel-border-color);
+
+      &:before {
+        position: absolute;
+        display: block;
+        top: 0;
+        left: 0;
+        width: var(--gcds-details-panel-border-width);
+        height: 100%;
+        content: '';
+        background-color: var(--gcds-details-panel-border-color);
+      }
 
       ::slotted(*) {
-        font: var(--gcds-details-font);
+        font: var(--gcds-details-font-desktop);
+
+        @media only screen and (width < 48em) {
+          font: var(--gcds-details-font-mobile);
+        }
       }
 
       ::slotted(*:not(:last-child)) {
@@ -98,7 +116,11 @@
       }
 
       ::slotted(small) {
-        font: var(--gcds-details-font-small);
+        font: var(--gcds-details-font-small-desktop);
+
+        @media only screen and (width < 48em) {
+          font: var(--gcds-details-font-small-mobile);
+        }
       }
     }
   }


### PR DESCRIPTION
# Summary | Résumé

Adjust details tokens:

- Add tokens for desktop and mobile font sizes
- Adjust padding for summary and panel

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1147)

Note: The link component already uses the correct styles.