### PR TITLE
chore: update prettier to 3.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33906,10 +33906,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -41335,7 +41336,7 @@
         "eslint-config-prettier": "9.0.0",
         "get-tsconfig": "^4.7.5",
         "make-dir-cli": "3.1.0",
-        "prettier": "3.1.0",
+        "prettier": "3.5.3",
         "replace-in-file": "^8.0.0",
         "tsx": "4.11.0",
         "typescript": "~5.1.0"
@@ -42064,21 +42065,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/react-ssr/node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "packages/react-ssr/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -42220,7 +42206,7 @@
         "jest-cli": "^28.1.3",
         "lit-html": "^2.6.1",
         "postcss-nested": "^6.0.0",
-        "prettier": "^3.0.0",
+        "prettier": "^3.5.3",
         "puppeteer": "^21.0.0",
         "react-syntax-highlighter": "^15.5.0",
         "sass": "^1.43.5",

--- a/packages/react-ssr/package.json
+++ b/packages/react-ssr/package.json
@@ -70,7 +70,7 @@
     "eslint-config-prettier": "9.0.0",
     "get-tsconfig": "^4.7.5",
     "make-dir-cli": "3.1.0",
-    "prettier": "3.1.0",
+    "prettier": "3.5.3",
     "replace-in-file": "^8.0.0",
     "tsx": "4.11.0",
     "typescript": "~5.1.0"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -76,7 +76,7 @@
     "jest-cli": "^28.1.3",
     "lit-html": "^2.6.1",
     "postcss-nested": "^6.0.0",
-    "prettier": "^3.0.0",
+    "prettier": "^3.5.3",
     "puppeteer": "^21.0.0",
     "react-syntax-highlighter": "^15.5.0",
     "sass": "^1.43.5",


### PR DESCRIPTION
# Summary | Résumé

Updating prettier dependency to version `3.5.3`.