### PR TITLE
Style/fix input and textarea font sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4135,9 +4135,9 @@
       "link": true
     },
     "node_modules/@cdssnc/gcds-tokens": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.13.0.tgz",
-      "integrity": "sha512-g/M4yr71/Rp/c5R6LHupvIS45+Z/SRamcj9NGSW5Zs01QHb8+9vzwrvcLEspDNZLC9WaGzJxvGGE+A2ArS7AcA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-tokens/-/gcds-tokens-2.13.1.tgz",
+      "integrity": "sha512-lDf+1EYnPBA6jG4jtQpV8csCUwSHPQ5lygwNNrpfUQmaoMAPz1NUEKbW3Kg+cWgb/6vPVShQ/iobLzjFR5Vt/A==",
       "dev": true,
       "license": "MIT"
     },
@@ -40787,7 +40787,7 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
         "@bgotink/playwright-coverage": "^0.3.2",
-        "@cdssnc/gcds-tokens": "^2.13.0",
+        "@cdssnc/gcds-tokens": "^2.13.1",
         "@gcds-core/fonts": "^1.0.0",
         "@playwright/test": "^1.52.0",
         "@stencil/angular-output-target": "file:../../utils/angular-output-target",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-typescript": "^7.21.0",
     "@bgotink/playwright-coverage": "^0.3.2",
     "@gcds-core/fonts": "^1.0.0",
-    "@cdssnc/gcds-tokens": "^2.13.0",
+    "@cdssnc/gcds-tokens": "^2.13.1",
     "@playwright/test": "^1.52.0",
     "@stencil/angular-output-target": "file:../../utils/angular-output-target",
     "@stencil/playwright": "^0.2.1",

--- a/packages/web/src/components/gcds-input/gcds-input.css
+++ b/packages/web/src/components/gcds-input/gcds-input.css
@@ -20,9 +20,13 @@
   :host .gcds-input-wrapper {
     max-width: 75ch;
     width: 100%;
-    font: var(--gcds-input-font);
+    font: var(--gcds-input-font-desktop);
     color: var(--gcds-input-default-text);
     transition: color ease-in-out 0.15s;
+
+    @media only screen and (width < 48em) {
+      font: var(--gcds-input-font-mobile);
+    }
 
     input {
       display: block;

--- a/packages/web/src/components/gcds-textarea/gcds-textarea.css
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.css
@@ -20,9 +20,13 @@
   :host .gcds-textarea-wrapper {
     width: 100%;
     max-width: 75ch;
-    font: var(--gcds-textarea-font);
+    font: var(--gcds-textarea-font-desktop);
     color: var(--gcds-textarea-default-text);
     transition: color ease-in-out 0.15s;
+
+    @media only screen and (width < 48em) {
+      font: var(--gcds-textarea-font-mobile);
+    }
 
     textarea {
       display: block;


### PR DESCRIPTION
# Summary | Résumé

The input and textarea component currently don't adjust their font size for smaller viewports. Adding desktop and mobile font tokens two both components to be consistent with our other form components & general typography.

## Bug fix

This style change is a bug fix for [this bug](https://github.com/cds-snc/gcds-components/issues/941).
Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/gcds-components/941) for the change.