### PR TITLE
style(gcds-card): improve img alt text and card title alignment

### DIFF
--- a/packages/web/src/components/gcds-card/gcds-card.css
+++ b/packages/web/src/components/gcds-card/gcds-card.css
@@ -42,6 +42,7 @@
     }
 
     .gcds-card__image {
+      display: block;
       width: 100%;
       margin: var(--gcds-card-image-margin);
     }

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -207,6 +207,7 @@
           description="This is a card"
           badge="New"
           img-src="https://picsum.photos/480/270"
+          img-alt="Random image from picsum"
         >
         </gcds-card>
         <gcds-card
@@ -215,6 +216,7 @@
           href="#red"
           badge="New"
           img-src="https://picsum.photos/480/270"
+          img-alt="Random image from picsum"
         >
         </gcds-card>
 
@@ -224,6 +226,7 @@
           href="#red"
           description="This is a card with an img and possibly more"
           img-src="https://picsum.photos/480/270"
+          img-alt="Random image from picsum"
         >
         </gcds-card>
 
@@ -234,6 +237,7 @@
           badge="Card with badge that is too long"
           description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque viverra ex at scelerisque vulputate. Morbi malesuada interdum augue. Nam id quam non orci aliquam malesuada sit amet ut magna. Integer hendrerit lorem sit amet risus dignissim aliquam."
           img-src="https://picsum.photos/480/270"
+          img-alt="Random image from picsum"
         >
           Text passed by the slot.
         </gcds-card>


### PR DESCRIPTION
# Summary | Résumé

## Improved layout for image fallback state

While working on the card component today, I noticed a small visual issue when the image fails to load and the alt text is displayed instead. Currently, the alt text and card title appear on the same line, which doesn’t look great due to their differing font sizes and colours. To improve readability and maintain consistency, the alt text should be visually separated from the card title in a similar manner to how the image and title are spaced.

This change will ensure a cleaner and more balanced layout when the image is unavailable.

## Screenshots

Screenshot of what the alt text and card title looked like before this change:

<img width="428" height="569" alt="Screenshot 2025-12-15 at 5 30 26 PM" src="https://github.com/user-attachments/assets/d68c60e1-bff1-4c11-9ac3-2f809a765341" />

Screenshot of what the alt text and card title look like after this change:

<img width="395" height="549" alt="Screenshot 2025-12-15 at 5 30 53 PM" src="https://github.com/user-attachments/assets/1fb0f627-dcbd-4aba-9daf-203d0baf5aec" />

