### PR TITLE
docs: update small documentation typos

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -500,11 +500,11 @@ export class GcdsDateInput {
 
 export declare interface GcdsDateInput extends Components.GcdsDateInput {
   /**
-   * Emitted when an date-input has focus.
+   * Emitted when a date-input has focus.
    */
   gcdsFocus: EventEmitter<CustomEvent<void>>;
   /**
-   * Emitted when an date-input loses focus.
+   * Emitted when a date-input loses focus.
    */
   gcdsBlur: EventEmitter<CustomEvent<void>>;
   /**
@@ -512,15 +512,15 @@ export declare interface GcdsDateInput extends Components.GcdsDateInput {
    */
   gcdsInput: EventEmitter<CustomEvent<string>>;
   /**
-   * Emitted when an date-input has changed. Contains the new value in the event detail.
+   * Emitted when a date-input has changed. Contains the new value in the event detail.
    */
   gcdsChange: EventEmitter<CustomEvent<string>>;
   /**
-   * Emitted when an date-input has a validation error.
+   * Emitted when a date-input has a validation error.
    */
   gcdsError: EventEmitter<CustomEvent<object>>;
   /**
-   * Emitted when an date-input has validated.
+   * Emitted when a date-input has validated.
    */
   gcdsValid: EventEmitter<CustomEvent<object>>;
 }
@@ -1657,7 +1657,7 @@ export declare interface GcdsNotice extends Components.GcdsNotice {}
 export class GcdsPagination {
   protected el: HTMLGcdsPaginationElement;
     /**
-   * Navigation element label @default 'list'
+   * Determines the pagination display style. @default 'list'
    */
   set display(_: Components.GcdsPagination['display']) {};
     /**

--- a/packages/web/specs/components.json
+++ b/packages/web/specs/components.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-08-01T13:38:37",
+  "timestamp": "2025-08-21T22:52:12",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.35.1",
@@ -2410,7 +2410,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when an date-input loses focus.",
+          "docs": "Emitted when a date-input loses focus.",
           "docsTags": []
         },
         {
@@ -2424,7 +2424,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when an date-input has changed. Contains the new value in the event detail.",
+          "docs": "Emitted when a date-input has changed. Contains the new value in the event detail.",
           "docsTags": []
         },
         {
@@ -2438,7 +2438,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when an date-input has a validation error.",
+          "docs": "Emitted when a date-input has a validation error.",
           "docsTags": []
         },
         {
@@ -2452,7 +2452,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when an date-input has focus.",
+          "docs": "Emitted when a date-input has focus.",
           "docsTags": []
         },
         {
@@ -2480,7 +2480,7 @@
           },
           "cancelable": true,
           "composed": true,
-          "docs": "Emitted when an date-input has validated.",
+          "docs": "Emitted when a date-input has validated.",
           "docsTags": []
         }
       ],
@@ -2733,7 +2733,20 @@
           "docsTags": []
         }
       ],
-      "listeners": [],
+      "listeners": [
+        {
+          "event": "beforeprint",
+          "target": "window",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "afterprint",
+          "target": "window",
+          "capture": false,
+          "passive": false
+        }
+      ],
       "styles": [],
       "slots": [
         {
@@ -3912,7 +3925,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/Users/ethanwallace/Documents/work/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/melanie.boeckmann/Projects/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -4211,7 +4224,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/Users/ethanwallace/Documents/work/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/melanie.boeckmann/Projects/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -4307,7 +4320,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/Users/ethanwallace/Documents/work/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/melanie.boeckmann/Projects/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -4397,7 +4410,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/Users/ethanwallace/Documents/work/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/melanie.boeckmann/Projects/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -4487,7 +4500,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/Users/ethanwallace/Documents/work/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/melanie.boeckmann/Projects/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -4577,7 +4590,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/Users/ethanwallace/Documents/work/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/melanie.boeckmann/Projects/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -6684,10 +6697,10 @@
         },
         {
           "name": "type",
-          "type": "\"email\" | \"number\" | \"password\" | \"search\" | \"text\" | \"url\"",
+          "type": "\"email\" | \"number\" | \"password\" | \"search\" | \"tel\" | \"text\" | \"url\"",
           "complexType": {
-            "original": "'email' | 'number' | 'password' | 'search' | 'text' | 'url'",
-            "resolved": "\"email\" | \"number\" | \"password\" | \"search\" | \"text\" | \"url\"",
+            "original": "'email' | 'number' | 'password' | 'search' | 'tel' | 'text' | 'url'",
+            "resolved": "\"email\" | \"number\" | \"password\" | \"search\" | \"tel\" | \"text\" | \"url\"",
             "references": {}
           },
           "mutable": false,
@@ -6716,6 +6729,10 @@
             },
             {
               "value": "search",
+              "type": "string"
+            },
+            {
+              "value": "tel",
               "type": "string"
             },
             {
@@ -8248,7 +8265,7 @@
           "mutable": false,
           "attr": "display",
           "reflectToAttr": false,
-          "docs": "Navigation element label",
+          "docs": "Determines the pagination display style.",
           "docsTags": [
             {
               "name": "default",

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -956,7 +956,7 @@ export namespace Components {
          */
         "currentPage": number;
         /**
-          * Navigation element label
+          * Determines the pagination display style.
           * @default 'list'
          */
         "display": 'list' | 'simple';
@@ -2524,19 +2524,19 @@ declare namespace LocalJSX {
          */
         "name": string;
         /**
-          * Emitted when an date-input loses focus.
+          * Emitted when a date-input loses focus.
          */
         "onGcdsBlur"?: (event: GcdsDateInputCustomEvent<void>) => void;
         /**
-          * Emitted when an date-input has changed. Contains the new value in the event detail.
+          * Emitted when a date-input has changed. Contains the new value in the event detail.
          */
         "onGcdsChange"?: (event: GcdsDateInputCustomEvent<string>) => void;
         /**
-          * Emitted when an date-input has a validation error.
+          * Emitted when a date-input has a validation error.
          */
         "onGcdsError"?: (event: GcdsDateInputCustomEvent<object>) => void;
         /**
-          * Emitted when an date-input has focus.
+          * Emitted when a date-input has focus.
          */
         "onGcdsFocus"?: (event: GcdsDateInputCustomEvent<void>) => void;
         /**
@@ -2544,7 +2544,7 @@ declare namespace LocalJSX {
          */
         "onGcdsInput"?: (event: GcdsDateInputCustomEvent<string>) => void;
         /**
-          * Emitted when an date-input has validated.
+          * Emitted when a date-input has validated.
          */
         "onGcdsValid"?: (event: GcdsDateInputCustomEvent<object>) => void;
         /**
@@ -3337,7 +3337,7 @@ declare namespace LocalJSX {
          */
         "currentPage"?: number;
         /**
-          * Navigation element label
+          * Determines the pagination display style.
           * @default 'list'
          */
         "display"?: 'list' | 'simple';

--- a/packages/web/src/components/gcds-date-input/gcds-date-input.tsx
+++ b/packages/web/src/components/gcds-date-input/gcds-date-input.tsx
@@ -188,12 +188,12 @@ export class GcdsDateInput {
    */
 
   /**
-   * Emitted when an date-input has focus.
+   * Emitted when a date-input has focus.
    */
   @Event() gcdsFocus!: EventEmitter<void>;
 
   /**
-   * Emitted when an date-input loses focus.
+   * Emitted when a date-input loses focus.
    */
   @Event() gcdsBlur!: EventEmitter<void>;
 
@@ -209,17 +209,17 @@ export class GcdsDateInput {
   @Event() gcdsInput: EventEmitter<string>;
 
   /**
-   * Emitted when an date-input has changed. Contains the new value in the event detail.
+   * Emitted when a date-input has changed. Contains the new value in the event detail.
    */
   @Event() gcdsChange: EventEmitter<string>;
 
   /**
-   * Emitted when an date-input has a validation error.
+   * Emitted when a date-input has a validation error.
    */
   @Event() gcdsError!: EventEmitter<object>;
 
   /**
-   * Emitted when an date-input has validated.
+   * Emitted when a date-input has validated.
    */
   @Event() gcdsValid!: EventEmitter<object>;
 

--- a/packages/web/src/components/gcds-date-input/readme.md
+++ b/packages/web/src/components/gcds-date-input/readme.md
@@ -29,12 +29,12 @@ A date input is a space to enter a known date.
 
 | Event        | Description                                                                                 | Type                  |
 | ------------ | ------------------------------------------------------------------------------------------- | --------------------- |
-| `gcdsBlur`   | Emitted when an date-input loses focus.                                                     | `CustomEvent<void>`   |
-| `gcdsChange` | Emitted when an date-input has changed. Contains the new value in the event detail.         | `CustomEvent<string>` |
-| `gcdsError`  | Emitted when an date-input has a validation error.                                          | `CustomEvent<object>` |
-| `gcdsFocus`  | Emitted when an date-input has focus.                                                       | `CustomEvent<void>`   |
+| `gcdsBlur`   | Emitted when a date-input loses focus.                                                      | `CustomEvent<void>`   |
+| `gcdsChange` | Emitted when a date-input has changed. Contains the new value in the event detail.          | `CustomEvent<string>` |
+| `gcdsError`  | Emitted when a date-input has a validation error.                                           | `CustomEvent<object>` |
+| `gcdsFocus`  | Emitted when a date-input has focus.                                                        | `CustomEvent<void>`   |
 | `gcdsInput`  | Emitted when the date-input has received input. Contains the new value in the event detail. | `CustomEvent<string>` |
-| `gcdsValid`  | Emitted when an date-input has validated.                                                   | `CustomEvent<object>` |
+| `gcdsValid`  | Emitted when a date-input has validated.                                                    | `CustomEvent<object>` |
 
 
 ## Methods

--- a/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
+++ b/packages/web/src/components/gcds-pagination/gcds-pagination.tsx
@@ -33,7 +33,7 @@ export class GcdsPagination {
    */
 
   /**
-   * Navigation element label
+   * Determines the pagination display style.
    */
   @Prop() display: 'list' | 'simple' = 'list';
 

--- a/packages/web/src/components/gcds-pagination/readme.md
+++ b/packages/web/src/components/gcds-pagination/readme.md
@@ -14,7 +14,7 @@ Pagination is a division of content into multiple linked pages.
 | Property             | Attribute        | Description                                                             | Type                 | Default     |
 | -------------------- | ---------------- | ----------------------------------------------------------------------- | -------------------- | ----------- |
 | `currentPage`        | `current-page`   | List display - Current page number                                      | `number`             | `undefined` |
-| `display`            | `display`        | Navigation element label                                                | `"list" \| "simple"` | `'list'`    |
+| `display`            | `display`        | Determines the pagination display style.                                | `"list" \| "simple"` | `'list'`    |
 | `label` _(required)_ | `label`          | Navigation element label                                                | `string`             | `undefined` |
 | `nextHref`           | `next-href`      | Simple display - href for next link                                     | `string`             | `undefined` |
 | `nextLabel`          | `next-label`     | Simple display - lable for next link                                    | `string`             | `undefined` |


### PR DESCRIPTION
# Summary | Résumé

Updating a couple of small typos in the date-input and pagination docs.