### PR TITLE
ci: update publishing workflow for react-ssr canary tag

### DIFF
--- a/.github/workflows/compile-and-publish.yml
+++ b/.github/workflows/compile-and-publish.yml
@@ -85,6 +85,7 @@ jobs:
           - name: "@cdssnc/gcds-components-react-ssr"
             package: "./packages/react-ssr"
             dist: "./packages/react-ssr"
+            tag: canary
 
     steps:
       - name: Git Checkout
@@ -105,7 +106,7 @@ jobs:
       - name: Publish ${{ matrix.name }}
         id: publish
         working-directory: ${{ matrix.dist }}
-        run: npm publish --ignore-scripts --access public
+        run: npm publish --ignore-scripts --access public --tag ${{ matrix.tag || 'latest' }}
 
       - name: Report deployment to Sentinel
         if: steps.publish.outputs.id != ''


### PR DESCRIPTION
# Summary | Résumé
The canary package of react-ssr is failing. This fixes that issue