### PR TITLE
fix(gcds-select): Remove resetting value on options rerender

### DIFF
--- a/packages/web/src/components/gcds-select/gcds-select.tsx
+++ b/packages/web/src/components/gcds-select/gcds-select.tsx
@@ -413,8 +413,6 @@ export class GcdsSelect {
     };
     const observer = new MutationObserver(() => {
       this.options = Array.from(this.el.children);
-      // Reset value to null to prevent unwanted selection
-      this.value = null;
     });
     observer.observe(this.el, config);
   }


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/1069, the `gcds-date-input` loses the month value when language has been switched on the component. This was caused by logic built into the `gcds-select` that resets the value when the options have changed. Since the most common use case of options changing inside the select component will most likely be language switches, like in the `gcds-date-input`, we have decided tor emove that bit of logic from the `gcds-select`.

## How to test

```html
      <gcds-date-input
        legend="Date input"
        name="date-input"
        format="full"
        hint="Formatted: YYYY-MM-DD"
        lang="en"
      ></gcds-date-input>
```

1. On the main branch using the HTML above, enter a valid date into the date input.
2. Modify the HTML in dev tools and change the `lang` attribute to `fr`.
3. Notice day and year keep their values but the month has been reset.
4. On this branch, enter a valid date into the date input.
5. Modify the HTML in dev tools and change the `lang` attribute to `fr`.
6.  Notice all values have stay assigned.