### PR TITLE
fix: align structural markup for link and search with GCWeb

### DIFF
--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -182,7 +182,6 @@ export class GcdsLink {
       <Host>
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
         <a
-          role="link"
           tabIndex={0}
           {...attrs}
           class={`gcds-link link--${size} ${

--- a/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
+++ b/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
@@ -11,7 +11,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="#">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" part="link" href="#" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" part="link" href="#" tabindex="0" target="_self">
             <slot></slot>
           </a>
         </mock:shadow-root>
@@ -32,7 +32,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="https://google.com" target="_blank">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" role="link" tabindex="0">
+          <a class="gcds-link link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" tabindex="0">
             <slot></slot>
             <gcds-icon name="external" label="${i18n.en.external}" margin-left="75" />
           </a>
@@ -50,7 +50,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="https://google.com" target="_blank" lang="fr">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" role="link" tabindex="0">
+          <a class="gcds-link link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" tabindex="0">
             <slot></slot>
             <gcds-icon name="external" label="${i18n.fr.external}" margin-left="75" />
           </a>
@@ -68,7 +68,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="https://google.com" download>
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="https://google.com" part="link" download role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="https://google.com" part="link" download tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="download" label="${i18n.en.download}" margin-left="75" />
           </a>
@@ -86,7 +86,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="https://google.com" download lang="fr">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="https://google.com" part="link" download role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="https://google.com" part="link" download tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="download" label="${i18n.fr.download}" margin-left="75" />
           </a>
@@ -104,7 +104,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="https://google.com" download="myfile.pdf">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="https://google.com" part="link" download="myfile.pdf" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="https://google.com" part="link" download="myfile.pdf" tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="download" label="${i18n.en.download}" margin-left="75" />
           </a>
@@ -122,7 +122,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="https://google.com" download="myfile.pdf" lang="fr">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="https://google.com" part="link" download="myfile.pdf" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="https://google.com" part="link" download="myfile.pdf" tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="download" label="${i18n.fr.download}" margin-left="75" />
           </a>
@@ -140,7 +140,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="tel:1234567890">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="tel:1234567890" part="link" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="tel:1234567890" part="link" tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="phone" label="${i18n.en.phone}" margin-left="75" />
           </a>
@@ -158,7 +158,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="tel:1234567890" lang="fr">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="tel:1234567890" part="link" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="tel:1234567890" part="link" tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="phone" label="${i18n.fr.phone}" margin-left="75" />
           </a>
@@ -176,7 +176,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="mailto:test@test.com">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="mailto:test@test.com" part="link" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="mailto:test@test.com" part="link" tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="email" label="${i18n.en.email}" margin-left="75" />
           </a>
@@ -194,7 +194,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="mailto:test@test.com" lang="fr">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" href="mailto:test@test.com" part="link" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" href="mailto:test@test.com" part="link" tabindex="0" target="_self">
             <slot></slot>
             <gcds-icon name="email" label="${i18n.fr.email}" margin-left="75" />
           </a>
@@ -212,7 +212,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="#" size="small">
         <mock:shadow-root>
-          <a class="gcds-link link--small" part="link" href="#" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--small" part="link" href="#" tabindex="0" target="_self">
             <slot></slot>
           </a>
         </mock:shadow-root>
@@ -229,7 +229,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="#" size="regular">
         <mock:shadow-root>
-          <a class="gcds-link link--regular" part="link" href="#" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--regular" part="link" href="#" tabindex="0" target="_self">
             <slot></slot>
           </a>
         </mock:shadow-root>
@@ -246,7 +246,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="#" size="inherit">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit" part="link" href="#" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit" part="link" href="#" tabindex="0" target="_self">
             <slot></slot>
           </a>
         </mock:shadow-root>
@@ -263,7 +263,7 @@ describe('gcds-link', () => {
     expect(root).toEqualHtml(`
       <gcds-link href="#" variant="light">
         <mock:shadow-root>
-          <a class="gcds-link link--inherit variant-light" part="link" href="#" role="link" tabindex="0" target="_self">
+          <a class="gcds-link link--inherit variant-light" part="link" href="#" tabindex="0" target="_self">
             <slot></slot>
           </a>
         </mock:shadow-root>

--- a/packages/web/src/components/gcds-search/gcds-search.tsx
+++ b/packages/web/src/components/gcds-search/gcds-search.tsx
@@ -138,7 +138,7 @@ export class GcdsSearch {
 
     return (
       <Host>
-        <div class="gcds-search">
+        <section class="gcds-search">
           <gcds-sr-only tag="h2">{I18N[lang].search}</gcds-sr-only>
           <form
             action={formAction}
@@ -155,7 +155,7 @@ export class GcdsSearch {
             <input
               type="search"
               id={searchId}
-              list="search-list"
+              {...(suggested ? { list: 'search-list' } : {})}
               size={34}
               maxLength={170}
               onInput={e => this.handleInput(e, this.gcdsInput)}
@@ -187,7 +187,7 @@ export class GcdsSearch {
               ></gcds-icon>
             </gcds-button>
           </form>
-        </div>
+        </section>
       </Host>
     );
   }

--- a/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
+++ b/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
@@ -10,18 +10,18 @@ describe('gcds-search', () => {
     expect(page.root).toEqualHtml(`
       <gcds-search>
         <mock:shadow-root>
-          <div class="gcds-search">
+          <section class="gcds-search">
             <gcds-sr-only tag="h2">
               Search
             </gcds-sr-only>
             <form action="https://www.canada.ca/en/sr/srb.html" class="gcds-search__form" method="get" role="search">
               <gcds-label hide-label="" label="Search Canada.ca" label-for="search"></gcds-label>
-              <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Search Canada.ca" size="34" type="search">
+              <input class="gcds-search__input" id="search" maxlength="170" name="q" placeholder="Search Canada.ca" size="34" type="search">
               <gcds-button class="gcds-search__button" exportparts="button" type="submit">
                 <gcds-icon label="Search" name="search" size="h3"></gcds-icon>
               </gcds-button>
             </form>
-          </div>
+          </section>
         </mock:shadowroot>
       </gcds-search>
     `);
@@ -34,18 +34,18 @@ describe('gcds-search', () => {
     expect(page.root).toEqualHtml(`
       <gcds-search lang="fr">
         <mock:shadow-root>
-          <div class="gcds-search">
+          <section class="gcds-search">
             <gcds-sr-only tag="h2">
               Recherche
             </gcds-sr-only>
             <form action="https://www.canada.ca/fr/sr/srb.html" class="gcds-search__form" method="get" role="search">
               <gcds-label hide-label="" label="Rechercher dans Canada.ca" label-for="search"></gcds-label>
-              <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Rechercher dans Canada.ca" size="34" type="search">
+              <input class="gcds-search__input" id="search" maxlength="170" name="q" placeholder="Rechercher dans Canada.ca" size="34" type="search">
               <gcds-button class="gcds-search__button" exportparts="button" type="submit">
                 <gcds-icon label="Recherche" name="search" size="h3"></gcds-icon>
               </gcds-button>
             </form>
-          </div>
+          </section>
         </mock:shadowroot>
       </gcds-search>
     `);
@@ -64,18 +64,18 @@ describe('gcds-search', () => {
     expect(page.root).toEqualHtml(`
       <gcds-search action="submit.html" method="post" name="s" placeholder="Text.ca" search-id="searchForm">
         <mock:shadow-root>
-          <div class="gcds-search">
+          <section class="gcds-search">
             <gcds-sr-only tag="h2">
               Search
             </gcds-sr-only>
             <form action="submit.html" class="gcds-search__form" method="post" role="search">
             <gcds-label hide-label="" label="Search Text.ca" label-for="searchForm"></gcds-label>
-              <input class="gcds-search__input" id="searchForm" list="search-list" maxlength="170" name="s" placeholder="Search Text.ca" size="34" type="search">
+              <input class="gcds-search__input" id="searchForm" maxlength="170" name="s" placeholder="Search Text.ca" size="34" type="search">
               <gcds-button class="gcds-search__button" exportparts="button" type="submit">
                 <gcds-icon label="Search" name="search" size="h3"></gcds-icon>
               </gcds-button>
             </form>
-          </div>
+          </section>
         </mock:shadowroot>
       </gcds-search>
     `);


### PR DESCRIPTION
# Summary | Résumé

Align the structural markup of the GCDS `links` and `search` components with GCWeb patterns to ensure consistency when users (developers) use the two together on the same page.

## Changes

- `gcds-link`: `role="link"` has been removed from the `<a>` tag.
- `gcds-search`: If the `suggested` property is not set or assigned, the list attribute on the input element is removed.
- `gcds-search`: Replace the `div` with a `section` for a more semantic markup.

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1647) for the change.