### PR TITLE
fix: React output package.json configuration

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,13 +18,13 @@
     "build": "npm run tsc",
     "tsc": "tsc -p . --outDir ./dist"
   },
-  "main": "dist/lib/index.js",
-  "module": "dist/lib/index.js",
-  "types": "dist/types/lib/index.d.ts",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/lib/index.js",
-      "types": "./dist/types/lib/index.d.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./gcds.css": {
       "import": "./gcds.css",


### PR DESCRIPTION
# Summary | Résumé

Fix the configuration in the react package's `package.json` to point to the correct files.

Currently when using `@cdssnc/gcds-components-react@0.38.0`, you receive an error of `Cannot find module '@cdssnc/gcds-components-react' or its corresponding type declarations.` when importing any components.

## How to test

1. In a react app, install the latest version of `@cdssnc/gcds-components-react`.
2. Import a gcds component.
3. Notice the `Cannot find module '@cdssnc/gcds-components-react` error on the import statement.
4. Using this branch, use `npm link` to link the local gcds-components-react package to your app.
5. Notice the import now resolves properly.
