### PR TITLE
fix(gcds-file-uploader): emit missing gcdsChange/change event

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -1,7 +1,7 @@
 import {
   Component,
   Element,
-  Event,
+  Event as StencilEvent,
   EventEmitter,
   Prop,
   Watch,
@@ -176,12 +176,12 @@ export class GcdsFileUploader {
   /**
    * Emitted when the uploader has focus.
    */
-  @Event() gcdsFocus!: EventEmitter<void>;
+  @StencilEvent() gcdsFocus!: EventEmitter<void>;
 
   /**
    * Emitted when the uploader loses focus.
    */
-  @Event() gcdsBlur!: EventEmitter<void>;
+  @StencilEvent() gcdsBlur!: EventEmitter<void>;
 
   private onBlur = () => {
     if (this.validateOn == 'blur') {
@@ -194,12 +194,12 @@ export class GcdsFileUploader {
   /**
    * Emitted when the user has made a file selection.
    */
-  @Event() gcdsChange: EventEmitter;
+  @StencilEvent() gcdsChange: EventEmitter;
 
   /**
    * Emitted when the user has uploaded a file.
    */
-  @Event() gcdsInput: EventEmitter;
+  @StencilEvent() gcdsInput: EventEmitter;
 
   private handleInput = (e, customEvent) => {
     const filesContainer: string[] = [];
@@ -232,7 +232,7 @@ export class GcdsFileUploader {
   /**
    * Remove file and update value.
    */
-  @Event() gcdsRemoveFile: EventEmitter;
+  @StencilEvent() gcdsRemoveFile: EventEmitter;
   removeFile = e => {
     e.preventDefault();
     const fileName = e.target.closest('.file-uploader__uploaded-file')
@@ -259,6 +259,8 @@ export class GcdsFileUploader {
 
     this.value = [...filesContainer];
     this.gcdsRemoveFile.emit(this.value);
+    this.gcdsChange.emit(this.value);
+    this.el.dispatchEvent(new Event('change', { bubbles: true }));
   };
 
   /**
@@ -279,12 +281,12 @@ export class GcdsFileUploader {
   /**
    * Emitted when the input has a validation error.
    */
-  @Event() gcdsError!: EventEmitter<object>;
+  @StencilEvent() gcdsError!: EventEmitter<object>;
 
   /**
    * Emitted when the input has a validation error.
    */
-  @Event() gcdsValid!: EventEmitter<object>;
+  @StencilEvent() gcdsValid!: EventEmitter<object>;
 
   @Listen('submit', { target: 'document' })
   submitListener(e) {
@@ -345,6 +347,9 @@ export class GcdsFileUploader {
         this.shadowElement.files = dt.files;
         this.files = dt.files;
       }
+
+      this.gcdsChange.emit(this.value);
+      this.el.dispatchEvent(new Event('change', { bubbles: true }));
     }
 
     // Focus file input after drop


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/842, add missing `gcdsChange`/`change` event to `gcds-file-uploader` when dragging and dropping and removing a files to match native HTML input behaviour.

## How to test

Using the code below

```html
      <gcds-file-uploader
        uploader-id="form-uploader"
        label="Upload file"
        name="file"
        multiple
        required
      ></gcds-file-uploader>

      <script>
        const file = document.querySelector('gcds-file-uploader[name="file"]');

        file.addEventListener('change', ev => {
          console.log(ev);
        });
        file.addEventListener('gcdsChange', ev => {
          console.log(ev);
        });
      </script>
```

1. Using `main` branch, drag and drop a file onto the `gcds-file-uploader`.
2. Remove the file by clicking 'Remove'.
3. Notice in the browser console no events have been logged.
4. Using `main` branch, drag and drop a file onto the `gcds-file-uploader`.
5. Remove the file by clicking 'Remove'.
6. The `gcdsChange` and `change` events should now appear in the console.
