### PR TITLE
fix: reflect gcds-button `disabled` prop to support :host([disabled]) styles

### DIFF
--- a/packages/web/src/components/gcds-button/gcds-button.tsx
+++ b/packages/web/src/components/gcds-button/gcds-button.tsx
@@ -88,7 +88,7 @@ export class GcdsButton {
   /**
    * The disabled attribute for a <button> element.
    */
-  @Prop() disabled: boolean;
+  @Prop({ reflect: true }) disabled: boolean;
 
   @Watch('disabled')
   validateDisabled(newValue: boolean) {


### PR DESCRIPTION
# Summary | Résumé

Without `reflect: true`, the `disabled` prop was not reflected as an attribute on the `gcds-button` host element, causing styles like `:host([disabled])` to fail in Vue.

This led to missing disabled button styles in Vue, where props are passed but not automatically reflected as attributes.

Adding `reflect: true` ensures consistent styling across frameworks.

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/gcds-components/862) for the task.