### PR TITLE
fix: nav component display and interaction issues

### DIFF
--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
@@ -111,7 +111,7 @@
     height: 100vh;
     overflow-y: scroll;
     background-color: var(--gcds-nav-group-mobile-background);
-    padding: var(--gcds-nav-group-mobile-padding);
+    padding: var(--gcds-nav-group-mobile-padding) !important;
   }
 }
 

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
@@ -74,9 +74,21 @@ export class GcdsTopNav {
 
           if (mobileTrigger.hasAttribute('open')) {
             mobileTrigger.toggleNav();
+            const childNavGroups = nav.querySelectorAll('gcds-nav-group');
+            childNavGroups.forEach(navGroup => {
+              if (navGroup.hasAttribute('open')) {
+                navGroup.toggleNav();
+              }
+            });
           }
         } else {
           nav.updateNavSize('mobile');
+          const childNavGroups = nav.querySelectorAll('gcds-nav-group');
+          childNavGroups.forEach(navGroup => {
+            if (navGroup.hasAttribute('open')) {
+              navGroup.toggleNav();
+            }
+          });
           await nav.updateNavItemQueue(nav);
         }
       });

--- a/packages/web/src/utils/menus/utils.ts
+++ b/packages/web/src/utils/menus/utils.ts
@@ -72,20 +72,24 @@ export async function handleKeyDownNav(event, nav, queue) {
       }
       break;
 
-    // Tab - only in top-nav
+    // Tab - special logic on mobile screen size
     case 'Tab':
-      if (nav.nodeName != 'GCDS-SIDE-NAV') {
-        // On open nav trigger
-        if (
-          activeElement.nodeName == 'GCDS-NAV-GROUP' &&
-          activeElement.hasAttribute('open')
-        ) {
-          event.preventDefault();
-          await toggleNavGroup(activeElement, nav);
-          // In open nav group
-        } else if (activeElement.parentNode.nodeName == 'GCDS-NAV-GROUP') {
-          event.preventDefault();
-          await toggleNavGroup(activeElement.parentNode, nav);
+      if ((await nav.getNavSize()) == 'mobile') {
+        // shift + tab
+        if (event.shiftKey) {
+          if (
+            currentIndex == queue.length - 1 &&
+            activeElement.hasAttribute('open')
+          ) {
+            event.preventDefault();
+            await focusNavItem(queue.length - 2, queue);
+          }
+        } else {
+          // tab
+          if (currentIndex == queue.length - 2) {
+            event.preventDefault();
+            await focusNavItem(queue.length - 1, queue);
+          }
         }
       }
       break;
@@ -140,14 +144,7 @@ async function toggleNavGroup(group, nav) {
       );
     }, 10);
 
-    if (nav.nodeName == 'GCDS-SIDE-NAV') {
-      nav.updateNavItemQueue(nav);
-    } else {
-      nav.updateNavItemQueue(
-        document.activeElement == nav ? nav : navGroup,
-        document.activeElement == nav ? false : true,
-      );
-    }
+    nav.updateNavItemQueue(nav);
   }
 }
 

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -60,7 +60,7 @@ export const assignLanguage = (el: HTMLElement) => {
 };
 
 // Allows use of closest() function across shadow boundaries
-const closestElement = (selector, el) => {
+export const closestElement = (selector, el) => {
   if (el) {
     return (
       (el &&


### PR DESCRIPTION
# Summary | Résumé

Address multiple issues with the navigation components (`gcds-top-nav`, `gcds-nav-group` and `gcds-side-nav`) like using tab to navigate the `gcds-top-nav`, `gcds-side-nav` mobile menu display issue and mobile menu for both nav components not preventing pagescrolling.

## Fixes

### Using TAB to navigate the gcds-top-nav component

As mentioned in https://github.com/cds-snc/gcds-components/issues/719 using `tab` would close dropdown/mobile menus, you are now able to fully navigate the `gcds-top-nav` using `tab`. When using `tab` in the mobile menus, the focus will stay within the menu until the user clicks the close button or hits `esc`. 

#### How to test

Using the navigation component below:

```html
<gcds-top-nav label="topbar" alignment="right" lang="en">
  <gcds-nav-link href="#home" slot="home">Home</gcds-nav-link>
  <gcds-nav-link href="#install">Installation</gcds-nav-link>
  <gcds-nav-link href="#foundations">Foundations</gcds-nav-link>
  <gcds-nav-link href="#components" current>Components</gcds-nav-link>
  <gcds-nav-group
      menu-label="Contact us submenu"
      open-trigger="Contact us"
    >
      <gcds-nav-link href="#form">Form</gcds-nav-link>
      <gcds-nav-link href="#github">GitHub</gcds-nav-link>
      <gcds-nav-link href="#slack">Slack</gcds-nav-link>
    </gcds-nav-group>
  </gcds-top-nav>
```

On desktop screen size, use `tab` to navigate to the nav group 'Contact us' and open it with `enter`. Use `tab` to navigate into the dropdown.

### Side navigation mobile display issue

Fixed the CSS in `gcds-nav-group` so that the mobile menu of the `gcds-side-nav` no longer overlapped with the edge of the screen.

### Prevent page scroll when mobile menu is open

Added logic to the `gcds-nav-group` to add styles to the `body` element to prevent scrolling when mobile menu is open for each nav component.

#### How to test

Using either nav component on mobile screen size, open the mobile menu and try to scroll the page. Notice how the scroll bar is no longer present.
