### PR TITLE
fix(gcds-link): Display property to allow normal link wrap behaviour

### DIFF
--- a/packages/web/src/components/gcds-link/gcds-link.css
+++ b/packages/web/src/components/gcds-link/gcds-link.css
@@ -2,7 +2,7 @@
 
 @layer reset {
   :host {
-    display: inline-block;
+    display: inline;
 
     slot {
       display: initial;


### PR DESCRIPTION
# Summary | Résumé

While publishing new content for our site, I noticed our `gcds-link` component does not wrap around in paragraphs like a normal `<a>` tag. Update the reset style to `display: inline` to allow the `gcds-link` to wrap like a default HTML `a` tag.

## How to test

Using the paragraph below, observe how the `gcds-link` wraps around the page while changing the viewport size.

```
<p>GC Design System is a service that is owned and operated by the Canadian Digital Service (CDS) at <gcds-link href="https://www.canada.ca/en/employment-social-development.html" external>Employment and Social Development Canada (ESDC).</gcds-link> This service enables Canadian federal departments and agencies to build and design trusted, predictable and accessible web and application experiences.</p>
```
