### PR TITLE
feat(gcds-file-uploader): Add files prop for ease of access to uploaded files

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -423,7 +423,7 @@ export declare interface GcdsFieldset extends Components.GcdsFieldset {
 
 
 @ProxyCmp({
-  inputs: ['accept', 'disabled', 'errorMessage', 'hint', 'label', 'multiple', 'name', 'required', 'uploaderId', 'validateOn', 'validator', 'value'],
+  inputs: ['accept', 'disabled', 'errorMessage', 'files', 'hint', 'label', 'multiple', 'name', 'required', 'uploaderId', 'validateOn', 'validator', 'value'],
   methods: ['validate'],
   outputs: ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid']
 })
@@ -432,7 +432,7 @@ export declare interface GcdsFieldset extends Components.GcdsFieldset {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['accept', 'disabled', 'errorMessage', 'hint', 'label', 'multiple', 'name', 'required', 'uploaderId', 'validateOn', 'validator', 'value'],outputs: ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid'],
+  inputs: ['accept', 'disabled', 'errorMessage', 'files', 'hint', 'label', 'multiple', 'name', 'required', 'uploaderId', 'validateOn', 'validator', 'value'],outputs: ['gcdsFocus', 'gcdsBlur', 'gcdsChange', 'gcdsInput', 'gcdsRemoveFile', 'gcdsError', 'gcdsValid'],
 })
 export class GcdsFileUploader {
   protected el: HTMLElement;

--- a/packages/vue/lib/components.ts
+++ b/packages/vue/lib/components.ts
@@ -164,6 +164,7 @@ export const GcdsFileUploader = /*@__PURE__*/ defineContainer<JSX.GcdsFileUpload
   'value',
   'accept',
   'multiple',
+  'files',
   'errorMessage',
   'hint',
   'validator',

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -380,6 +380,10 @@ export namespace Components {
          */
         "errorMessage": string;
         /**
+          * FileList of uploaded files to input
+         */
+        "files": FileList;
+        /**
           * Hint displayed below the label.
          */
         "hint": string;
@@ -2255,6 +2259,10 @@ declare namespace LocalJSX {
           * Error message for an invalid file uploader element.
          */
         "errorMessage"?: string;
+        /**
+          * FileList of uploaded files to input
+         */
+        "files"?: FileList;
         /**
           * Hint displayed below the label.
          */

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -94,6 +94,11 @@ export class GcdsFileUploader {
   @Prop({ reflect: true, mutable: false }) multiple: boolean;
 
   /**
+   * FileList of uploaded files to input
+   */
+  @Prop({ mutable: true }) files: FileList;
+
+  /**
    * Error message for an invalid file uploader element.
    */
   @Prop({ reflect: true, mutable: true }) errorMessage: string;
@@ -188,6 +193,7 @@ export class GcdsFileUploader {
   private handleInput = (e, customEvent) => {
     const filesContainer: string[] = [];
     const files = Array.from(e.target.files);
+    this.files = e.target.files;
 
     files.map(file => {
       filesContainer.push(file['name']);
@@ -236,6 +242,7 @@ export class GcdsFileUploader {
       }
 
       this.shadowElement.files = dt.files;
+      this.files = dt.files;
       this.addFilesToFormData(this.shadowElement.files);
     }
 

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -97,6 +97,18 @@ export class GcdsFileUploader {
    * FileList of uploaded files to input
    */
   @Prop({ mutable: true }) files: FileList;
+  @Watch('files')
+  watchFiles() {
+    const filesContainer: string[] = [];
+    const files = Array.from(this.files);
+
+    files.map(file => {
+      filesContainer.push(file['name']);
+    });
+
+    this.addFilesToFormData(files);
+    this.value = [...filesContainer];
+  }
 
   /**
    * Error message for an invalid file uploader element.
@@ -312,9 +324,11 @@ export class GcdsFileUploader {
   private addFilesToFormData = files => {
     const formData = new FormData();
 
-    files.forEach(file => {
-      formData.append(this.name, file, file.name);
-    });
+    if (files.length > 0) {
+      files.forEach(file => {
+        formData.append(this.name, file, file.name);
+      });
+    }
 
     this.internals.setFormValue(formData);
   };

--- a/packages/web/src/components/gcds-file-uploader/readme.md
+++ b/packages/web/src/components/gcds-file-uploader/readme.md
@@ -10,6 +10,7 @@
 | `accept`                  | `accept`        | Defines the file types the file uploader accepts.                           | `string`                                            | `undefined` |
 | `disabled`                | `disabled`      | Specifies if a file uploader element is disabled or not.                    | `boolean`                                           | `false`     |
 | `errorMessage`            | `error-message` | Error message for an invalid file uploader element.                         | `string`                                            | `undefined` |
+| `files`                   | --              | FileList of uploaded files to input                                         | `FileList`                                          | `undefined` |
 | `hint`                    | `hint`          | Hint displayed below the label.                                             | `string`                                            | `undefined` |
 | `label` _(required)_      | `label`         | Form field label.                                                           | `string`                                            | `undefined` |
 | `multiple`                | `multiple`      | Boolean that specifies if the user is allowed to select more than one file. | `boolean`                                           | `undefined` |

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
@@ -12,7 +12,7 @@ describe('gcds-file-uploader', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  it('renders', async () => {
+  it('upload 1 files', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<gcds-file-uploader label="file uploader label" name="file" uploader-id="file-uploader" />',
@@ -25,7 +25,69 @@ describe('gcds-file-uploader', () => {
 
     await fileChooser.accept(['./gcds-file-uploader.e2e.ts']);
 
+    await page.waitForChanges();
+
     expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(1);
+  });
+
+  it('upload multiple files', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<gcds-file-uploader label="file uploader label" multiple name="file" uploader-id="file-uploader" />',
+    );
+
+    const [fileChooser] = await Promise.all([
+      page.waitForFileChooser(),
+      page.click('gcds-file-uploader >>> input')
+    ]);
+
+    await fileChooser.accept(['./gcds-file-uploader.e2e.ts', './gcds-file-uploader.spec.tsx']);
+
+    await page.waitForChanges();
+
+    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(2);
+  });
+
+  it('upload and remove file', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<gcds-file-uploader label="file uploader label" name="file" uploader-id="file-uploader" />',
+    );
+
+    const [fileChooser] = await Promise.all([
+      page.waitForFileChooser(),
+      page.click('gcds-file-uploader >>> input')
+    ]);
+
+    await fileChooser.accept(['./gcds-file-uploader.e2e.ts']);
+
+    await page.waitForChanges();
+
+    await (await page.find('gcds-file-uploader >>> .file-uploader__uploaded-file > button')).click();
+
+    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(0);
+  });
+
+  it('set files property manually', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<gcds-file-uploader label="file uploader label" name="file" uploader-id="file-uploader" />',
+    );
+
+    await page.evaluate(() => {
+      const blob = new Blob(['hello world'], { type: 'text/plain' });
+      const file = new File([blob], './example.txt', { type: 'text/plain' });
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      
+      document.querySelector('gcds-file-uploader').files = dataTransfer.files;
+    })
+
+    await page.waitForChanges();
+
+    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(1);
+    expect((await page.find('gcds-file-uploader >>> gcds-text')).textContent).toBe('./example.txt');
   });
 });
 

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
@@ -20,14 +20,20 @@ describe('gcds-file-uploader', () => {
 
     const [fileChooser] = await Promise.all([
       page.waitForFileChooser(),
-      page.click('gcds-file-uploader >>> input')
+      page.click('gcds-file-uploader >>> input'),
     ]);
 
     await fileChooser.accept(['./gcds-file-uploader.e2e.ts']);
 
     await page.waitForChanges();
 
-    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(1);
+    expect(
+      (
+        await page.findAll(
+          'gcds-file-uploader >>> .file-uploader__uploaded-file',
+        )
+      ).length,
+    ).toBe(1);
   });
 
   it('upload multiple files', async () => {
@@ -38,14 +44,23 @@ describe('gcds-file-uploader', () => {
 
     const [fileChooser] = await Promise.all([
       page.waitForFileChooser(),
-      page.click('gcds-file-uploader >>> input')
+      page.click('gcds-file-uploader >>> input'),
     ]);
 
-    await fileChooser.accept(['./gcds-file-uploader.e2e.ts', './gcds-file-uploader.spec.tsx']);
+    await fileChooser.accept([
+      './gcds-file-uploader.e2e.ts',
+      './gcds-file-uploader.spec.tsx',
+    ]);
 
     await page.waitForChanges();
 
-    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(2);
+    expect(
+      (
+        await page.findAll(
+          'gcds-file-uploader >>> .file-uploader__uploaded-file',
+        )
+      ).length,
+    ).toBe(2);
   });
 
   it('upload and remove file', async () => {
@@ -56,16 +71,26 @@ describe('gcds-file-uploader', () => {
 
     const [fileChooser] = await Promise.all([
       page.waitForFileChooser(),
-      page.click('gcds-file-uploader >>> input')
+      page.click('gcds-file-uploader >>> input'),
     ]);
 
     await fileChooser.accept(['./gcds-file-uploader.e2e.ts']);
 
     await page.waitForChanges();
 
-    await (await page.find('gcds-file-uploader >>> .file-uploader__uploaded-file > button')).click();
+    await (
+      await page.find(
+        'gcds-file-uploader >>> .file-uploader__uploaded-file > button',
+      )
+    ).click();
 
-    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(0);
+    expect(
+      (
+        await page.findAll(
+          'gcds-file-uploader >>> .file-uploader__uploaded-file',
+        )
+      ).length,
+    ).toBe(0);
   });
 
   it('set files property manually', async () => {
@@ -80,14 +105,22 @@ describe('gcds-file-uploader', () => {
 
       const dataTransfer = new DataTransfer();
       dataTransfer.items.add(file);
-      
+
       document.querySelector('gcds-file-uploader').files = dataTransfer.files;
-    })
+    });
 
     await page.waitForChanges();
 
-    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(1);
-    expect((await page.find('gcds-file-uploader >>> gcds-text')).textContent).toBe('./example.txt');
+    expect(
+      (
+        await page.findAll(
+          'gcds-file-uploader >>> .file-uploader__uploaded-file',
+        )
+      ).length,
+    ).toBe(1);
+    expect(
+      (await page.find('gcds-file-uploader >>> gcds-text')).textContent,
+    ).toBe('./example.txt');
   });
 });
 

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
@@ -12,7 +12,7 @@ describe('gcds-file-uploader', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  it('upload 1 files', async () => {
+  it('upload 1 file', async () => {
     const page = await newE2EPage();
     await page.setContent(
       '<gcds-file-uploader label="file uploader label" name="file" uploader-id="file-uploader" />',

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
@@ -11,6 +11,22 @@ describe('gcds-file-uploader', () => {
     const element = await page.find('gcds-file-uploader');
     expect(element).toHaveClass('hydrated');
   });
+
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<gcds-file-uploader label="file uploader label" name="file" uploader-id="file-uploader" />',
+    );
+
+    const [fileChooser] = await Promise.all([
+      page.waitForFileChooser(),
+      page.click('gcds-file-uploader >>> input')
+    ]);
+
+    await fileChooser.accept(['./gcds-file-uploader.e2e.ts']);
+
+    expect((await page.findAll('gcds-file-uploader >>> .file-uploader__uploaded-file')).length).toBe(1);
+  });
 });
 
 /**


### PR DESCRIPTION
# Summary | Résumé

To match how developers interact with the native HTML file input, add a `files` property to easily access uploaded files to file uploader.

## Example

With HTML file inputs, to access the files uploaded on a change event a developer would just need to use `event.target.files`. With `gcds-file-uploader` it requires using `event.target.shadowRoot.querySelector('input').files` to acheive the same functionality. Adding the `files` prop will allow developers to use the usual method to gain access to the files.

```html
      <gcds-file-uploader
        uploader-id="form-uploader"
        label="Upload file"
        id="file"
        multiple
        required
      ></gcds-file-uploader>

      <script>
        document.getElementById('file').addEventListener('change', (e) => {
          // File-uploader files - new way
          console.log(e.target.files);
          // Input in shadow-dom files - old way
          console.log(e.target.shadowRoot.querySelector('input').files);
        })
      </script>
``` 
