### PR TITLE
fix: remove redundant z-index from card and fix focus state

### DIFF
--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -55,7 +55,7 @@
         font: var(--gcds-card-title-font-mobile);
       }
 
-      &:has( + .gcds-card__description) {
+      &:has(+ .gcds-card__description) {
         margin: var(--gcds-card-title-margin);
       }
     }
@@ -77,7 +77,6 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 1;
     pointer-events: auto;
     content: '';
   }
@@ -95,7 +94,7 @@
 
 @layer focus {
   :host {
-    .gcds-card:has(:focus-within) {
+    .gcds-card:focus-within {
       box-shadow: var(--gcds-card-focus-box-shadow);
       outline: var(--gcds-card-focus-outline);
       outline-offset: var(--gcds-card-focus-outline-offset);


### PR DESCRIPTION
# Summary | Résumé

Removing redundant `z-index` from the card component link which is causing issues with header navigational elements as reported in [this issue](https://github.com/cds-snc/gcds-components/issues/875). While working on this, I also noticed that the card focus state wasn't displaying properly when using keyboard navigation, which has been fixed in this PR as well. 