### PR TITLE
refactor: adjust form element spacing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2818,9 +2818,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.0.1.tgz",
-      "integrity": "sha512-vX7WKvFd8yawpSw+bibMwxLTcwZe74c9IZ3IuwPR+EgTQD38U3g7uYO4l1zmacHNKMoQ8H0D9OqyJCsubMywzQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.0.2.tgz",
+      "integrity": "sha512-xDgIlIDdO7FXY/OJMOEI4YF78CpBl4944YIajMurMSGpHN7C/rlotgVYXCvF8eO8BY5drGmadzFD2qG/f3ktzA==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -44165,7 +44165,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^2.0.1",
+        "@cdssnc/gcds-tokens": "^2.0.2",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/vue/tests/app/package-lock.json
+++ b/packages/vue/tests/app/package-lock.json
@@ -19,10 +19,10 @@
     },
     "../..": {
       "name": "@cdssnc/gcds-components-vue",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "MIT",
       "dependencies": {
-        "@cdssnc/gcds-components": "^0.28.0"
+        "@cdssnc/gcds-components": "^0.29.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.44.1",
@@ -962,7 +962,7 @@
     "@cdssnc/gcds-components-vue": {
       "version": "file:../..",
       "requires": {
-        "@cdssnc/gcds-components": "^0.28.0",
+        "@cdssnc/gcds-components": "^0.29.0",
         "@playwright/test": "^1.44.1",
         "@types/node": "^20.14.2",
         "@vitejs/plugin-vue": "^5.0.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^2.0.1",
+    "@cdssnc/gcds-tokens": "^2.0.2",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
+++ b/packages/web/src/components/gcds-error-message/gcds-error-message.tsx
@@ -25,7 +25,7 @@ export class GcdsErrorMessage {
         id={`error-message-${messageId}`}
         class="gcds-error-message-wrapper"
       >
-        <gcds-text class="error-message" role="alert" margin-bottom="100">
+        <gcds-text class="error-message" role="alert" margin-bottom="75">
           <gcds-icon name="triangle-exclamation" margin-right="50"></gcds-icon>
           <strong>
             <slot></slot>

--- a/packages/web/src/components/gcds-error-message/test/gcds-error-message.spec.ts
+++ b/packages/web/src/components/gcds-error-message/test/gcds-error-message.spec.ts
@@ -10,7 +10,7 @@ describe('gcds-error-message', () => {
     expect(root).toEqualHtml(`
       <gcds-error-message message-id="input-renders" id="error-message-input-renders" class="gcds-error-message-wrapper">
         <mock:shadow-root>
-          <gcds-text class="error-message" role="alert" margin-bottom="100">
+          <gcds-text class="error-message" role="alert" margin-bottom="75">
             <gcds-icon name="triangle-exclamation" margin-right="50"></gcds-icon>
             <strong>
               <slot></slot>


### PR DESCRIPTION
# Summary | Résumé

Adjust spacing for some of our form elements to optimize design after our spacing update.

Note:
Wait for the [updated token package](https://github.com/cds-snc/gcds-tokens/pull/365) to release form spacing changes together.