### PR TITLE
style: update date-modified font size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,11 +4055,10 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.4.0.tgz",
-      "integrity": "sha512-qJrJDoQIzNVQTO3vrXzjrx/stFV9mA0iUhz9NdwQBBOvOmzxZjji8zMZRmsRXo1kfxXc7mKQDhCTxE1xtdeFyQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.5.0.tgz",
+      "integrity": "sha512-Cti0kM5anzSr0JR6GlJljBGknKSiyc0LKKjmwLOMSfnZIyOrMnM4B94fuM+kopHpwfqH+Kt+ehxtx4FwIGfU4Q==",
+      "dev": true
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -42120,7 +42119,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^2.4.0",
+        "@cdssnc/gcds-tokens": "^2.5.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^2.4.0",
+    "@cdssnc/gcds-tokens": "^2.5.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-date-modified/gcds-date-modified.css
+++ b/packages/web/src/components/gcds-date-modified/gcds-date-modified.css
@@ -25,5 +25,9 @@
     dd {
       margin: var(--gcds-date-modified-description-margin);
     }
+
+    gcds-text::part(text) {
+      font: var(--gcds-date-modified-font);
+    }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

To match the requirements for the alignment of the mandatory elements, update the font size of the date-modified component to 16px.

## Requirements

Date-modified text uses font size of 16px for both desktop and mobile since it is a sub-component of the footer.

## Zenhub ticket

The [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1266) for the requested change.

## Note

Do not merge until token package has been updated to include [this PR](https://github.com/cds-snc/gcds-tokens/pull/396).
