### PR TITLE
fix(select): prevent double-escaping of special characters in select options

### DIFF
--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -448,7 +448,7 @@ export class GcdsSelect {
 
                 return (
                   <option value={opt.getAttribute('value')} {...selected}>
-                    {opt.innerHTML}
+                    {opt.textContent}
                   </option>
                 );
               } else if (opt.nodeName === 'OPTGROUP') {
@@ -459,7 +459,7 @@ export class GcdsSelect {
 
                   return (
                     <option value={sub.getAttribute('value')} {...selected}>
-                      {sub.innerHTML}
+                      {sub.textContent}
                     </option>
                   );
                 });

--- a/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
+++ b/packages/web/src/components/gcds-select/test/gcds-select.spec.tsx
@@ -216,4 +216,34 @@ describe('gcds-select', () => {
       </gcds-select>
     `);
   });
+
+  /**
+   * Select with special characters
+   */
+  it('renders special character', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSelect],
+      html: `
+        <gcds-select label="select" select-id="select" name="select">
+        <option value="1">This is option 1 & option 1.1</option>
+        <option value="2">& also option 2</option>
+        </gcds-select>
+      `,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-select select-id="select" name="select" label="select">
+        <mock:shadow-root>
+          <div class="gcds-select-wrapper">
+            <gcds-label label="select" label-for="select" lang="en"></gcds-label>
+            <select id="select" name="select" part="select" aria-invalid="false">
+              <option value="1">This is option 1 & option 1.1</option>
+              <option value="2">& also option 2</option>
+            </select>
+          </div>
+        </mock:shadow-root>
+        <option value="1">This is option 1 & option 1.1</option>
+        <option value="2">& also option 2</option>
+      </gcds-select>
+    `);
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

A user reported an issue with the `select` component where ampersands (&) in options were being rendered incorrectly.

The issue stems from how the component is rendering the `option` content. The component is using `innerHTML` to set the option content, which includes encoded HTML entities (e.g., `&`). When rendered via JSX, these entities are being escaped again, causing them to appear incorrectly (e.g., `&amp;` instead of `&`).

## What’s Changed

Refactored the rendering logic for the `select` slot to use `textContent` unstead of `innerHTML` to prevent double-escaping of entities like `&`.

## Reported issue

The reported user issue can be found [here](https://cds-snc.freshdesk.com/a/tickets/24269).

## How to test

1. Using the `main` branch, add the following code to your test page:

```
<gcds-select
    select-id="select-props"
    label="Label"
    name="select"
    default-value="Select option."
>
    <option value="1">Option 1</option>
    <option value="2">& Option 2</option>
    <option value="3">Option 3</option>
</gcds-select>
```

2. Click on the select and notice that option 2 displays `&amp;` instead of `&`.
3. Switch to this branch and add the same code.
4. Click on the select and notice that option 2 now correctly displays the `&` as `&`.