### PR TITLE
refactor: improve date-modified validation

### DIFF
--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Host, Prop, State, h } from '@stencil/core';
-import { assignLanguage, observerConfig } from '../../utils/utils';
+import { assignLanguage, observerConfig, logError } from '../../utils/utils';
 import i18n from './i18n/i18n';
 
 @Component({
@@ -20,6 +20,12 @@ export class GcdsDateModified {
   @Prop({ mutable: true }) type: 'date' | 'version' = 'date';
 
   /**
+   * State to track validation on properties
+   * Contains a list of properties that have an error associated with them
+   */
+  @State() errors: Array<string> = [];
+
+  /**
    * Language of rendered component
    */
   @State() lang: string;
@@ -36,11 +42,34 @@ export class GcdsDateModified {
     observer.observe(this.el, observerConfig);
   }
 
+  private validateChildren() {
+    if (this.el.innerHTML.trim() == '') {
+      this.errors.push('children');
+    } else if (this.errors.includes('children')) {
+      this.errors.splice(this.errors.indexOf('children'), 1);
+    }
+  }
+
+  private validateRequiredProps() {
+    this.validateChildren();
+
+    if (this.errors.includes('children')) {
+      return false;
+    }
+    return true;
+  }
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
 
     this.updateLang();
+
+    let valid = this.validateRequiredProps();
+
+    if (!valid) {
+      logError('gcds-date-modified', this.errors);
+    }
   }
 
   render() {
@@ -48,24 +77,26 @@ export class GcdsDateModified {
 
     return (
       <Host>
-        <dl class="gcds-date-modified">
-          <dt>
-            <gcds-text display="inline" margin-bottom="0">
-              {type === 'version' ? i18n[lang].version : i18n[lang].date}
-            </gcds-text>
-          </dt>
-          <dd>
-            <gcds-text display="inline" margin-bottom="0">
-              {type === 'version' ? (
-                <slot></slot>
-              ) : (
-                <time>
+        {this.validateRequiredProps() && (
+          <dl class="gcds-date-modified">
+            <dt>
+              <gcds-text display="inline" margin-bottom="0">
+                {type === 'version' ? i18n[lang].version : i18n[lang].date}
+              </gcds-text>
+            </dt>
+            <dd>
+              <gcds-text display="inline" margin-bottom="0">
+                {type === 'version' ? (
                   <slot></slot>
-                </time>
-              )}
-            </gcds-text>
-          </dd>
-        </dl>
+                ) : (
+                  <time>
+                    <slot></slot>
+                  </time>
+                )}
+              </gcds-text>
+            </dd>
+          </dl>
+        )}
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
+++ b/packages/web/src/components/gcds-date-modified/stories/gcds-date-modified.stories.tsx
@@ -25,6 +25,9 @@ export default {
       table: {
         category: 'Slots | Fentes',
       },
+      type: {
+        required: true,
+      },
     },
   },
 };

--- a/packages/web/src/components/gcds-date-modified/test/gcds-date-modified.spec.tsx
+++ b/packages/web/src/components/gcds-date-modified/test/gcds-date-modified.spec.tsx
@@ -73,4 +73,17 @@ describe('gcds-date-modified', () => {
       </gcds-date-modified>
     `);
   });
+
+  it('does not render - no children', async () => {
+    const page = await newSpecPage({
+      components: [GcdsDateModified],
+      html: `<gcds-date-modified lang="en"></gcds-date-modified>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-date-modified lang="en">
+        <mock:shadow-root>
+        </mock:shadow-root>
+      </gcds-date-modified>
+    `);
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

Prevent date-modified component from rendering when no children (date or version) are passed.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1127)