### PR TITLE
fix(gcds-checkboxes): handle onChange events and emit values

### DIFF
--- a/packages/web/src/components/gcds-checkboxes/checkbox.tsx
+++ b/packages/web/src/components/gcds-checkboxes/checkbox.tsx
@@ -143,7 +143,7 @@ export const renderCheckbox = (checkbox, element, emitEvent, handleInput) => {
         {...attrsInput}
         onBlur={isGroup ? () => gcdsBlur.emit() : onBlurValidate}
         onFocus={() => gcdsFocus.emit()}
-        onChange={() => gcdsChange.emit()}
+        onChange={e => handleInput(e, gcdsChange)}
         onInput={e => handleInput(e, gcdsInput)}
         onClick={e =>
           !disabled ? emitEvent(e, gcdsClick) : e.stopImmediatePropagation()

--- a/packages/web/src/components/gcds-checkboxes/test/gcds-checkboxes.spec.tsx
+++ b/packages/web/src/components/gcds-checkboxes/test/gcds-checkboxes.spec.tsx
@@ -532,4 +532,46 @@ describe('gcds-checkbox', () => {
       </gcds-checkboxes>
     `);
   });
+  it('emits events with value in detail property', async () => {
+    // Create the component
+    const page = await newSpecPage({
+      components: [GcdsCheckboxes],
+      html: `
+      <gcds-checkboxes
+        legend="Test Events"
+        name="test-events"
+        options='[{"label": "Option 1", "id": "option1", "value": "option1"}]'
+      ></gcds-checkboxes>
+    `,
+    });
+
+    // Set up event listeners with spies
+    const inputSpy = jest.fn();
+    const changeSpy = jest.fn();
+    page.root.addEventListener('gcdsInput', inputSpy);
+    page.root.addEventListener('gcdsChange', changeSpy);
+
+    // Simulate checking the checkbox directly via component's handleInput method
+    const component = page.rootInstance;
+    const mockEvent = {
+      target: { checked: true, value: 'option1' },
+      type: 'input',
+    };
+
+    // Trigger input event
+    component.handleInput(mockEvent, component.gcdsInput);
+    await page.waitForChanges();
+
+    // Trigger change event
+    mockEvent.type = 'change';
+    component.handleInput(mockEvent, component.gcdsChange);
+    await page.waitForChanges();
+
+    // Verify both events emitted the correct value in their detail
+    expect(inputSpy).toHaveBeenCalled();
+    expect(inputSpy.mock.calls[0][0].detail).toEqual(['option1']);
+
+    expect(changeSpy).toHaveBeenCalled();
+    expect(changeSpy.mock.calls[0][0].detail).toEqual(['option1']);
+  });
 });


### PR DESCRIPTION
# Summary | Résumé
Fix for https://github.com/cds-snc/design-gc-conception/issues/1892
Issue: GcdsChange on GcdsCheckboxes doesn't populate the values on the `detail` object when it is emitted

# Test instructions | Instructions pour tester la modification
When using gcds-checkboxes, listen to the gcdsChange event being emitted and check for the value in the detail object.

On the fable app built in react, I tested it in the SubmitHoliday.tsx file like this:
```javascript
  document.addEventListener('gcdsInput', (e: any) => {
    if (e.target && (e.target.tagName === 'GCDS-CHECKBOXES' || e.target.tagName === 'GCDS-RADIOS')) {
      console.log('gcdsInput:', {
        component: e.target.tagName,
        name: e.target.name,
        detail: e.detail,
        detailType: typeof e.detail,
        isArray: Array.isArray(e.detail)
      });
    }
  document.addEventListener('gcdsChange', (e: any) => {
    if (e.target && (e.target.tagName === 'GCDS-CHECKBOXES' || e.target.tagName === 'GCDS-RADIOS')) {
      console.log('gcdsChange:', {
        component: e.target.tagName,
        name: e.target.name,
        detail: e.detail,
        detailType: typeof e.detail,
        isArray: Array.isArray(e.detail)
      });
    }
  });
```