### PR TITLE
fix(gcds-signature): High contrast mode and variant property

### DIFF
--- a/packages/web/src/components/gcds-signature/gcds-signature.css
+++ b/packages/web/src/components/gcds-signature/gcds-signature.css
@@ -64,11 +64,8 @@
 
 @layer highcontrast {
   :host svg .fip_text {
-    @media (prefers-color-scheme: light) {
-      fill: var(--gcds-signature-color-text);
-    }
-    @media (prefers-color-scheme: dark) {
-      fill: var(--gcds-signature-white-default);
+    @media (forced-colors: active) {
+      fill: CanvasText;
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/1113, the `gcds-signature` component no longer respects the `variant` property option. This bug was introduced in https://github.com/cds-snc/gcds-components/pull/1100 with the CSS change to `gcds-signature`. 

The old CSS `prefers-color-scheme: light/dark` would overwrite the variant CSS each time it renders. Switch to using  `forced-colors: active` to only use the high contrast layer when something like Windows High Contrast mode is on.

## How to test

```html
      <gcds-signature type="signature" variant="colour"></gcds-signature>
      <gcds-signature type="wordmark" variant="colour"></gcds-signature>

      <div class="bg-dark p-300">
        <gcds-signature type="signature" variant="white"></gcds-signature>
        <gcds-signature type="wordmark" variant="white"></gcds-signature>
      </div>
```

1. On the main branch, copy the HTML above.
2. Notice the signature component on the dark background will be black.
3. On this branch, copy the HTML above.
4. Notice the signature components will appear as they should following their `variant` property.
5. Extra test: View the above HTML on a windows device with high contrast mode on. Notice the signatures will adapt to the theme colours.
