### PR TITLE
fix(gcds-file-uploader): ability to drag and drop

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
@@ -58,6 +58,10 @@
       height: 100%;
       opacity: 0;
       cursor: pointer;
+
+      &::-webkit-file-upload-button {
+        cursor: pointer;
+      }
     }
 
     #file-uploader__summary {
@@ -79,7 +83,6 @@
     padding: var(--gcds-file-uploader-file-padding);
     border: var(--gcds-file-uploader-file-border-width) solid
       var(--gcds-file-uploader-file-border-color);
-    cursor: pointer;
 
     &:not(:last-of-type) {
       border-block-end: 0;

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -255,7 +255,7 @@ export class GcdsFileUploader {
 
       this.shadowElement.files = dt.files;
       this.files = dt.files;
-      this.addFilesToFormData(this.shadowElement.files);
+      this.addFilesToFormData(Array.from(this.shadowElement.files));
     }
 
     this.value = [...filesContainer];
@@ -332,6 +332,47 @@ export class GcdsFileUploader {
 
     this.internals.setFormValue(formData);
   };
+
+  /*
+   * Handle drop event on file uploader
+   */
+  private handleDrop(e) {
+    e.preventDefault();
+
+    const droppedFiles = e.dataTransfer.files;
+
+    if (droppedFiles.length > 0) {
+      const dt = new DataTransfer();
+      for (const file of droppedFiles) {
+        if (this.isFileAccepted(file)) {
+          dt.items.add(file);
+        }
+      }
+
+      if (dt.files.length > 0) {
+        this.shadowElement.files = dt.files;
+        this.files = dt.files;
+      }
+    }
+  }
+
+  /*
+   * Check if dropped files are accpeted file types
+   */
+  private isFileAccepted(file) {
+    if (this.accept) {
+      const acceptedTypes = this.accept.split(',').map(type => type.trim());
+      return acceptedTypes.some(type => {
+        if (type.startsWith('.')) {
+          return file.name.endsWith(type);
+        } else {
+          return file.type === type;
+        }
+      });
+    }
+
+    return true;
+  }
 
   /*
    * Observe lang attribute change
@@ -437,6 +478,8 @@ export class GcdsFileUploader {
             class={`file-uploader__input ${
               value.length > 0 ? 'uploaded-files' : ''
             }`}
+            onDrop={e => this.handleDrop(e)}
+            onDragOver={e => e.preventDefault()}
           >
             <button
               type="button"


### PR DESCRIPTION
# Summary | Résumé

Fix the drag and drop functionality for `gcds-file-uploader` to allow proper reading of files dropped on the file input.

https://github.com/cds-snc/gcds-components/issues/783

## Fixes

- Add `drop` and `dragover` to file uploader to catch files being dropped on the file input. If the `accept` attribute is in use, the file uploader will not accept any files not of that type.
- Fix proper cursor display on interactive elements of the file uploader
- Fix a type error when removing an uploaded file. 
