### PR TITLE
fix(text-area): add null check in watchValue for shadowElement

### DIFF
--- a/packages/web/specs/components.json
+++ b/packages/web/specs/components.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-08-28T18:42:24",
+  "timestamp": "2025-09-11T00:21:04",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.35.1",

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -149,10 +149,14 @@ export class GcdsTextarea {
    */
   @Watch('value')
   watchValue(val) {
-    this.shadowElement.value = val;
-    this.internals.setFormValue(val ? val : null);
-  }
+    // Update DOM textarea if it exists
+    if (this.shadowElement) {
+      this.shadowElement.value = val || '';
+    }
 
+    // Update form value for form association
+    this.internals.setFormValue(val || null);
+  }
   /**
    * Array of validators
    */
@@ -320,10 +324,17 @@ export class GcdsTextarea {
    * Form internal functions
    */
   formResetCallback() {
-    if (this.value != this.initialValue) {
-      this.internals.setFormValue(this.initialValue);
+    if (this.value !== this.initialValue) {
+      // Update all relevant values to initialValue
       this.value = this.initialValue;
-      this.shadowElement.value = this.initialValue;
+
+      // Update DOM element if available
+      if (this.shadowElement) {
+        this.shadowElement.value = this.initialValue || '';
+      }
+
+      // Update form value
+      this.internals.setFormValue(this.initialValue || null);
     }
   }
 

--- a/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
+++ b/packages/web/src/components/gcds-textarea/test/gcds-textarea.spec.ts
@@ -403,4 +403,40 @@ describe('gcds-textarea', () => {
       </gcds-textarea>
     `);
   });
+
+  it('should update shadowElement value when it exists', async () => {
+    const page = await newSpecPage({
+      components: [GcdsTextarea],
+      html: '<gcds-textarea label="Label" textarea-id="test-id" name="test-name"></gcds-textarea>',
+    });
+
+    const component = page.rootInstance;
+    // Mock the shadowElement
+    component.shadowElement = { value: '' };
+    component.internals = { setFormValue: jest.fn() };
+
+    // Call the watchValue method
+    component.watchValue('new value');
+
+    expect(component.shadowElement.value).toBe('new value');
+    expect(component.internals.setFormValue).toHaveBeenCalledWith('new value');
+  });
+
+  it('should handle null shadowElement gracefully', async () => {
+    const page = await newSpecPage({
+      components: [GcdsTextarea],
+      html: '<gcds-textarea label="Label" textarea-id="test-id" name="test-name"></gcds-textarea>',
+    });
+
+    const component = page.rootInstance;
+    // Explicitly set shadowElement to null
+    component.shadowElement = null;
+    component.internals = { setFormValue: jest.fn() };
+
+    // Call the watchValue method - should not throw
+    component.watchValue('new value');
+
+    // Only check that form value is set
+    expect(component.internals.setFormValue).toHaveBeenCalledWith('new value');
+  });
 });


### PR DESCRIPTION
# Summary | Résumé
Fixes #916 

# Test instructions | Instructions pour tester la modification
Build and consume the components and angular package from this PR
Test with this code reproduction URL:
https://github.com/LagaceM/gcds-textarea-bug

I did further testing on this by adding a clear and a reset like so:
```
  public clearTextarea() {
    this.formControl.setValue('');
  }

  public resetTextarea() {
    this.formControl.setValue(this.defaultTextareaValue);
  }
```
and no errors so far.