### PR TITLE
fix(gcds-top-nav/gcds-side-nav): Issues with mobile menu closing

### DIFF
--- a/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
+++ b/packages/web/src/components/gcds-side-nav/gcds-side-nav.tsx
@@ -85,7 +85,7 @@ export class GcdsSideNav {
 
   @Listen('focusout', { target: 'document' })
   async focusOutListener(e) {
-    if (!this.el.contains(e.relatedTarget)) {
+    if (e.relatedTarget !== null && e.relatedTarget !== this.el && !this.el.contains(e.relatedTarget)) {
       if (this.navSize == 'mobile') {
         if (this.mobile.hasAttribute('open')) {
           await this.mobile.toggleNav();
@@ -98,6 +98,9 @@ export class GcdsSideNav {
   async keyDownListener(e) {
     if (this.el.contains(document.activeElement)) {
       handleKeyDownNav(e, this.el, this.navItems);
+    } if (this.navSize == 'mobile' && this.mobile.open == true && e.key == 'Escape') {
+      // Close mobile nav on ESC
+      await this.mobile.toggleNav();
     }
   }
 

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.tsx
@@ -102,7 +102,7 @@ export class GcdsTopNav {
 
   @Listen('focusout', { target: 'document' })
   async focusOutListener(e) {
-    if (!this.el.contains(e.relatedTarget)) {
+    if (e.relatedTarget !== null && e.relatedTarget !== this.el && !this.el.contains(e.relatedTarget)) {
       if (this.navSize == 'mobile') {
         if (this.mobile.hasAttribute('open')) {
           await this.mobile.toggleNav();
@@ -115,6 +115,9 @@ export class GcdsTopNav {
   async keyDownListener(e) {
     if (this.el.contains(document.activeElement)) {
       handleKeyDownNav(e, this.el, this.navItems);
+    } else if (this.navSize == 'mobile' && this.mobile.open == true && e.key == 'Escape') {
+      // Close mobile nav on ESC
+      await this.mobile.toggleNav();
     }
   }
 


### PR DESCRIPTION
# Summary | Résumé

Address two recent issues with top/side nav.

## First issue

As mentioned in https://github.com/cds-snc/gcds-components/issues/1005, the top/side nav mobile menus may become stuck open if the viewport size is resized to desktop size when the mobile menu is open. Menus now close properly and escape should now close the mobile menu at all times.

## Second issue

As mentioned in https://github.com/cds-snc/design-gc-conception/issues/2044, users using a mobile screen reader were experiencing issues with the mobile menu closing unexpectedly. Fixed the focusout logic to stop closing the menu when they use swipe gestures.

## How to test

```html
      <!-- ------------- Side nav ------------- -->

      <gcds-heading tag="h2">Side navigation</gcds-heading>
      <gcds-side-nav class="mt-700" label="Sidenav">
        <gcds-nav-link href="#installation">Installation</gcds-nav-link>
        <gcds-nav-link href="#foundations" current>Foundations</gcds-nav-link>
        <gcds-nav-link href="#components">Components</gcds-nav-link>
        <gcds-nav-group menu-label="Contact submenu" open-trigger="Contact">
          <gcds-nav-link href="#site1">Site</gcds-nav-link>
          <gcds-nav-link href="#github1">GitHub</gcds-nav-link>
          <gcds-nav-group
            menu-label="Sub level submenu"
            open-trigger="Sub level"
          >
            <gcds-nav-link href="#site2">Site</gcds-nav-link>
            <gcds-nav-link href="#github2">GitHub</gcds-nav-link>
            <gcds-nav-link href="#slack">Slack</gcds-nav-link>
          </gcds-nav-group>
        </gcds-nav-group>
      </gcds-side-nav>

      <!-- ------------- Top nav ------------- -->

      <gcds-heading tag="h2">Top navigation</gcds-heading>
      <gcds-top-nav label="topbar" alignment="right" lang="en">
        <gcds-nav-link href="#home" slot="home">Home</gcds-nav-link>
        <gcds-nav-link href="#install">Installation</gcds-nav-link>
        <gcds-nav-link href="#foundations">Foundations</gcds-nav-link>
        <gcds-nav-link href="#components" current>Components</gcds-nav-link>
        <gcds-nav-group
          menu-label="Contact us submenu"
          open-trigger="Contact us"
        >
          <gcds-nav-link href="#form">Form</gcds-nav-link>
          <gcds-nav-link href="#github">GitHub</gcds-nav-link>
          <gcds-nav-link href="#slack">Slack</gcds-nav-link>
        </gcds-nav-group>
      </gcds-top-nav>
```

### Issue one

1. On the main branch in mobile view, open the mobile menu of the nav component.
2. Resize the window to desktop size.
3. Notice the menu can be stuck open and is unable to be closed (may have to repeat steps 1 and 2 a few times to replicate).
4. On this branch, open the mobile menu of a nav component.
5. Resize the window to desktop size.
6. Notice the menu closes properly now.

### Issue two

1. On the main branch in mobile view, open the mobile menu of the nav component.
2. Click below the listed links.
3. Notice the menu will close.
4. On this branch, open the mobile menu of a nav component.
5. Click below the links.
6. Notice the menu will stay open and will only close when pressing the close button or pressing the `Escape` key

