### PR TITLE
feat(angular): Update angular peer dependencies to support v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39923,8 +39923,8 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^19.0.0",
-        "@angular/core": "^19.0.0",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
         "@cdssnc/gcds-components": "^0.43.1"
       }
     },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -18,8 +18,8 @@
     "build": "cd ../.. && ng build @cdssnc/gcds-components-angular"
   },
   "peerDependencies": {
-    "@angular/common": "^19.0.0",
-    "@angular/core": "^19.0.0",
+    "@angular/common": "^19.0.0 || ^20.0.0",
+    "@angular/core": "^19.0.0 || ^20.0.0",
     "@cdssnc/gcds-components": "^0.43.1"
   },
   "dependencies": {


### PR DESCRIPTION
# Summary | Résumé

Update `peerDependencies` in `@cdssnc/gcds-components-angular` to allow installation in an v20 Angular app.

https://github.com/cds-snc/gcds-components/issues/904