### PR TITLE
style: adjust mobile padding for footer bands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,9 +4055,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.5.0.tgz",
-      "integrity": "sha512-Cti0kM5anzSr0JR6GlJljBGknKSiyc0LKKjmwLOMSfnZIyOrMnM4B94fuM+kopHpwfqH+Kt+ehxtx4FwIGfU4Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.6.0.tgz",
+      "integrity": "sha512-7DS8F8wIUvaddHBMGB4ZIfmf956XFMWP0DHLndmiBvX0VH1VOgJUP+zE1lD7jRUPIclaWzKBX/G4RKHa15tQBQ==",
       "dev": true
     },
     "node_modules/@colors/colors": {
@@ -42119,7 +42119,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^2.5.0",
+        "@cdssnc/gcds-tokens": "^2.6.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^2.5.0",
+    "@cdssnc/gcds-tokens": "^2.6.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-footer/gcds-footer.css
+++ b/packages/web/src/components/gcds-footer/gcds-footer.css
@@ -31,7 +31,7 @@
     .gcds-footer__contextual,
     .gcds-footer__main,
     .gcds-footer__sub {
-      padding: var(--gcds-footer-band-padding);
+      padding: var(--gcds-footer-band-padding-desktop);
     }
 
     .sub__header,
@@ -156,6 +156,17 @@
 }
 
 @layer compact {
+  /* Mobile specific style */
+  @media only screen and (width < 45em) {
+    :host {
+      .gcds-footer__contextual,
+      .gcds-footer__main,
+      .gcds-footer__sub {
+        padding: var(--gcds-footer-band-padding-mobile);
+      }
+    }
+  }
+
   @container sub (width <= 30em) {
     :host .gcds-footer__sub .sub__container {
       slot[name='wordmark'],


### PR DESCRIPTION
# Summary | Résumé

We are slightly adjusting the mobile padding for the footer bands and increasing the spacing between the links in the sub band to match the other link spacing.

## Note

Dependant on the next token release, including [this PR](https://github.com/cds-snc/gcds-tokens/pull/403).