### PR TITLE
style: fix inconsistent text scaling across desktop + mobile styles for multiple components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4062,9 +4062,9 @@
       "dev": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.11.0.tgz",
-      "integrity": "sha512-3mNbKGOxr9CYCNrbWPoPg05bjODg5LUi/JtVePvba3nd/y1nY5LS1Vx1sC7TdsjFT4ClTRZSNTu3Tc3kteqDlA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.11.1.tgz",
+      "integrity": "sha512-rTZNiGs1uCX4Jb6J1UusdlruGPpkt8JkiGjVpfU/rtXyfYccj7zPjpZjwprPBW0Mfhb59xfy2j2y1Pev5UxQEg==",
       "dev": true,
       "license": "MIT"
     },
@@ -42190,7 +42190,7 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
         "@cdssnc/gcds-fonts": "^0.2.2",
-        "@cdssnc/gcds-tokens": "^2.11.0",
+        "@cdssnc/gcds-tokens": "^2.11.1",
         "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
     "@cdssnc/gcds-fonts": "^0.2.2",
-    "@cdssnc/gcds-tokens": "^2.11.0",
+    "@cdssnc/gcds-tokens": "^2.11.1",
     "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",

--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.css
@@ -24,9 +24,13 @@
     flex-direction: column;
     align-items: flex-start;
     max-width: 90%;
-    font: var(--gcds-file-uploader-font);
+    font: var(--gcds-file-uploader-font-desktop);
     color: var(--gcds-file-uploader-default-text);
     transition: color ease-in-out 0.15s;
+
+    @media only screen and (width < 48em) {
+      font: var(--gcds-file-uploader-font-mobile);
+    }
 
     button {
       border-radius: var(--gcds-file-uploader-file-button-border-radius);

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.css
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.css
@@ -20,8 +20,12 @@
 
       a {
         color: var(--gcds-pagination-default-text);
-        font: var(--gcds-pagination-font);
+        font: var(--gcds-pagination-font-desktop);
         border-radius: var(--gcds-pagination-border-radius);
+
+        @media only screen and (width < 48em) {
+          font: var(--gcds-pagination-font-mobile);
+        }
       }
     }
   }

--- a/packages/web/src/components/gcds-select/gcds-select.css
+++ b/packages/web/src/components/gcds-select/gcds-select.css
@@ -23,9 +23,13 @@
 @layer default {
   :host .gcds-select-wrapper {
     max-width: 75ch;
-    font: var(--gcds-select-font);
+    font: var(--gcds-select-font-desktop);
     color: var(--gcds-select-default-text);
     transition: color ease-in-out 0.15s;
+
+    @media only screen and (width < 48em) {
+      font: var(--gcds-select-font-mobile);
+    }
 
     select {
       display: block;

--- a/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
+++ b/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
@@ -42,7 +42,7 @@
         padding: var(--gcds-topic-menu-button-padding);
         text-transform: uppercase;
         cursor: pointer;
-        font: var(--gcds-topic-menu-button-font);
+        font: inherit;
 
         &.gcds-topic-menu--home {
           background-color: var(--gcds-topic-menu-button-home-background);
@@ -189,7 +189,7 @@
                 );
 
                 [role='menuitem'] {
-                  font: var(--gcds-topic-menu-mostrequested-item-first-font);
+                  font: inherit;
                   text-decoration: underline;
                   width: auto;
                 }
@@ -235,7 +235,7 @@
         border-block-end: var(--gcds-topic-menu-border-width) solid
           var(--gcds-topic-menu-menuitem-border-block-end);
         color: var(--gcds-topic-menu-menuitem-text);
-        font: var(--gcds-topic-menu-menuitem-font);
+        font: var(--gcds-topic-menu-font);
         text-decoration: none;
         display: block;
         padding: var(--gcds-topic-menu-menuitem-padding);
@@ -249,7 +249,6 @@
           z-index: 9999 !important;
         }
 
-
         &:hover,
         &[aria-expanded='true'] {
           background-color: var(--gcds-topic-menu-menuitem-expanded-background);
@@ -257,7 +256,9 @@
         }
       }
 
-      [role='menuitem'][aria-haspopup='true'][aria-expanded='false'][aria-controls]:not([aria-controls*="sub"]) {
+      [role='menuitem'][aria-haspopup='true'][aria-expanded='false'][aria-controls]:not(
+          [aria-controls*='sub']
+        ) {
         background-color: var(--gcds-topic-menu-themelist-background);
       }
     }
@@ -312,9 +313,7 @@
               }
 
               &[aria-haspopup] {
-                font: var(
-                  --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font
-                );
+                font: inherit;
               }
             }
           }
@@ -329,9 +328,6 @@
                 );
               color: var(
                 --gcds-topic-menu-mobile-topiclist-item-first-menuitem-text
-              );
-              font: var(
-                --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font
               );
               text-decoration: underline;
               width: auto;


### PR DESCRIPTION
# Summary | Résumé

This PR addresses inconsistent text scaling across desktop and mobile styles for multiple components. It was reported by a user in this [Freshdesk ticket.](https://gcdigital.slack.com/archives/C04U4PCDZ24/p1727183846723389)

## Changed components

The following components now have a font token for desktop & mobile:

- Topic menu
- Select
- File uploader
- Pagination

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1196) for this change.

## Note

This PR can't be merged until it has the latest update to the tokens package.