### PR TITLE
storybook: Update/fix components events & properties table

### DIFF
--- a/packages/web/src/components/gcds-date-input/stories/gcds-date-input.stories.tsx
+++ b/packages/web/src/components/gcds-date-input/stories/gcds-date-input.stories.tsx
@@ -24,7 +24,7 @@ export default {
       control: { type: 'select' },
       options: ['full', 'compact'],
       table: {
-        type: { summary: 'boolean' },
+        type: { summary: 'string' },
         defaultValue: { summary: '-' },
       },
       type: {

--- a/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
+++ b/packages/web/src/components/gcds-fieldset/stories/gcds-fieldset.stories.tsx
@@ -71,6 +71,18 @@ export default {
     ...validatorProps,
     ...langProp,
 
+    // Slots
+    default: {
+      control: {
+        type: 'text',
+      },
+      description:
+        'Customize the content or include additional elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires.',
+      table: {
+        category: 'Slots | Fentes',
+      },
+    },
+
     // Events
     gcdsGroupError: {
       action: 'GroupError',
@@ -96,7 +108,10 @@ const Template = args =>
   ${args.validateOn != 'blur' ? `validate-on="${args.validateOn}"` : null}
   ${args.lang != 'en' ? `lang="${args.lang}"` : null}
 >
-  <gcds-input
+  ${
+    args.default
+      ? args.default
+      : `<gcds-input
     input-id="${args.fieldsetId}-input"
     label="Input label"
     hint="Hint / Example message."
@@ -116,7 +131,8 @@ const Template = args =>
     <option value="6">Option 6</option>
     <option value="7">Option 7</option>
     <option value="8">Option 8</option>
-  </gcds-select>
+  </gcds-select>`
+  }
 </gcds-fieldset>
 
 <!-- React code -->
@@ -130,7 +146,10 @@ const Template = args =>
   ${args.validateOn != 'blur' ? `validateOn="${args.validateOn}"` : null}
   ${args.lang != 'en' ? `lang="${args.lang}"` : null}
 >
-  <GcdsInput
+    ${
+      args.default
+        ? args.default
+        : `<GcdsInput
     inputId="${args.fieldsetId}-input"
     label="Input label"
     hint="Hint / Example message."
@@ -150,7 +169,8 @@ const Template = args =>
     <option value="6">Option 6</option>
     <option value="7">Option 7</option>
     <option value="8">Option 8</option>
-  </GcdsSelect>
+  </GcdsSelect>`
+    }
 </GcdsFieldset>
 `.replace(/\s\snull\n/g, '');
 
@@ -258,6 +278,7 @@ Default.args = {
   disabled: false,
   validateOn: 'blur',
   lang: 'en',
+  default: '',
 };
 
 export const Required = TemplateRequired.bind({});
@@ -270,6 +291,7 @@ Required.args = {
   disabled: false,
   validateOn: 'blur',
   lang: 'en',
+  default: '',
 };
 
 export const Disabled = Template.bind({});
@@ -282,6 +304,7 @@ Disabled.args = {
   disabled: true,
   validateOn: 'blur',
   lang: 'en',
+  default: '',
 };
 
 export const Error = Template.bind({});
@@ -294,6 +317,7 @@ Error.args = {
   disabled: false,
   validateOn: 'blur',
   lang: 'en',
+  default: '',
 };
 
 export const Props = Template.bind({});
@@ -306,6 +330,7 @@ Props.args = {
   disabled: false,
   validateOn: 'blur',
   lang: 'en',
+  default: '',
 };
 
 export const Playground = TemplatePlayground.bind({});
@@ -318,4 +343,5 @@ Playground.args = {
   disabled: false,
   validateOn: 'blur',
   lang: 'en',
+  default: '',
 };

--- a/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
+++ b/packages/web/src/components/gcds-input/stories/gcds-input.stories.tsx
@@ -63,8 +63,7 @@ export default {
       },
     },
     autocomplete: {
-      control: { type: 'select' },
-      options: ['on', 'off'],
+      control: 'text',
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: '-' },
@@ -213,7 +212,7 @@ Default.args = {
   size: '',
   value: '',
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   hideLabel: false,
   validateOn: 'blur',
 };
@@ -229,7 +228,7 @@ Disabled.args = {
   hint: 'Hint / example message.',
   disabled: true,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -243,7 +242,7 @@ Error.args = {
   required: true,
   errorMessage: 'Error message or validation message.',
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -256,7 +255,7 @@ Required.args = {
   hint: 'Hint / example message.',
   required: true,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -271,7 +270,7 @@ Email.args = {
   hint: 'Hint / example message.',
   disabled: false,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -284,7 +283,7 @@ Number.args = {
   hint: 'Hint / example message.',
   disabled: false,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -297,7 +296,7 @@ Password.args = {
   hint: 'Hint / example message.',
   disabled: false,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -310,7 +309,7 @@ Search.args = {
   hint: 'Hint / example message.',
   disabled: false,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -323,7 +322,7 @@ Text.args = {
   hint: 'Hint / example message.',
   disabled: false,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -336,7 +335,7 @@ Url.args = {
   hint: 'Hint / example message.',
   disabled: false,
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   validateOn: 'blur',
 };
 
@@ -355,7 +354,7 @@ Props.args = {
   size: null,
   value: '',
   lang: 'en',
-  autocomplete: 'off',
+  autocomplete: '',
   hideLabel: false,
   validateOn: 'blur',
 };
@@ -374,7 +373,7 @@ Playground.args = {
   disabled: false,
   size: '',
   value: '',
-  autocomplete: 'off',
+  autocomplete: '',
   hideLabel: false,
   validateOn: 'blur',
   lang: 'en',

--- a/packages/web/src/components/gcds-radio-group/stories/gcds-radio-group.stories.tsx
+++ b/packages/web/src/components/gcds-radio-group/stories/gcds-radio-group.stories.tsx
@@ -9,7 +9,7 @@ export default {
   parameters: {
     actions: {
       argTypesRegex: '^gcds.*',
-      handles: ['RadioChange', 'focus', 'blur'],
+      handles: ['change', 'focus', 'blur'],
     },
   },
 
@@ -50,8 +50,8 @@ export default {
     ...langProp,
 
     // Events
-    gcdsRadioChange: {
-      action: 'RadioChange',
+    gcdsChange: {
+      action: 'change',
       ...eventProp,
     },
     gcdsFocus: {

--- a/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
+++ b/packages/web/src/components/gcds-select/stories/gcds-select.stories.tsx
@@ -97,6 +97,18 @@ export default {
     ...validatorProps,
     ...langProp,
 
+    // Slots
+    default: {
+      control: {
+        type: 'text',
+      },
+      description:
+        'Customize the content or include additional elements. Accepts `<options>` and `<optgroup>` elements. | Personnalisez le contenu ou ajoutez des éléments supplémentaires. Accepte les éléments `<options>` et `<optgroup>`.',
+      table: {
+        category: 'Slots | Fentes',
+      },
+    },
+
     // Events
     gcdsChange: {
       action: 'change',
@@ -112,6 +124,18 @@ export default {
     },
   },
 };
+
+const selectOptions = `<option value="1">Option 1</option>
+  <option value="2">Option 2</option>
+  <option value="3">Option 3</option>
+  <option value="4">Option 4</option>
+  <optgroup label="Group">
+    <option value="5">Option 5</option>
+    <option value="6">Option 6</option>
+    <option value="7">Option 7</option>
+    <option value="8">Option 8</option>
+  </optgroup>
+`;
 
 const Template = args =>
   `
@@ -129,14 +153,7 @@ const Template = args =>
   ${args.validateOn != 'blur' ? `validate-on="${args.validateOn}"` : null}
   ${args.lang != 'en' ? `lang="${args.lang}"` : null}
 >
-  <option value="1">Option 1</option>
-  <option value="2">Option 2</option>
-  <option value="3">Option 3</option>
-  <option value="4">Option 4</option>
-  <option value="5">Option 5</option>
-  <option value="6">Option 6</option>
-  <option value="7">Option 7</option>
-  <option value="8">Option 8</option>
+  ${args.default}
 </gcds-select>
 
 <!-- React code -->
@@ -153,14 +170,7 @@ const Template = args =>
   ${args.validateOn != 'blur' ? `validateOn="${args.validateOn}"` : null}
   ${args.lang != 'en' ? `lang="${args.lang}"` : null}
 >
-  <option value="1">Option 1</option>
-  <option value="2">Option 2</option>
-  <option value="3">Option 3</option>
-  <option value="4">Option 4</option>
-  <option value="5">Option 5</option>
-  <option value="6">Option 6</option>
-  <option value="7">Option 7</option>
-  <option value="8">Option 8</option>
+  ${args.default}
 </GcdsSelect>
 `.replace(/\s\snull\n/g, '');
 
@@ -178,14 +188,7 @@ const TemplatePlayground = args => `
   ${args.validateOn != 'blur' ? `validate-on="${args.validateOn}"` : null}
   ${args.lang != 'en' ? `lang="${args.lang}"` : null}
 >
-  <option value="1">Option 1</option>
-  <option value="2">Option 2</option>
-  <option value="3">Option 3</option>
-  <option value="4">Option 4</option>
-  <option value="5">Option 5</option>
-  <option value="6">Option 6</option>
-  <option value="7">Option 7</option>
-  <option value="8">Option 8</option>
+  ${args.default}
 </gcds-select>
 `;
 
@@ -204,6 +207,7 @@ Default.args = {
   disabled: false,
   lang: 'en',
   validateOn: 'blur',
+  default: selectOptions,
 };
 
 // ------ Select states ------
@@ -218,6 +222,7 @@ Disabled.args = {
   disabled: true,
   lang: 'en',
   validateOn: 'blur',
+  default: selectOptions,
 };
 
 export const Error = Template.bind({});
@@ -231,6 +236,7 @@ Error.args = {
   errorMessage: 'Error message or validation message.',
   lang: 'en',
   validateOn: 'blur',
+  default: selectOptions,
 };
 
 export const Required = Template.bind({});
@@ -243,6 +249,7 @@ Required.args = {
   required: true,
   lang: 'en',
   validateOn: 'blur',
+  default: selectOptions,
 };
 
 // ------ Select without default value ------
@@ -255,6 +262,7 @@ WithoutDefaultValue.args = {
   hint: 'Hint / Example message.',
   lang: 'en',
   validateOn: 'blur',
+  default: selectOptions,
 };
 
 // ------ Select events & properties ------
@@ -272,6 +280,7 @@ Props.args = {
   disabled: false,
   lang: 'en',
   validateOn: 'blur',
+  default: selectOptions,
 };
 
 // ------ Select playground ------
@@ -289,4 +298,5 @@ Playground.args = {
   disabled: false,
   lang: 'en',
   validateOn: 'blur',
+  default: selectOptions,
 };


### PR DESCRIPTION
# Summary | Résumé

Fix issues in storybook identified in https://github.com/cds-snc/design-gc-conception/issues/1504 and https://github.com/cds-snc/design-gc-conception/issues/1244.

## Fixes

- Updated the `compact` property for `gcds-date-input` to have the correct type of `string`
- Updated the `autocomplete` property for `gcds-input` to be an open text field instead of a select element
- Updated the events listed for `gcds-radio-group` to remove `gcdsRadioChange` event and list the `gcdsChange` event
- Updated the properties table for `gcds-select` and `gcds-fieldset` to show they both use slots
