### PR TITLE
fix(gcds-top-nav): Increase mobile menu padding to reveal last menu item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,10 +4055,11 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.8.0.tgz",
-      "integrity": "sha512-oIXd1WZW7RUq8ivcGkx5BmDZFuZFZx3ZVIfjvDSnUfi8h2XVWBxhoZizcIJeWF/g9fpGRqBtgjWE9HqNvMO3zg==",
-      "dev": true
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.9.0.tgz",
+      "integrity": "sha512-sAmQHeWNZ3BQArTXhJuZ+mHYMmB5Anb2FpZ3wAfJCndYyi6/ierXku3zNhZKPPMvkhxaB+vVhpcXKgHw6f5oYA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -42170,7 +42171,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^2.8.0",
+        "@cdssnc/gcds-tokens": "^2.9.0",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^2.8.0",
+    "@cdssnc/gcds-tokens": "^2.9.0",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",


### PR DESCRIPTION
# Summary | Résumé

https://github.com/cds-snc/gcds-components/issues/770

Install latest version of `@cdssnc/gcds-tokens` to inherit new mobile padding to fix hidden last menu item on large menus in Safari.

## How to test

1. On main branch, create a page with a gcds-side-nav with many nav links.
2. View the page on a mobile Safari browser.
3. Notice the last nav link will be hidden and not accessible to click.
4. Load this branch and run `npm install`.
5. View the page on a mobile Safari browser.
6. Notice the last nav link will now be above the URL bar.
