### PR TITLE
fix(gcds-fieldset): Add CSS to allow form components to maintain responsive layout

### DIFF
--- a/packages/web/src/components/gcds-fieldset/gcds-fieldset.css
+++ b/packages/web/src/components/gcds-fieldset/gcds-fieldset.css
@@ -7,6 +7,7 @@
     .gcds-fieldset {
       border: 0;
       padding: 0;
+      min-inline-size: auto
     }
 
     legend {


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/682, elements in the `gcds-fieldset` would no longer be responsive and overflow with the viewport. The issue just mentions the `gcds-select` but further tests found this was also happening with the other form components (input, textarea, etc). Added `min-inline-size: auto` to the fieldset's CSS as recommended from the issue.
