### PR TITLE
chore: update UF link in demo page

### DIFF
--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -11,7 +11,7 @@
     <!-- Utility framework -->
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/gh/cds-snc/gcds-utilities/dist/gcds-utility.css"
+      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@latest/dist/gcds-utility.min.css"
     />
 
     <!-- Fonts -->


### PR DESCRIPTION
# Summary | Résumé

Updating the utility framework link in our demo page to use the correct, new link and set it to `@latest`.