### PR TITLE
Increase `z-index` of `gcds-nav-group` to be above the `z-index` for `gcds-card`

### DIFF
--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
@@ -129,7 +129,7 @@
       }
 
       .gcds-nav--dropdown {
-        z-index: 1;
+        z-index: 2;
         position: absolute;
         top: 100%;
         width: var(--gcds-nav-group-top-nav-dropdown-width);


### PR DESCRIPTION
# Summary

Stop `gcds-card` from blocking interactions with `gcds-nav-links` in a `gcds-nav-group`
Closes: https://github.com/cds-snc/gcds-components/issues/875

# Test instructions | Instructions pour tester la modification

1) Use this page as a reference: https://codesandbox.io/p/sandbox/35qp46?file=%2Findex.html
2) update to use built gcds-components
3) open navlink group
4) interact with the 4th nav link in the group
5) gcds-card is no longer clicked


