### PR TITLE
fix: Set form value on manual value update

### DIFF
--- a/packages/web/src/components/gcds-date-input/gcds-date-input.tsx
+++ b/packages/web/src/components/gcds-date-input/gcds-date-input.tsx
@@ -91,12 +91,17 @@ export class GcdsDateInput {
   validateValue() {
     if (this.value && !isValidDate(this.value)) {
       this.errors.push('value');
-      this.value = '';
+      this.value = null;
       console.error(
         `${i18n['en'].valueError}${i18n['en'][`valueFormat${this.format}`]} | ${i18n['fr'].valueError}${i18n['fr'][`valueFormat${this.format}`]}`,
       );
     } else if (this.errors.includes('value')) {
       this.errors.splice(this.errors.indexOf('value'), 1);
+    }
+
+    if (this.value) {
+      this.splitFormValue();
+      this.internals.setFormValue(this.value);
     }
   }
 

--- a/packages/web/src/components/gcds-input/gcds-input.tsx
+++ b/packages/web/src/components/gcds-input/gcds-input.tsx
@@ -129,6 +129,11 @@ export class GcdsInput {
    */
   @Prop({ mutable: true }) value?: string;
 
+  @Watch('value')
+  watchValue(val) {
+    this.internals.setFormValue(val ? val : null);
+  }
+
   /**
    * String to have autocomplete enabled.
    */

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -90,6 +90,22 @@ export class GcdsSelect {
    */
   @Prop({ mutable: true }) value?: string;
 
+  @Watch('value')
+  watchValue(val) {
+    this.internals.setFormValue(val ? val : null);
+    this.options.forEach(option => {
+      if (option.nodeName === 'OPTION') {
+        this.checkValueOrSelected(option);
+      } else if (option.nodeName === 'OPTGROUP') {
+        const subOptions = Array.from(option.children);
+
+        subOptions.map(sub => {
+          this.checkValueOrSelected(sub);
+        });
+      }
+    });
+  }
+
   /**
    * Error message for an invalid select element.
    */
@@ -262,6 +278,7 @@ export class GcdsSelect {
 
     if (option.hasAttribute('selected')) {
       this.value = value;
+      this.internals.setFormValue(value);
       this.initialValue = this.value ? this.value : null;
     }
   }

--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -93,17 +93,6 @@ export class GcdsSelect {
   @Watch('value')
   watchValue(val) {
     this.internals.setFormValue(val ? val : null);
-    this.options.forEach(option => {
-      if (option.nodeName === 'OPTION') {
-        this.checkValueOrSelected(option);
-      } else if (option.nodeName === 'OPTGROUP') {
-        const subOptions = Array.from(option.children);
-
-        subOptions.map(sub => {
-          this.checkValueOrSelected(sub);
-        });
-      }
-    });
   }
 
   /**

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -131,6 +131,7 @@ export class GcdsTextarea {
   @Watch('value')
   watchValue(val) {
     this.shadowElement.value = val;
+    this.internals.setFormValue(val ? val : null);
   }
 
   /**


### PR DESCRIPTION
# Summary | Résumé

While testing https://github.com/cds-snc/gcds-docs/pull/621, it was discovered that some GC Design System form components will not properly set the value for the HTML form when manually updating their `value` property. Add some extra logic to the `gcds-input`, `gcds-textarea`, `gcds-select` and `gcds-date-input` components to catch this behaviour.

## How to test

Use the HTML form below:

```html
      <form>
        <gcds-input
          input-id="form-name"
          label="Name"
          hint="Please enter your full name."
          name="form-name"
        ></gcds-input>

        <gcds-textarea
          textarea-id="form-message"
          label="Message"
          hint="This is a hint."
          character-count="400"
          name="form-message"
        ></gcds-textarea>

        <gcds-date-input
          legend="Date input"
          name="date-input"
          format="full"
          hint="Formatted: YYYY-MM-DD"
          name="date-input"
        ></gcds-date-input>

        <gcds-select
          select-id="form-select"
          name="form-select"
          label="Name"
          hint="Please enter your full name."
          default-value="Please select an option"
        >
          <option value="red">Option 1</option>
          <option value="green">Option 2</option>
          <option value="blue">Option 3</option>
        </gcds-select>

        <gcds-button type="submit" button-role="primary"> Submit </gcds-button>
        <gcds-button type="button" button-role="secondary" onclick="changeIt()">
          Change
        </gcds-button>

        <script>
          function changeIt() {
            const form = document.querySelector('form');

            for (const element of form.children) {
              if (element.tagName === 'GCDS-DATE-INPUT') {
                element.value = '2024-01-01';
              } else {
                element.value = 'green';
              }
            }
          }
        </script>
      </form>
```

1. On the `main` branch, use the form above.
2. Hit the `Change` button.
3. Notice all inputs in the form have a new value set.
4. Click the submit button.
5. Notice none of the new values were passed to the form in the url's query strings.
6. Switch to this branch.
7. Repeat steps 2 - 4.
8. Notice the new values will now appear in the url's query strings.

