### PR TITLE
fix: Prevent click event on disabled button

### DIFF
--- a/packages/web/src/components/gcds-button/gcds-button.css
+++ b/packages/web/src/components/gcds-button/gcds-button.css
@@ -77,10 +77,14 @@
 }
 
 @layer disabled {
-  :host .gcds-button[aria-disabled='true'] {
-    cursor: not-allowed;
+  :host([disabled]) {
     pointer-events: none;
-    opacity: var(--gcds-button-shared-disabled-opacity);
+
+    .gcds-button[aria-disabled='true'] {
+      cursor: not-allowed;
+      pointer-events: none;
+      opacity: var(--gcds-button-shared-disabled-opacity);
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-button/gcds-button.tsx
+++ b/packages/web/src/components/gcds-button/gcds-button.tsx
@@ -90,6 +90,13 @@ export class GcdsButton {
    */
   @Prop() disabled: boolean;
 
+  @Watch('disabled')
+  validateDisabled(newValue: boolean) {
+    if (newValue === false || (newValue === true && this.type === 'link')) {
+      this.el.removeAttribute('disabled');
+    }
+  }
+
   /**
    * The value attribute specifies the value for a <button> element.
    */
@@ -165,6 +172,7 @@ export class GcdsButton {
     this.validateType(this.type);
     this.validateButtonRole(this.buttonRole);
     this.validateSize(this.size);
+    this.validateDisabled(this.disabled);
 
     this.inheritedAttributes = inheritAttributes(this.el, this.shadowElement);
 
@@ -247,7 +255,9 @@ export class GcdsButton {
           id={buttonId}
           onBlur={() => this.gcdsBlur.emit()}
           onFocus={() => this.gcdsFocus.emit()}
-          onClick={e => !disabled && this.handleClick(e)}
+          onClick={e =>
+            !disabled ? this.handleClick(e) : e.stopImmediatePropagation()
+          }
           class={`gcds-button button--role-${buttonRole} button--${size}`}
           ref={element => (this.shadowElement = element as HTMLElement)}
           {...inheritedAttributes}

--- a/packages/web/src/components/gcds-button/test/gcds-button.e2e.ts
+++ b/packages/web/src/components/gcds-button/test/gcds-button.e2e.ts
@@ -9,29 +9,35 @@ describe('gcds-button', () => {
     const element = await page.find('gcds-button');
     expect(element.textContent).toEqual('Button Label');
   });
-  it('fires gcdsClick event', async () => {
+  it('fires gcdsClick and click event event', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<gcds-button>Button Label</gcds-button>');
     const gcdsClick = await page.spyOnEvent('gcdsClick');
+    const click = await page.spyOnEvent('gcdsClick');
+
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
 
     await page.waitForChanges();
 
     expect(gcdsClick.events.length).toBe(1);
+    expect(click.events.length).toBe(1);
   });
-  it('disabled - will not fire gcdsClick event', async () => {
+  it('disabled - will not fire gcdsClick and click event', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<gcds-button disabled>Button Label</gcds-button>');
     const gcdsClick = await page.spyOnEvent('gcdsClick');
+    const click = await page.spyOnEvent('gcdsClick');
+
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
 
     await page.waitForChanges();
 
     expect(gcdsClick.events.length).toBe(0);
+    expect(click.events.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
# Summary | Résumé

Prevent `click` event from firing when button is disabled. Added additional logic to remove disabled attribute if `type="link` or `disabled="false"`.

For #819 

## How to test

Using example below

```
<gcds-button button-role="start" onClick="buttonClicked()">Start</gcds-button>

<script>
  function buttonClicked() {
    console.log('clicked')
  }
</script>
```

1. Copy the code example above into a document
2. Click the start button and observe 'clicked' in the console
3. Focus the element and click the button using the keyboard. Observe 'clicked' in the console.
4. Add the disabled attribute to the button and repeat the steps above. The button should no longer log anything to the console.

