### PR TITLE
ci: pin workflow image to ubuntu 22

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-deploy:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04.5
     steps:
       - name: Git Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-deploy:
     name: Run Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04 # latest version 24 has incompatibility issues (playwright)
     steps:
       - name: Git Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-deploy:
     name: Run Tests
-    runs-on: ubuntu-22.04.5
+    runs-on: ubuntu-22.04
     steps:
       - name: Git Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
# Summary | Résumé

Noticed the run-tests workflow was no longer working as it was failing trying to install dependencies for playwright.

## Cause

GitHub has started transitioning the runner `ubuntu-latest` to use Ubuntu v24 instead of Ubuntu v22.04. Playwright has not been updated to work with the latest version of Ubuntu so we need to force using `v22.04` with our `run-tests` workflow.
