### PR TITLE
chore: remove old font awesome npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4626,16 +4626,6 @@
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
       "dev": true
     },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
-      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -42191,7 +42181,6 @@
         "@babel/preset-typescript": "^7.21.0",
         "@cdssnc/gcds-fonts": "^0.2.2",
         "@cdssnc/gcds-tokens": "^2.12.0",
-        "@fortawesome/fontawesome-free": "^6.3.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",
         "@stencil/postcss": "^2.1.0",
         "@stencil/sass": "^3.0.0-0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,7 +47,6 @@
     "@babel/preset-typescript": "^7.21.0",
     "@cdssnc/gcds-fonts": "^0.2.2",
     "@cdssnc/gcds-tokens": "^2.12.0",
-    "@fortawesome/fontawesome-free": "^6.3.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/postcss": "^2.1.0",
     "@stencil/sass": "^3.0.0-0",


### PR DESCRIPTION
# Summary | Résumé

Doing some cleanup and removing the old Font Awesome package since we no longer use Font Awesome for our icons.