### PR TITLE
style: update header spacing and border colour + width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,9 +4055,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.6.0.tgz",
-      "integrity": "sha512-7DS8F8wIUvaddHBMGB4ZIfmf956XFMWP0DHLndmiBvX0VH1VOgJUP+zE1lD7jRUPIclaWzKBX/G4RKHa15tQBQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.7.1.tgz",
+      "integrity": "sha512-UaezorlEhNoROkPNxhSBa5q7JckGHFFYSXTzbXCk9opxHjoOoYbe8JXdog+1ffrenR3D+K9swtobxUOKzwq8tw==",
       "dev": true
     },
     "node_modules/@colors/colors": {
@@ -42170,7 +42170,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^2.6.0",
+        "@cdssnc/gcds-tokens": "^2.7.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^2.6.0",
+    "@cdssnc/gcds-tokens": "^2.7.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -31,7 +31,7 @@
       gcds-link {
         z-index: 3;
         position: absolute;
-        top: var(--gcds-header-skiptonav-top);
+        top: 0;
         left: 0;
         width: inherit;
 
@@ -52,7 +52,6 @@
     border-block-end: var(--gcds-header-brand-border-width) solid
       var(--gcds-header-brand-border-color);
     padding: var(--gcds-header-brand-padding);
-    margin: var(--gcds-header-brand-margin);
 
     .brand__container {
       display: grid;
@@ -76,10 +75,7 @@
 
       :is(.brand__signature, slot[name='signature']) {
         grid-area: signature;
-
-        gcds-signature {
-          margin: var(--gcds-header-brand-signature-margin);
-        }
+        align-content: center;
       }
 
       .brand__search {

--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -1,4 +1,4 @@
-@layer reset, default, brand, wide;
+@layer reset, default, brand, menu, wide;
 
 @layer reset {
   :host {
@@ -84,6 +84,12 @@
         display: block;
       }
     }
+  }
+}
+
+@layer menu {
+  :host {
+    --gcds-nav-group-mobile-trigger-margin: var(--gcds-header-menu-top-nav-mobile-trigger-margin);
   }
 }
 

--- a/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
+++ b/packages/web/src/components/gcds-lang-toggle/gcds-lang-toggle.css
@@ -16,6 +16,7 @@
 @layer default {
   :host .gcds-lang-toggle {
     gcds-link::part(link) {
+      display: inline-block;
       padding: var(--gcds-lang-toggle-padding);
     }
 
@@ -35,8 +36,8 @@
   @media screen and (width >= 48em) {
     :host .gcds-lang-toggle {
       gcds-link::part(link) {
-        padding: 0;
         font: var(--gcds-lang-toggle-font-desktop);
+        padding-inline: 0 !important;
       }
 
       span {

--- a/packages/web/src/components/gcds-signature/gcds-signature.css
+++ b/packages/web/src/components/gcds-signature/gcds-signature.css
@@ -14,6 +14,7 @@
     }
 
     svg {
+      display: block;
       max-width: 100%;
 
       .fip_flag {
@@ -56,7 +57,7 @@
 @layer desktop {
   :host(:not([type='wordmark'])) svg {
     @media screen and (width >= 64em) {
-      height: 2.125rem;
+      height: var(--gcds-signature-signature-height-desktop);
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Updating the header spacing tokens as well as the header border colour and width to align with the new header design. This work is part of the alignment work for mandatory elements with DTO.

## Zenhub ticket

The Zenhub ticket for this work can be found [here](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1267).

## Note

Do not merge this PR until the tokens package has been merged including the changes from PR [#419](https://github.com/cds-snc/gcds-tokens/pull/419).