### PR TITLE
fix(gcds-card): Ensure shadow dom are structuraly valid according to spec

### DIFF
--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -197,7 +197,7 @@ export class GcdsCard {
                 size="small"
               >
                 <strong>
-                  <gcds-sr-only>{i18n[lang].tagged}</gcds-sr-only>
+                  <gcds-sr-only tag="span">{i18n[lang].tagged}</gcds-sr-only>
                   {badge}
                 </strong>
               </gcds-text>

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -38,7 +38,7 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <gcds-text class="gcds-badge" id="gcds-badge" margin-bottom="0" size="small" text-role="light">
             <strong>
-              <gcds-sr-only>
+              <gcds-sr-only tag="span">
                 Tagged:
               </gcds-sr-only>
               new


### PR DESCRIPTION
# Summary | Résumé

The shadow DOM HTML structure, when extracted and compiled, are not valid according to HTML5 spec content model. The concern is there are a paragraph inside a paragraph while a paragraph can only contain phrasing content and not flow content. 

Reference:
* List of HTML element that are valid as phrasing content - https://html.spec.whatwg.org/multipage/dom.html#phrasing-content
* the paragraph element, see the content model: https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element

# Test instructions | Instructions pour tester la modification

1. Use a page with a gcds-card that contain a tag
2. Extract and manually compile the HTML structure of the shadow DOM imbrication
3. Ensure the extracted and compiled HTML are conform to HTML 5 content model specification.

# Before that change - Technical note

I was able to observe the following HTML shadow dom structure for a gcds-card that contained a tag. We can observe that there is a paragraph inside a paragraph which is invalid HTML

```html
<gcds-card card-title="Link card number 1" title-element="h4" href="#red" description="This is a card" badge="New" img-src="https://picsum.photos/480/270" class="hydrated">
	<style sty-id="sc-gcds-card"></style>
	<div class="gcds-card">
		<gcds-text id="gcds-badge" class="gcds-badge hydrated" text-role="light" margin-bottom="0">
			<style sty-id="sc-gcds-text"></style>
			<p class="gcds-text role-light limit mt-0 mb-0 size-small" part="text">
				<small>
					<strong>
						<gcds-sr-only class="hydrated">
							<style sty-id="sc-gcds-sr-only"></style>
							<p>
								Tagged:
							</p>
						</gcds-sr-only>
						New
					</strong>
				</small>
			</p>
		</gcds-text>
		<img src="https://picsum.photos/480/270" alt="" class="gcds-card__image">
		<gcds-link class="gcds-card__title hydrated" aria-describedby="gcds-badge">
			<style sty-id="sc-gcds-link"></style>
			<a role="link" tabindex="0" href="#red" target="_self" class="gcds-link link--inherit" aria-describedby="gcds-badge" part="link">
				Link card number 1
			</a>
		</gcds-link>
		<div class="gcds-card__description">
			<gcds-text margin-bottom="0" class="hydrated">
				<style sty-id="sc-gcds-text"></style>
				<p class="gcds-text role-primary limit mt-0 mb-0" part="text">
					This is a card
				</p>
			</gcds-text>
		</div>
	</div>
</gcds-card>
```

# Once that change is applied - Technical note

After this change, the gcds-sr-only are now using a span element which ensure that only phrasing content are contained in the paragraph.

```html

<gcds-card card-title="Link card number 1" title-element="h4" href="#red" description="This is a card" badge="New" img-src="https://picsum.photos/480/270" class="hydrated">
	<style sty-id="sc-gcds-card"></style>
	<div class="gcds-card">
		<gcds-text id="gcds-badge" class="gcds-badge hydrated" text-role="light" margin-bottom="0">
			<style sty-id="sc-gcds-text"></style>
			<p class="gcds-text role-light limit mt-0 mb-0 size-small" part="text">
				<small>
					<strong>
						<gcds-sr-only class="hydrated">
							<style sty-id="sc-gcds-sr-only"></style>
							<span>Tagged:</span>
						</gcds-sr-only>
						New
					</strong>
				</small>
			</p>
		</gcds-text>
		<img src="https://picsum.photos/480/270" alt="" class="gcds-card__image">
		<gcds-link class="gcds-card__title hydrated" aria-describedby="gcds-badge">
			<style sty-id="sc-gcds-link"></style>
			<a role="link" tabindex="0" href="#red" target="_self" class="gcds-link link--inherit" aria-describedby="gcds-badge" part="link">
				Link card number 1
			</a>
		</gcds-link>
		<div class="gcds-card__description">
			<gcds-text margin-bottom="0" class="hydrated">
				<style sty-id="sc-gcds-text"></style>
				<p class="gcds-text role-primary limit mt-0 mb-0" part="text">
					This is a card
				</p>
			</gcds-text>
		</div>
	</div>
</gcds-card>
```

# Note

This will require more investigation, but I am not sure about the use of the small element in this gcds-card context because it don't seem to be aligned with how the HTML 5 describe it. The [spec ](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-small-element) describe it as small print which can be features disclaimers, caveats, legal restrictions, or copyrights. Using it for listing tags before the main content of the gcds-card might don't fit that definition.