### PR TITLE
fix(gcds-textarea): Properly set value in shadow-root textarea

### DIFF
--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -125,6 +125,14 @@ export class GcdsTextarea {
   @Prop({ mutable: true }) value?: string;
 
   /**
+   * Set value on internal textarea to allow proper resets
+   */
+  @Watch('value')
+  watchValue(val) {
+    this.shadowElement.value = val;
+  }
+
+  /**
    * Array of validators
    */
   @Prop({ mutable: true }) validator: Array<
@@ -200,6 +208,7 @@ export class GcdsTextarea {
     const val = e.target && e.target.value;
     this.value = val;
     this.internals.setFormValue(val ? val : null);
+    this.shadowElement.value = val;
 
     if (e.type === 'change') {
       const changeEvt = new e.constructor(e.type, e);


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/685, the `gcds-textarea` value would not be properly reset when using Formgroup. After some investigation it was revealed this wasn't directly related to the Angular implementation of `gcds-textarea` and was just a bug within the web component.

When the component's value changes, the value was not properly being transferred to the textarea in the shadow-root of the component so the shadow-root textarea would keep the previous value while the rest of the component would register the new value.

## How to test

### Code example

```html
      <gcds-textarea
        textarea-id="form-message"
        label="Message"
        hint="This is a hint."
        character-count="400"
        required
        id="text"
      ></gcds-textarea>

      <button type="button" onclick="resettextarea();">Reset textarea value</button>

      <script>
        function resettextarea() {
          let text = document.getElementById('text')
          text.value = '';
        }
      </script>
```

### Instructions

Run through the instructions once on the `main` branch and then on this branch to see the fix.

1. Add the code example to document.
2. Type text into the `gcds-textarea` component.
3. Click the reset button.
4. On `main` branch, the textarea will still show the typed text in the textarea but the character count will be reset. On this branch, the textarea should no longer show any text in the textarea.
