### PR TITLE
storybook: Add externalLinks check to prevent iframe navigation

### DIFF
--- a/packages/web/.storybook/preview-head.html
+++ b/packages/web/.storybook/preview-head.html
@@ -427,6 +427,14 @@
 <script>
   const url = new URLSearchParams(window.location.search);
 
+  if (url.get('externalLinks')) {
+    document.addEventListener('gcdsClick', (ev) => {
+      if (ev.detail && ev.detail.includes('https://')) {
+        top.window.location.href = ev.detail;
+      }
+    });
+  }
+
   if (url.get('demo') && url.get('lang')) {
     var tableTimer = setInterval(function () {
       if (document.querySelector('.docblock-argstable')) {


### PR DESCRIPTION
# Summary | Résumé

Add an additional check for the properties page we use for code display on the documentation through an iframe. When `externalLinks` is present in the query strings, the page will capture the `href` of the clicked link if it is external and will send that `href` to the top to allow the browser to navigate to the selected page.

To support https://github.com/cds-snc/gcds-docs/issues/515

## How to test

1. Build and start storybook.
2. Create an html page with an iframe like below: 
```html
<iframe
  title="Overview of gcds-footer properties and events."
  src="http://localhost:6006/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties&lang=en"
  width="1200"
  height="2150"
  style="display: block; margin: 0 auto;"
  frameBorder="0"
  allow="clipboard-write"
></iframe>
```
3. Click one of the links in either the main or sub band of the footer.
4. Notice the iframe will navigate away but the top page will remain the same.
5. Refresh page and add `&externalLinks=true` to the `src` of the iframe.
6. Click one of the links in either the main or sub band of the footer.
7. The browser should now navigate to the clicked link.
