### PR TITLE
fix(gcds-nav-group): Focusout logic to close open dropdowns

### DIFF
--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -88,7 +88,7 @@ export class GcdsNavGroup {
     if (
       (e.target === this.el || this.el.contains(e.target)) &&
       !this.el.contains(e.relatedTarget) &&
-      this.navStyle === 'dropdown' &&
+      this.navStyle.includes('dropdown') &&
       this.open &&
       window.innerWidth >= 1024
     ) {


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/383, the issue of dropdowns not closing when selecting another item in the `gcds-top-nav` has reappeared. Edited the conditional logic to catch all dropdown variants in the `gcds-nav-group`'s `navStyle` state.

## How to test

Using the code below:

```html
<gcds-top-nav slot="menu" label="Top navigation" alignment="right">
  <gcds-nav-link href="#home" slot="home">Home</gcds-nav-link>
  <gcds-nav-link href="#">Nav link</gcds-nav-link>

  <gcds-nav-group
    open-trigger="Nav group trigger"
    menu-label="Nav group trigger"
  >
    <gcds-nav-link href="#" current>Nav link</gcds-nav-link>
    <gcds-nav-link href="#">Nav link</gcds-nav-link>
    <gcds-nav-link href="#">Nav link</gcds-nav-link>
    <gcds-nav-link href="#">Nav link</gcds-nav-link>
  </gcds-nav-group>

  <gcds-nav-link href="#">Nav link</gcds-nav-link>

  <gcds-nav-group
    open-trigger="Nav group trigger"
    menu-label="Nav group trigger"
  >
    <gcds-nav-link href="#" current>Nav link</gcds-nav-link>
    <gcds-nav-link href="#">Nav link</gcds-nav-link>
    <gcds-nav-link href="#">Nav link</gcds-nav-link>
    <gcds-nav-link href="#">Nav link</gcds-nav-link>
  </gcds-nav-group>
</gcds-top-nav>
```

1.  On the main branch, click to open one of the nav groups.
2. Click to open the second nav group.
3. Notice the other dropdown remains open.
4. On this branch, click to open one of the nav groups.
5. Click to open the second nav group.
6. Notice the first dropdown menu has closed.
