### PR TITLE
fix(gcds-label): align with WCAG technique C7 when `hide-label` is true

### DIFF
--- a/packages/web/src/components/gcds-label/gcds-label.css
+++ b/packages/web/src/components/gcds-label/gcds-label.css
@@ -20,11 +20,13 @@
     }
 
     &.label--hidden {
+      clip-path: inset(100%);
+      clip: rect(1px, 1px, 1px, 1px);
+      height: 1px;
       overflow: hidden;
-      opacity: 0;
-      width: 0;
-      height: 0;
-      margin: 0;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
     }
 
     .label--required {


### PR DESCRIPTION
# Summary | Résumé

This follows the same technique that is used for gcds-sr-only for hidden labels 

Related:
https://github.com/cds-snc/gcds-css-shortcuts/pull/288
https://www.w3.org/WAI/WCAG22/Techniques/css/C7

