### PR TITLE
style(gcds-footer): update footer media query to match global media queries

### DIFF
--- a/packages/web/src/components/gcds-footer/gcds-footer.css
+++ b/packages/web/src/components/gcds-footer/gcds-footer.css
@@ -157,7 +157,7 @@
 
 @layer compact {
   /* Mobile specific style */
-  @media only screen and (width < 45em) {
+  @media only screen and (width < 48em) {
     :host {
       .gcds-footer__contextual,
       .gcds-footer__main,


### PR DESCRIPTION
# Summary | Résumé

Updating one media query in the footer component that wasn't matching our global media queries from `45em` to `48em` to match.