### PR TITLE
style: fix topic menu link background on hover

### DIFF
--- a/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
+++ b/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
@@ -258,7 +258,7 @@
 
       [role='menuitem'][aria-haspopup='true'][aria-expanded='false'][aria-controls]:not(
           [aria-controls*='sub']
-        ) {
+        ):not(:hover) {
         background-color: var(--gcds-topic-menu-themelist-background);
       }
     }


### PR DESCRIPTION
# Summary | Résumé

Currently when hovering over text in the theme and topic menu component, the background colour changes faster than the text colour, leading to low-contrast text. I adjusted the styling to change the background colour at the same time as the text.

## Bug fix

This style change is a bug fix for [this ticket](https://github.com/cds-snc/gcds-components/issues/847).

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/gcds-components/847) for the change.

How to test

1. Using the main branch, add the following code to your test page:

```
 <gcds-topic-menu ></gcds-topic-menu>
 ```

2. Click on the menu button and hover over any of the menu items on the left hand side. Notice that the link text colour on hover switches from white to black right away, while the link background colour takes a few seconds to switch.
3. Switch to this branch and add the same code.
4. Click on the menu button  and hover over any of the menu items on the left hand side.  Notice that the link background colour on hover changes at the same time as the link text colour.
