### PR TITLE
build: Set addGlobalStyleToComponents to false

### DIFF
--- a/packages/web/stencil.config.ts
+++ b/packages/web/stencil.config.ts
@@ -97,6 +97,6 @@ export const config: Config = {
     enableImportInjection: true,
     experimentalScopedSlotChanges: true,
     experimentalSlotFixes: true,
-    addGlobalStyleToComponents: true,
+    addGlobalStyleToComponents: false,
   },
 };


### PR DESCRIPTION
# Summary | Résumé

Set `addGlobalStyleToComponents` in the `stencil.config.ts` file to `false` to prevent stencil from adding the global styles CSS file into each component shadowRoot's [adoptedStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/adoptedStyleSheets) to prevent each component from loading more CSS then it needs to.

[More about this feature](https://stenciljs.com/docs/config-extras#addglobalstyletocomponents)
