### PR TITLE
fix: nav-group dropdown alignment within top-nav

### DIFF
--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
@@ -132,12 +132,18 @@
         z-index: 1;
         position: absolute;
         top: 100%;
+        left: 0;
         width: var(--gcds-nav-group-top-nav-dropdown-width);
         background-color: var(--gcds-nav-group-top-nav-dropdown-background);
         margin-block-start: var(--gcds-spacing-200);
         padding: var(--gcds-nav-group-top-nav-dropdown-padding);
         box-shadow: var(--gcds-nav-group-top-nav-dropdown-box-shadow);
         border-radius: var(--gcds-border-radius-md);
+
+        &.dropdown-right {
+          left: auto;
+          right: 0;
+        }
       }
     }
 
@@ -154,12 +160,6 @@
 
     :host(.gcds-mobile-nav-topnav) > .gcds-nav--expandable {
       display: flex;
-    }
-  }
-
-  @media only screen and (width >= 64em) and (width < 96em) {
-    :host .gcds-nav--dropdown {
-      right: 0;
     }
   }
 }

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -158,7 +158,17 @@ export class GcdsNavGroup {
     this.updateLang();
 
     if (this.el.parentNode.nodeName == 'GCDS-TOP-NAV') {
+      // Set the navStyle to 'dropdown' and add a class for alignment if specified
       this.navStyle = 'dropdown';
+
+      // Get the alignment value from the parent + append the corresponding class
+      const alignment = (this.el.parentNode as HTMLElement).getAttribute(
+        'alignment',
+      );
+
+      if (alignment === 'right') {
+        this.navStyle += ' dropdown-right';
+      }
 
       if (this.open) {
         this.open = false;

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.css
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.css
@@ -29,7 +29,8 @@
   /* Note: viewport specific style decisions */
   @media only screen and (width >= 64em) {
     :host .gcds-top-nav {
-      border-block-end: var(--gcds-top-nav-border-width) solid var(--gcds-top-nav-border-color);
+      border-block-end: var(--gcds-top-nav-border-width) solid
+        var(--gcds-top-nav-border-color);
 
       .gcds-top-nav__container {
         flex-direction: row;

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -81,9 +81,24 @@
 
       <gcds-search slot="search"></gcds-search>
 
-      <!-- ------------- Theme & topic menu ------------- -->
+      <!-- ------------- Top nav ------------- -->
 
-      <gcds-topic-menu slot="menu"></gcds-topic-menu>
+      <gcds-top-nav slot="menu" label="Top navigation" alignment="right">
+        <gcds-nav-link href="#home" slot="home">Home</gcds-nav-link>
+        <gcds-nav-link href="#">Nav link</gcds-nav-link>
+
+        <gcds-nav-group
+          open-trigger="Nav group trigger"
+          menu-label="Nav group trigger"
+        >
+          <gcds-nav-link href="#" current>Nav link</gcds-nav-link>
+          <gcds-nav-link href="#">Nav link</gcds-nav-link>
+          <gcds-nav-link href="#">Nav link</gcds-nav-link>
+          <gcds-nav-link href="#">Nav link</gcds-nav-link>
+        </gcds-nav-group>
+
+        <gcds-nav-link href="#">Nav link</gcds-nav-link>
+      </gcds-top-nav>
 
       <!-- ------------- Breadcrumbs ------------- -->
 


### PR DESCRIPTION
# Summary | Résumé

The dropdown of the `nav-group` component gets partially cut-off in the `top-nav` component when the `top-nav` is set to `alignment=left` and doesn't use the `home` slot.

More details and screenshots can be found in [this issue](https://github.com/cds-snc/gcds-components/issues/857).

The dropdown alignment has been changed to be aligned left when the `top-nav` component uses `alignment=left`, and it will be aligned right, when the `top-nav` component uses `alignment=right`.

## How to test

Using the code below:

```html
<gcds-header>
  <gcds-top-nav slot="menu" label="Top navigation" alignment="left">
      <gcds-nav-group
        open-trigger="Nav group trigger"
        menu-label="Nav group trigger"
      >
        <gcds-nav-link href="#" current>Nav link</gcds-nav-link>
        <gcds-nav-link href="#">Nav link</gcds-nav-link>
        <gcds-nav-link href="#">Nav link</gcds-nav-link>
        <gcds-nav-link href="#">Nav link</gcds-nav-link>
      </gcds-nav-group>

      <gcds-nav-link href="#">Nav link</gcds-nav-link>
      <gcds-nav-link href="#">Nav link</gcds-nav-link>
    </gcds-top-nav>
</gcds-header>
```

1.  Using the main branch, add the above code to a page.
2.  Change your screensize to 1200px and open the nav-group.
3.  Notice that the nav-group dropdown gets cut-off and is not fully visible in the viewport.
4.  Using this branch, add the above code to a page.
5.  Change your screensize to 1200px and open the nav-group.
6.  Notice that the nav-group dropdown doesn't get cut-off.
