### PR TITLE
fix: update spacing between links and small typo in footer sub band

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,9 +4055,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.8.0.tgz",
-      "integrity": "sha512-oIXd1WZW7RUq8ivcGkx5BmDZFuZFZx3ZVIfjvDSnUfi8h2XVWBxhoZizcIJeWF/g9fpGRqBtgjWE9HqNvMO3zg==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.9.1.tgz",
+      "integrity": "sha512-8Xk4O1rN2I3bJWVXp/fjdRwZcxMCENC5FqUGQiyWzLvdTEmym3BnZcj8MkukDBk0lKsOqCmVXuUYRQywMaOVAQ==",
       "dev": true
     },
     "node_modules/@colors/colors": {
@@ -42172,7 +42172,7 @@
         "@babel/core": "^7.20.12",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
-        "@cdssnc/gcds-tokens": "^2.8.0",
+        "@cdssnc/gcds-tokens": "^2.9.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@cdssnc/gcds-tokens": "^2.8.0",
+    "@cdssnc/gcds-tokens": "^2.9.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-footer/i18n/i18n.js
+++ b/packages/web/src/components/gcds-footer/i18n/i18n.js
@@ -4,7 +4,7 @@ const I18N = {
       heading: 'Government of Canada',
       menu: {
         contacts: {
-          text: 'All Contacts',
+          text: 'All contacts',
           link: 'https://www.canada.ca/en/contact.html',
         },
         dept: {

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
@@ -73,7 +73,7 @@ describe('gcds-footer', () => {
                 <ul class="govnav__list">
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/en/contact.html">
-                      All Contacts
+                      All contacts
                     </gcds-link>
                   </li>
                   <li>
@@ -509,7 +509,7 @@ describe('gcds-footer', () => {
                 <ul class="govnav__list">
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/en/contact.html">
-                      All Contacts
+                      All contacts
                     </gcds-link>
                   </li>
                   <li>


### PR DESCRIPTION
# Summary | Résumé

Updating the spacing between the links and a small typo in the footer sub band to align with GC Web.

## Zenhub ticket

[Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1552) for this change.
