### PR TITLE
style: add hover colour change to error summary link

### DIFF
--- a/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
+++ b/packages/web/src/components/gcds-error-summary/gcds-error-summary.css
@@ -39,6 +39,10 @@
 
           gcds-link::part(link):not(:focus) {
             color: var(--gcds-error-summary-link-color);
+
+            &:hover {
+              color: var(--gcds-error-summary-link-hover-color);
+            }
           }
         }
       }


### PR DESCRIPTION
# Summary | Résumé

Adding a new hover colour change to the links in the error summary as part of the red colour scale update implemented in [#427](https://github.com/cds-snc/gcds-tokens/pull/427).

## Note

This PR can't be merged without an updated tokens package that includes the changes from [PR #427](https://github.com/cds-snc/gcds-tokens/pull/427/files).