### PR TITLE
fix(gcds-radios): Fix focus when radios has an error

### DIFF
--- a/packages/web/src/components/gcds-radios/gcds-radios.tsx
+++ b/packages/web/src/components/gcds-radios/gcds-radios.tsx
@@ -412,11 +412,9 @@ export class GcdsRadios {
             ) : null}
 
             {errorMessage ? (
-              <div>
-                <gcds-error-message id="radios-error" messageId="radios">
-                  {errorMessage}
-                </gcds-error-message>
-              </div>
+              <gcds-error-message id="radios-error" messageId="radios">
+                {errorMessage}
+              </gcds-error-message>
             ) : null}
 
             {this.optionsArr &&
@@ -432,11 +430,10 @@ export class GcdsRadios {
 
                 if (radio.hint) {
                   const hintID = radio.hint ? `hint-${radio.id} ` : '';
-                  attrsInput['aria-describedby'] = `${hintID}${
-                    attrsInput['aria-describedby']
-                      ? `${attrsInput['aria-describedby']}`
-                      : ''
-                  }`;
+                  attrsInput['aria-describedby'] = `${hintID}${attrsInput['aria-describedby']
+                    ? `${attrsInput['aria-describedby']}`
+                    : ''
+                    }`;
                 }
 
                 if (hasError) {
@@ -446,9 +443,8 @@ export class GcdsRadios {
 
                 return (
                   <div
-                    class={`gcds-radio ${
-                      disabled ? 'gcds-radio--disabled' : ''
-                    } ${hasError ? 'gcds-radio--error' : ''}`}
+                    class={`gcds-radio ${disabled ? 'gcds-radio--disabled' : ''
+                      } ${hasError ? 'gcds-radio--error' : ''}`}
                   >
                     <input
                       id={radio.id}


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/966, the `gcds-radios` component was unable to regain focus with a keyboard after receiving and error when validating.

After testing I was only able to replicate this behaviour in Chrome but was able to find a small fix for it by changing the formatting around the error message.

## How to test

Using the HTML below:

```html
      <gcds-radios
        name="radio"
        legend="Radios"
        required
        options='[{ "label": "Radio 1 label", "id": "radio1", "value": "radio1"}, { "label": "Radio 2 label", "id": "radio2", "value": "radio2"}]'
      ></gcds-radios>
```

1. on the main branch, copy the code above.
2. Focus the radios with keyboard and then remove focus.
3. Radios should now have an error.
4. Using the keyboard, try to focus the radios component. Notice you are unable to focus the radio inputs.
5. Using this branch, focus the radios with keyboard and then remove focus.
6. Radios should now have an error.
7. Using the keyboard, focus the radios component. Notice you should be able to focus the radio inputs now.