### PR TITLE
fix: Mobile top-nav menu closing in Safari

### DIFF
--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -185,6 +185,7 @@ export class GcdsNavGroup {
       <Host role="listitem" open={open}>
         <button
           aria-haspopup="true"
+          tabIndex={0}
           aria-expanded={open.toString()}
           ref={element => (this.triggerElement = element as HTMLElement)}
           class={`gcds-nav-group__trigger gcds-trigger--${this.navStyle}`}

--- a/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.spec.tsx
+++ b/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.spec.tsx
@@ -10,7 +10,7 @@ describe('gcds-nav-group', () => {
     expect(page.root).toEqualHtml(`
     <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" role="listitem">
       <mock:shadow-root>
-        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable">
+        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable" tabindex="0">
           <gcds-icon name="angle-down"></gcds-icon>
           Nav group
         </button>
@@ -30,7 +30,7 @@ describe('gcds-nav-group', () => {
     expect(page.root).toEqualHtml(`
     <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" lang="fr" role="listitem">
       <mock:shadow-root>
-        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable">
+        <button aria-expanded="false" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable" tabindex="0">
           <gcds-icon name="angle-down"></gcds-icon>
           Nav group
         </button>
@@ -50,7 +50,7 @@ describe('gcds-nav-group', () => {
     expect(page.root).toEqualHtml(`
     <gcds-nav-group menu-label="Nav group submenu" open-trigger="Nav group" role="listitem" open>
       <mock:shadow-root>
-        <button aria-expanded="true" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable">
+        <button aria-expanded="true" aria-haspopup="true" class="gcds-nav-group__trigger gcds-trigger--expandable" tabindex="0">
           <gcds-icon name="angle-up"></gcds-icon>
           Nav group
         </button>

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.tsx
@@ -108,6 +108,7 @@ export class GcdsNavLink {
           class={`gcds-nav-link gcds-nav-link--${this.navStyle}`}
           href={href}
           {...linkAttrs}
+          tabIndex={0}
           onBlur={() => this.gcdsBlur.emit()}
           onFocus={() => this.gcdsFocus.emit()}
           onClick={e => emitEvent(e, this.gcdsClick, href)}

--- a/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.spec.tsx
+++ b/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.spec.tsx
@@ -10,7 +10,7 @@ describe('gcds-nav-link', () => {
     expect(page.root).toEqualHtml(`
       <gcds-nav-link href="#link" role="listitem">
         <mock:shadow-root>
-          <a href="#link" class="gcds-nav-link gcds-nav-link--sidenav">
+          <a href="#link" class="gcds-nav-link gcds-nav-link--sidenav" tabindex="0">
             <slot></slot>
           </a>
         </mock:shadow-root>
@@ -26,7 +26,7 @@ describe('gcds-nav-link', () => {
     expect(page.root).toEqualHtml(`
       <gcds-nav-link current="" href="#link" role="listitem">
         <mock:shadow-root>
-          <a aria-current="page" class="gcds-nav-link gcds-nav-link--sidenav" href="#link">
+          <a aria-current="page" class="gcds-nav-link gcds-nav-link--sidenav" href="#link" tabindex="0">
             <slot></slot>
           </a>
         </mock:shadow-root>


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/771, the top-nav mobile menu would close if a user expanded more than one sub-menu. To work in Safari, a `tabindex="0"` has been added to the `gcds-nav-link` and `gcds-nav-group` to properly focus each element and prevent the menu from closing.

Closes https://github.com/cds-snc/gcds-components/issues/771

## How to test

```html
  <gcds-top-nav label="topbar" alignment="right" lang="en">
        <gcds-nav-group
          menu-label="Contact us submenus"
          open-trigger="Others"
       >
          <gcds-nav-link href="#form">Form</gcds-nav-link>
          <gcds-nav-link href="#github">GitHub</gcds-nav-link>
          <gcds-nav-link href="#slack">Slack</gcds-nav-link>
    </gcds-nav-group>
    <gcds-nav-link href="#home" slot="home">Home</gcds-nav-link>
    <gcds-nav-link href="#install">Installation</gcds-nav-link>
    <gcds-nav-link href="#foundations">Foundations</gcds-nav-link>
    <gcds-nav-link href="#components" current>Components</gcds-nav-link>
    <gcds-nav-group
      menu-label="Contact us submenu"
      open-trigger="Contact us"
    >
      <gcds-nav-link href="#form">Form</gcds-nav-link>
      <gcds-nav-link href="#github">GitHub</gcds-nav-link>
      <gcds-nav-link href="#slack">Slack</gcds-nav-link>
    </gcds-nav-group>
  </gcds-top-nav>
```

1. In the `main` branch, open the top navigation component in mobile screen size in Safari.
2. Open the mobile menu.
3. Click to open one of the nav-groups.
4. Click on any other links or the other nav-group.
5. This should cause the mobile menu to close
6. Repeat steps 1 to 4 on this branch.
7. The mobile menu should remain open.