### PR TITLE
fix(gcds-search): Suggested attribute assignment

### DIFF
--- a/packages/web/specs/components.json
+++ b/packages/web/specs/components.json
@@ -10086,23 +10086,21 @@
         },
         {
           "name": "suggested",
-          "type": "string[]",
+          "type": "string | string[]",
           "complexType": {
-            "original": "Array<string>",
-            "resolved": "string[]",
-            "references": {
-              "Array": {
-                "location": "global",
-                "id": "global::Array"
-              }
-            }
+            "original": "string[] | string",
+            "resolved": "string | string[]",
+            "references": {}
           },
-          "mutable": false,
+          "mutable": true,
           "attr": "suggested",
           "reflectToAttr": false,
           "docs": "Set a list of predefined search terms",
           "docsTags": [],
           "values": [
+            {
+              "type": "string"
+            },
             {
               "type": "string[]"
             }

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1229,7 +1229,7 @@ export namespace Components {
         /**
           * Set a list of predefined search terms
          */
-        "suggested": Array<string>;
+        "suggested": string[] | string;
         /**
           * Set the value of the search input
          */
@@ -3821,7 +3821,7 @@ declare namespace LocalJSX {
         /**
           * Set a list of predefined search terms
          */
-        "suggested"?: Array<string>;
+        "suggested"?: string[] | string;
         /**
           * Set the value of the search input
          */

--- a/packages/web/src/components/gcds-search/readme.md
+++ b/packages/web/src/components/gcds-search/readme.md
@@ -11,15 +11,15 @@ Search is a space for entering keywords to find relevant information.
 
 ## Properties
 
-| Property      | Attribute     | Description                                                                        | Type              | Default          |
-| ------------- | ------------- | ---------------------------------------------------------------------------------- | ----------------- | ---------------- |
-| `action`      | `action`      | Sets the action for the search form. Default will be canada.ca global search       | `string`          | `'/sr/srb.html'` |
-| `method`      | `method`      | Set the form method of the search form                                             | `"get" \| "post"` | `'get'`          |
-| `name`        | `name`        | Set the name of the search input                                                   | `string`          | `'q'`            |
-| `placeholder` | `placeholder` | Set the placeholder and label for the search input. Becomes "Search [placeholder]" | `string`          | `'Canada.ca'`    |
-| `searchId`    | `search-id`   | Set the id of the search input                                                     | `string`          | `'search'`       |
-| `suggested`   | `suggested`   | Set a list of predefined search terms                                              | `string[]`        | `undefined`      |
-| `value`       | `value`       | Set the value of the search input                                                  | `string`          | `undefined`      |
+| Property      | Attribute     | Description                                                                        | Type                 | Default          |
+| ------------- | ------------- | ---------------------------------------------------------------------------------- | -------------------- | ---------------- |
+| `action`      | `action`      | Sets the action for the search form. Default will be canada.ca global search       | `string`             | `'/sr/srb.html'` |
+| `method`      | `method`      | Set the form method of the search form                                             | `"get" \| "post"`    | `'get'`          |
+| `name`        | `name`        | Set the name of the search input                                                   | `string`             | `'q'`            |
+| `placeholder` | `placeholder` | Set the placeholder and label for the search input. Becomes "Search [placeholder]" | `string`             | `'Canada.ca'`    |
+| `searchId`    | `search-id`   | Set the id of the search input                                                     | `string`             | `'search'`       |
+| `suggested`   | `suggested`   | Set a list of predefined search terms                                              | `string \| string[]` | `undefined`      |
+| `value`       | `value`       | Set the value of the search input                                                  | `string`             | `undefined`      |
 
 
 ## Events

--- a/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
+++ b/packages/web/src/components/gcds-search/test/gcds-search.spec.tsx
@@ -80,4 +80,33 @@ describe('gcds-search', () => {
       </gcds-search>
     `);
   });
+  it('renders w/ suggested', async () => {
+    const page = await newSpecPage({
+      components: [GcdsSearch],
+      html: `<gcds-search suggested='["red", "green", "blue"]'></gcds-search>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <gcds-search suggested='["red", "green", "blue"]'>
+        <mock:shadow-root>
+          <section class="gcds-search">
+            <gcds-sr-only tag="h2">
+              Search
+            </gcds-sr-only>
+            <form action="https://www.canada.ca/en/sr/srb.html" class="gcds-search__form" method="get" role="search">
+              <gcds-label hide-label="" label="Search Canada.ca" label-for="search"></gcds-label>
+              <input class="gcds-search__input" id="search" list="search-list" maxlength="170" name="q" placeholder="Search Canada.ca" size="34" type="search">
+              <datalist id="search-list">
+                <option value="red"></option>
+                <option value="green"></option>
+                <option value="blue"></option>
+              </datalist>
+              <gcds-button class="gcds-search__button" exportparts="button" type="submit">
+                <gcds-icon label="Search" name="search" size="h3"></gcds-icon>
+              </gcds-button>
+            </form>
+          </section>
+        </mock:shadowroot>
+      </gcds-search>
+    `);
+  });
 });


### PR DESCRIPTION
# Summary | Résumé

Previously the `suggested` attribute to assign predefined search terms on the `gcds-search` component was only working if the array was assigned using the Javascript property. The component should now accept the array using the `suggested` attribute.

## How to test

```
<gcds-search suggested='["red", "green", "blue"]'></gcds-search>
```

1. On the main branch use the HTML above.
2. Notice the search component does not provide any suggested search terms in a datalist when focused.
3. On this branch using the HTML above.
4. Notice the options 'red', 'green' and 'blue' will now appear when focusing the search input.
