### PR TITLE
refactor: update component spacing + pagination arrows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,9 +4055,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.0.3.tgz",
-      "integrity": "sha512-6AMHF6CBy89oDP02snfcqYpnaw+GT/LvqEsClPrRawRfZ1ApxYg+lP9mWWwbwpbZqm8WdYfl3sJpLcTM8fxwEQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.0.4.tgz",
+      "integrity": "sha512-Nvh+PX32uMS3lWCsg5pa76jhlpyV4Z3tom/q/3npjM+N3XOSGFamKpNWGlITrqB3R0KF21yrOGK6ZtPi9su01g==",
       "dev": true
     },
     "node_modules/@colors/colors": {
@@ -42119,7 +42119,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^2.0.3",
+        "@cdssnc/gcds-tokens": "^2.0.4",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^2.0.3",
+    "@cdssnc/gcds-tokens": "^2.0.4",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
@@ -174,7 +174,7 @@ export class GcdsPagination {
               }
             >
               {I18N[this.lang].next}
-              <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+              <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
             </a>
           ) : (
             <a
@@ -185,7 +185,7 @@ export class GcdsPagination {
                   : 'gcds-pagination-end-button-mobile'
               }
             >
-              <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+              <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
               {mobile
                 ? I18N[this.lang].previousMobile
                 : I18N[this.lang].previous}
@@ -399,7 +399,7 @@ export class GcdsPagination {
                     onFocus={() => this.gcdsFocus.emit()}
                     onClick={e => emitEvent(e, this.gcdsClick, previousHref)}
                   >
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     <div class="gcds-pagination-simple-text">
                       {I18N[lang].previous}
                     </div>
@@ -422,7 +422,7 @@ export class GcdsPagination {
                       {I18N[lang].next}
                     </div>
                     <span>{nextLabel}</span>
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               )}

--- a/packages/web/src/components/gcds-pagination/test/gcds-pagination.spec.tsx
+++ b/packages/web/src/components/gcds-pagination/test/gcds-pagination.spec.tsx
@@ -22,7 +22,7 @@ describe('gcds-pagination', () => {
             <ul class="gcds-pagination-simple">
               <li class="gcds-pagination-simple-previous">
                 <a aria-label="Previous page: Previous label" href="#previous">
-                  <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                  <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                   <div class="gcds-pagination-simple-text">
                     Previous
                   </div>
@@ -39,7 +39,7 @@ describe('gcds-pagination', () => {
                   <span>
                     Next label
                   </span>
-                  <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                  <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                 </a>
               </li>
             </ul>
@@ -67,7 +67,7 @@ describe('gcds-pagination', () => {
             <ul class="gcds-pagination-simple">
               <li class="gcds-pagination-simple-previous">
                 <a aria-label="Previous page" href="#previous">
-                  <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                  <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                   <div class="gcds-pagination-simple-text">
                     Previous
                   </div>
@@ -82,7 +82,7 @@ describe('gcds-pagination', () => {
                   </div>
                   <span>
                   </span>
-                  <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                  <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                 </a>
               </li>
             </ul>
@@ -112,7 +112,7 @@ describe('gcds-pagination', () => {
             <ul class="gcds-pagination-simple">
               <li class="gcds-pagination-simple-previous">
                 <a aria-label="Page précédente: Previous label" href="#previous">
-                  <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                  <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                   <div class="gcds-pagination-simple-text">
                   Précédent
                   </div>
@@ -129,7 +129,7 @@ describe('gcds-pagination', () => {
                   <span>
                     Next label
                   </span>
-                  <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                  <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                 </a>
               </li>
             </ul>
@@ -157,7 +157,7 @@ describe('gcds-pagination', () => {
             <ul class="gcds-pagination-simple">
               <li class="gcds-pagination-simple-previous">
                 <a aria-label="Page précédente" href="#previous">
-                  <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                  <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                   <div class="gcds-pagination-simple-text">
                     Précédent
                   </div>
@@ -172,7 +172,7 @@ describe('gcds-pagination', () => {
                   </div>
                   <span>
                   </span>
-                  <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                  <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                 </a>
               </li>
             </ul>
@@ -202,7 +202,7 @@ describe('gcds-pagination', () => {
               <ul class="gcds-pagination-list">
                 <li>
                   <a aria-label="Previous page: Page 4 of 9 of Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Previous
                   </a>
                 </li>
@@ -264,21 +264,21 @@ describe('gcds-pagination', () => {
                 <li>
                   <a aria-label="Next page: Page 6 of 9 of Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
                     Next
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>
               <ul class="gcds-pagination-list-mobile-prevnext">
                 <li>
                   <a aria-label="Previous page: Page 4 of 9 of Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Prev
                   </a>
                 </li>
                 <li>
                   <a aria-label="Next page: Page 6 of 9 of Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                     Next
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>
@@ -309,7 +309,7 @@ describe('gcds-pagination', () => {
               <ul class="gcds-pagination-list">
                 <li>
                   <a aria-label="Previous page: Page 9 of 20 of Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Previous
                   </a>
                 </li>
@@ -361,21 +361,21 @@ describe('gcds-pagination', () => {
                 <li>
                   <a aria-label="Next page: Page 11 of 20 of Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
                     Next
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>
               <ul class="gcds-pagination-list-mobile-prevnext">
                 <li>
                   <a aria-label="Previous page: Page 9 of 20 of Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Prev
                   </a>
                 </li>
                 <li>
                   <a aria-label="Next page: Page 11 of 20 of Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                     Next
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>
@@ -406,7 +406,7 @@ describe('gcds-pagination', () => {
               <ul class="gcds-pagination-list">
                 <li>
                   <a aria-label="Page précédente: Page 4 sur 9 des Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Précédent
                   </a>
                 </li>
@@ -468,21 +468,21 @@ describe('gcds-pagination', () => {
                 <li>
                   <a aria-label="Page suivante: Page 6 sur 9 des Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
                     Suivante
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>
               <ul class="gcds-pagination-list-mobile-prevnext">
                 <li>
                   <a aria-label="Page précédente: Page 4 sur 9 des Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Préc.
                   </a>
                 </li>
                 <li>
                   <a aria-label="Page suivante: Page 6 sur 9 des Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                     Suivante
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>
@@ -513,7 +513,7 @@ describe('gcds-pagination', () => {
               <ul class="gcds-pagination-list">
                 <li>
                   <a aria-label="Page précédente: Page 9 sur 20 des Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Précédent
                   </a>
                 </li>
@@ -565,21 +565,21 @@ describe('gcds-pagination', () => {
                 <li>
                   <a aria-label="Page suivante: Page 11 sur 20 des Search results" class="gcds-pagination-end-button" href="javascript:void(0)">
                     Suivante
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>
               <ul class="gcds-pagination-list-mobile-prevnext">
                 <li>
                   <a aria-label="Page précédente: Page 9 sur 20 des Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
-                    <gcds-icon margin-right="150" name="arrow-left"></gcds-icon>
+                    <gcds-icon margin-right="150" name="chevron-left"></gcds-icon>
                     Préc.
                   </a>
                 </li>
                 <li>
                   <a aria-label="Page suivante: Page 11 sur 20 des Search results" class="gcds-pagination-end-button-mobile" href="javascript:void(0)">
                     Suivante
-                    <gcds-icon margin-left="150" name="arrow-right"></gcds-icon>
+                    <gcds-icon margin-left="150" name="chevron-right"></gcds-icon>
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
# Summary | Résumé

Updating the component spacing for a few components to align with the design after the big typography and spacing update. Additionally, updating the arrows used in the pagination component to ensure they match the updated design. Here is an overview of the changes:

- Update error summary spacing
- Update nav group trigger
- Update stepper mobile margin
- Update pagination arrows to match the design

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1303)
