### PR TITLE
chore: update runner for tests to have manual dispatch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,6 @@
 name: Run Tests
 on:
+  workflow_dispatch:
   pull_request:
       branches:
         - main


### PR DESCRIPTION
# Summary | Résumé
For PRs that are not against main, the tests workflow file doesn't run. It works fine, but we're preparing to release the changes to the fieldset, checkboxes, and radios, and we should have a way to make sure the tests run on the branch or branches to make it easier to catch and work on. Adding a manual dispatch can allow us to selectively run it on a branch.