### PR TITLE
fix: input size property description

### DIFF
--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -624,7 +624,7 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
-          * Size attribute for an input element. Defines max-length as well.
+          * Size attribute for an input element to provide a visual indication of the expected text length to the user.
          */
         "size"?: number;
         /**
@@ -2453,7 +2453,7 @@ declare namespace LocalJSX {
          */
         "required"?: boolean;
         /**
-          * Size attribute for an input element. Defines max-length as well.
+          * Size attribute for an input element to provide a visual indication of the expected text length to the user.
          */
         "size"?: number;
         /**

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -104,8 +104,8 @@ export class GcdsInput {
   @Prop() required?: boolean = false;
 
   /**
-   * Size attribute for an input element.
-   * Defines max-length as well.
+   * Size attribute for an input element to provide a visual indication
+   * of the expected text length to the user.
    */
   @Prop() size?: number;
 

--- a/packages/web/src/components/gcds-input/readme.md
+++ b/packages/web/src/components/gcds-input/readme.md
@@ -7,22 +7,22 @@
 
 ## Properties
 
-| Property               | Attribute       | Description                                                      | Type                                                               | Default     |
-| ---------------------- | --------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------ | ----------- |
-| `autocomplete`         | `autocomplete`  | String to have autocomplete enabled                              | `string`                                                           | `undefined` |
-| `disabled`             | `disabled`      | Specifies if an input element is disabled or not.                | `boolean`                                                          | `false`     |
-| `errorMessage`         | `error-message` | Error message for an invalid input element.                      | `string`                                                           | `undefined` |
-| `hideLabel`            | `hide-label`    | Specifies if the label is hidden or not.                         | `boolean`                                                          | `false`     |
-| `hint`                 | `hint`          | Hint displayed below the label and above the input field.        | `string`                                                           | `undefined` |
-| `inputId` _(required)_ | `input-id`      | Id  attribute for an input element.                              | `string`                                                           | `undefined` |
-| `label` _(required)_   | `label`         | Form field label                                                 | `string`                                                           | `undefined` |
-| `name` _(required)_    | `name`          | Name attribute for an input element.                             | `string`                                                           | `undefined` |
-| `required`             | `required`      | Specifies if a form field is required or not.                    | `boolean`                                                          | `false`     |
-| `size`                 | `size`          | Size attribute for an input element. Defines max-length as well. | `number`                                                           | `undefined` |
-| `type`                 | `type`          | Set Input types                                                  | `"email" \| "number" \| "password" \| "search" \| "text" \| "url"` | `'text'`    |
-| `validateOn`           | `validate-on`   | Set event to call validator                                      | `"blur" \| "other" \| "submit"`                                    | `undefined` |
-| `validator`            | --              | Array of validators                                              | `(string \| ValidatorEntry \| Validator<string>)[]`                | `undefined` |
-| `value`                | `value`         | Default value for an input element.                              | `string`                                                           | `undefined` |
+| Property               | Attribute       | Description                                                                                                 | Type                                                               | Default     |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----------- |
+| `autocomplete`         | `autocomplete`  | String to have autocomplete enabled                                                                         | `string`                                                           | `undefined` |
+| `disabled`             | `disabled`      | Specifies if an input element is disabled or not.                                                           | `boolean`                                                          | `false`     |
+| `errorMessage`         | `error-message` | Error message for an invalid input element.                                                                 | `string`                                                           | `undefined` |
+| `hideLabel`            | `hide-label`    | Specifies if the label is hidden or not.                                                                    | `boolean`                                                          | `false`     |
+| `hint`                 | `hint`          | Hint displayed below the label and above the input field.                                                   | `string`                                                           | `undefined` |
+| `inputId` _(required)_ | `input-id`      | Id  attribute for an input element.                                                                         | `string`                                                           | `undefined` |
+| `label` _(required)_   | `label`         | Form field label                                                                                            | `string`                                                           | `undefined` |
+| `name` _(required)_    | `name`          | Name attribute for an input element.                                                                        | `string`                                                           | `undefined` |
+| `required`             | `required`      | Specifies if a form field is required or not.                                                               | `boolean`                                                          | `false`     |
+| `size`                 | `size`          | Size attribute for an input element to provide a visual indication of the expected text length to the user. | `number`                                                           | `undefined` |
+| `type`                 | `type`          | Set Input types                                                                                             | `"email" \| "number" \| "password" \| "search" \| "text" \| "url"` | `'text'`    |
+| `validateOn`           | `validate-on`   | Set event to call validator                                                                                 | `"blur" \| "other" \| "submit"`                                    | `undefined` |
+| `validator`            | --              | Array of validators                                                                                         | `(string \| ValidatorEntry \| Validator<string>)[]`                | `undefined` |
+| `value`                | `value`         | Default value for an input element.                                                                         | `string`                                                           | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
# Summary | Résumé

Update the input size description to explain more accurately what the property does.

## How to test

Look at the [README description](https://github.com/cds-snc/gcds-components/tree/fix-gcds-input-size-description/packages/web/src/components/gcds-input) for the input size prop.

## Zenhub ticket

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1206) for details.