### PR TITLE
feat: changes to footer links

### DIFF
--- a/packages/vue/tests/e2e/app.spec.ts
+++ b/packages/vue/tests/e2e/app.spec.ts
@@ -16,7 +16,7 @@ test('Page has loaded and rendered', async ({ page }) => {
 
   // Footer has rendered
   const footerLinks = await page.locator('gcds-footer a').count();
-  await expect(footerLinks).toBe(26);
+  await expect(footerLinks).toBe(27);
 });
 
 test('Select component event handling', async ({ page }) => {

--- a/packages/web/src/components/gcds-footer/gcds-footer.css
+++ b/packages/web/src/components/gcds-footer/gcds-footer.css
@@ -69,7 +69,7 @@
     }
 
     h3 {
-      font: var( --gcds-footer-font-heading);
+      font: var(--gcds-footer-font-heading);
       margin: var(--gcds-footer-heading-margin);
     }
 
@@ -113,7 +113,7 @@
 
       &.main__themenav .themenav__list {
         display: grid;
-        grid-template-rows: repeat(18, 1fr);
+        grid-template-rows: repeat(19, 1fr);
         grid-auto-flow: column;
       }
     }
@@ -194,7 +194,7 @@
       }
 
       nav.main__themenav .themenav__list {
-        grid-template-rows: repeat(9, 1fr);
+        grid-template-rows: repeat(10, 1fr);
       }
     }
   }
@@ -224,7 +224,7 @@
       }
 
       nav.main__themenav .themenav__list {
-        grid-template-rows: repeat(6, 1fr);
+        grid-template-rows: repeat(7, 1fr);
       }
     }
   }

--- a/packages/web/src/components/gcds-footer/i18n/i18n.js
+++ b/packages/web/src/components/gcds-footer/i18n/i18n.js
@@ -73,7 +73,7 @@ const I18N = {
           link: 'https://international.gc.ca/world-monde/index.aspx?lang=eng',
         },
         finance: {
-          text: 'Money and finance',
+          text: 'Money and finances',
           link: 'https://www.canada.ca/en/services/finance.html',
         },
         science: {
@@ -91,6 +91,10 @@ const I18N = {
         youth: {
           text: 'Youth',
           link: 'https://www.canada.ca/en/services/youth.html',
+        },
+        life: {
+          text: 'Manage life events',
+          link: 'https://www.canada.ca/en/services/life-events.html',
         },
       },
     },
@@ -196,7 +200,7 @@ const I18N = {
           link: 'https://www.international.gc.ca/world-monde/index.aspx?lang=fra',
         },
         finance: {
-          text: 'Argent et finance',
+          text: 'Argent et finances',
           link: 'https://www.canada.ca/fr/services/finance.html',
         },
         science: {
@@ -214,6 +218,10 @@ const I18N = {
         youth: {
           text: 'Jeunesse',
           link: 'https://www.canada.ca/fr/services/jeunesse.html',
+        },
+        life: {
+          text: 'Gérer les événements de la vie',
+          link: 'https://www.canada.ca/fr/services/evenements-vie.html',
         },
       },
     },

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.spec.tsx
@@ -160,7 +160,7 @@ describe('gcds-footer', () => {
                   </li>
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/en/services/finance.html">
-                      Money and finance
+                      Money and finances
                     </gcds-link>
                   </li>
                   <li>
@@ -181,6 +181,11 @@ describe('gcds-footer', () => {
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/en/services/youth.html">
                       Youth
+                    </gcds-link>
+                  </li>
+                  <li>
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/life-events.html">
+                      Manage life events
                     </gcds-link>
                   </li>
                 </ul>
@@ -389,7 +394,7 @@ describe('gcds-footer', () => {
                   </li>
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/fr/services/finance.html">
-                      Argent et finance
+                      Argent et finances
                     </gcds-link>
                   </li>
                   <li>
@@ -410,6 +415,11 @@ describe('gcds-footer', () => {
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/fr/services/jeunesse.html">
                       Jeunesse
+                    </gcds-link>
+                  </li>
+                  <li>
+                    <gcds-link size="small" href="https://www.canada.ca/fr/services/evenements-vie.html">
+                      Gérer les événements de la vie
                     </gcds-link>
                   </li>
                 </ul>
@@ -596,7 +606,7 @@ describe('gcds-footer', () => {
                   </li>
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/en/services/finance.html">
-                      Money and finance
+                      Money and finances
                     </gcds-link>
                   </li>
                   <li>
@@ -617,6 +627,11 @@ describe('gcds-footer', () => {
                   <li>
                     <gcds-link size="small" href="https://www.canada.ca/en/services/youth.html">
                       Youth
+                    </gcds-link>
+                  </li>
+                  <li>
+                    <gcds-link size="small" href="https://www.canada.ca/en/services/life-events.html">
+                      Manage life events
                     </gcds-link>
                   </li>
                 </ul>


### PR DESCRIPTION
# Summary | Résumé

The footer was updated to match the [english links here](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2545/templates/home/home-en.html) and the [french links here](https://servicecanada.github.io/wet-boew-demos/gcweb-pr2545/templates/home/home-fr.html).

### Preview of footer changes

Here is a preview of what the new footer looks like:

![Screenshot 2025-07-09 at 8 14 20 AM](https://github.com/user-attachments/assets/18245ada-f864-4db2-b3dc-7391c4b4afea)

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1680) for the details.