### PR TITLE
feat(components): add base font imports for default typography

### DIFF
--- a/packages/web/src/assets/css/global.css
+++ b/packages/web/src/assets/css/global.css
@@ -1,11 +1,17 @@
+/* Import GC Fonts (Lato + Noto Sans) */
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400;1,700&family=Noto+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Noto+Sans+Mono:wght@100..900&display=swap');
+
 /* Import GC Design System Tokens */
 @import '~@cdssnc/gcds-tokens/build/web/css/tokens.css';
 
 /* Import GC Design System Icon Font */
 @font-face {
   font-family: 'gcds-icons';
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@0.2.2/icons/gcds-icons.ttf") format("truetype"),
-        url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@0.2.2/icons/gcds-icons.woff") format("woff");
+  src:
+    url('https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@0.2.2/icons/gcds-icons.ttf')
+      format('truetype'),
+    url('https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@0.2.2/icons/gcds-icons.woff')
+      format('woff');
   font-weight: normal;
   font-style: normal;
   font-display: block;

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -6,42 +6,13 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
     />
-    <title>Stencil Component Starter</title>
+    <title>GC Design System Components Test</title>
 
-    <!-- Utility framework -->
+    <!-- GC Design System CSS Shortcuts -->
     <link
       rel="stylesheet"
-      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@latest/dist/gcds-utility.min.css"
+      href="https://cdn.design-system.alpha.canada.ca/@gcds-core/css-shortcuts@latest/dist/gcds-css-shortcuts.min.css"
     />
-
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap"
-      rel="stylesheet"
-    />
-
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap"
-      rel="stylesheet"
-    />
-
-    <!-- Font awesome 6 kit for this demo page. Anyone can create a free kit for open source. -->
-    <script
-      src="https://kit.fontawesome.com/892cb27850.js"
-      crossorigin="anonymous"
-    ></script>
 
     <!-- Local components -->
     <link rel="stylesheet" href="./build/gcds.css" />


### PR DESCRIPTION
# Summary | Résumé

This PR adds a base Google Fonts import to the components package so that components render with the expected typography out of the box, even when used in isolation. The font import follows the same pattern used by the CSS Shortcuts reset, ensuring consistency and avoiding duplicate font downloads when both are present. What's included:

- Added a base Google Fonts import to the components package.
- Components render with correct typography when used in isolation.
- Font import matches the CSS Shortcuts reset font configuration.
- No duplicate font loading occurs when CSS Shortcuts is also present.

## Rationale

Currently, users must manually import base fonts to ensure correct typography when using components on their own (without CSS Shortcuts). This creates:

- Extra setup work for users.
- Potential for inconsistent typography when components are used without CSS Shortcuts.
- Implicit coupling between components and external CSS Shortcuts resets.

By importing base fonts directly in the components package, we make consistent typography a default.

## How to test

### No duplicate font loading occurs when CSS Shortcuts is also present 

You can verify that base fonts are not loaded more than once in Google Chrome by opening our local testing environment for the components repo and inspecting the font network requests in DevTools.

1. Open the components in our local testing environment for this package in Google Chrome.
2. Open DevTools → Network.
3. Check “Disable cache”.
4. Reload the page.
5. Filter the Network panel by Font.
6. Each font file (.woff2 from fonts.gstatic.com) is loaded only once and no additional font files are requested. Font URLs between the components fonts import and the CSS Shortcuts import are identical and correctly de-duplicated by the browser.

### Fonts load without CSS Shortcuts

You can verify that base fonts are loaded correctly without CSS Shortcuts being present by opening our local testing environment for the components repo and commenting out line 12-14 in [this file](https://github.com/cds-snc/gcds-components/blob/feat/import-fonts-to-component-package/packages/web/src/index.html#L12) to temporarily remove CSS Shortcuts.

1. Open the components in our local testing environment for this package.
2. Comment out line 12-14 to temporarily remove CSS Shortcuts.
3. Notice that the correct fonts are being loaded.


