### PR TITLE
fix(gcds-checkboxes): Add logic to make sure a prechecked checkbox's value is removed on change

### DIFF
--- a/packages/web/src/components/gcds-checkboxes/gcds-checkboxes.tsx
+++ b/packages/web/src/components/gcds-checkboxes/gcds-checkboxes.tsx
@@ -136,7 +136,6 @@ export class GcdsCheckboxes {
   @Prop({ reflect: true, mutable: true }) value: string | Array<string> = [];
   @Watch('value')
   validateValue(newValue) {
-    console.log(this.name, newValue);
     // Convert string to array
     if (!Array.isArray(newValue)) {
       try {


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/876, when unchecking an option in a `gcds-checkboxes` component that has been prechecked with the use of the `options`, the value of the checkbox would remain active in the `value`. Add extra logic to the remove value logic to ensure the correct values are contained in the `value` array.

## How to test

Using the code below:

```html
      <form>
        <gcds-checkboxes
          legend="Checkbox group"
          name="checkgroup"
          hint="Select all that apply."
          required
          options='[{ "label": "Checkbox 1 label", "id": "check1", "value": "check1", "checked": true}, { "label": "Checkbox 2 label", "id": "check2", "value": "check2", "checked": true}, { "label": "Checkbox 3 label", "id": "check3", "value": "check3", "checked": true}]'
        ></gcds-checkboxes>

        <gcds-button type="submit">Submit</gcds-button>
      </form>
```

1. Using the `main` branch, add the above code to a page.
2. Uncheck two of the checkboxes and submit the form.
3. Notice all the values are still in the query string on form submission.
4. Using this branch, add the above code to a page.
5. Uncheck two of the checkboxes and submit the form.
6. Notice only the checked value is contained in the query string.
