### PR TITLE
fix: improve layout shift for components

### DIFF
--- a/packages/web/src/assets/css/global.css
+++ b/packages/web/src/assets/css/global.css
@@ -1,0 +1,16 @@
+/* Import GC Design System Tokens */
+@import '../../../../../node_modules/@cdssnc/gcds-tokens/build/web/css/tokens.css';
+
+/* Add fade-in animation to improve layout shift  */
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+body {
+  animation: fade 0.05s normal forwards ease-in-out;
+}

--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -8,8 +8,7 @@ import { vueOutputTarget } from '@stencil/vue-output-target';
 
 export const config: Config = {
   namespace: 'gcds',
-  globalStyle:
-    '../../node_modules/@cdssnc/gcds-tokens/build/web/css/tokens.css',
+  globalStyle: 'src/assets/css/global.css',
   srcDir: './src',
   outputTargets: [
     reactOutputTarget({


### PR DESCRIPTION
# Summary | Résumé

Improve content layout shift for components, especially for slower networks.

## Zenhub ticket

[Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1488) for this change.
