### PR TITLE
chore:  switch to CDS Release Bot

### DIFF
--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/create-github-app-token@af35edadc00be37caa72ed9f3e6d5f7801bfdf09 # v1.11.7
         id: sre_app_token
         with:
-          app-id: ${{ secrets.SRE_APP_ID }}
-          private-key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.CDS_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.CDS_RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         id: release


### PR DESCRIPTION
# Summary
Update the release please workflow to use a new, dedicated GitHub app for releases.  The reason for the change is so that we can scale back use of the SRE read/write app.

# Related
- https://github.com/cds-snc/platform-core-services/issues/707