### PR TITLE
feat(gcds-header): add sign in button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28101,6 +28101,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "sass": "1.97.3"
       }
@@ -28118,6 +28119,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28135,6 +28137,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28152,6 +28155,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28169,6 +28173,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28186,6 +28191,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28203,6 +28209,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28220,6 +28227,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28237,6 +28245,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28254,6 +28263,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28271,6 +28281,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28288,6 +28299,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28305,6 +28317,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28322,6 +28335,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28339,6 +28353,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28356,6 +28371,7 @@
         "!linux",
         "!win32"
       ],
+      "peer": true,
       "dependencies": {
         "sass": "1.97.3"
       }
@@ -28373,6 +28389,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -28390,6 +28407,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }

--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -329,7 +329,7 @@ export class GcdsCheckboxes {
    */
   set disabled(_: Components.GcdsCheckboxes['disabled']) {};
     /**
-   * If true, the checkobox will be focused on component render
+   * If true, the checkbox will be focused on component render
    */
   set autofocus(_: Components.GcdsCheckboxes['autofocus']) {};
     /**

--- a/packages/angular/tests/app/package-lock.json
+++ b/packages/angular/tests/app/package-lock.json
@@ -97,16 +97,16 @@
       }
     },
     "../../dist": {
-      "name": "@cdssnc/gcds-components-angular",
-      "version": "0.47.0",
+      "name": "@gcds-core/components-angular",
+      "version": "1.1.0",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^19.0.0 || ^20.0.0",
-        "@angular/core": "^19.0.0 || ^20.0.0",
-        "@cdssnc/gcds-components": "^0.47.0"
+        "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0",
+        "@gcds-core/components": "^1.1.0"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/packages/web/specs/components.json
+++ b/packages/web/specs/components.json
@@ -5485,6 +5485,10 @@
         {
           "name": "slot",
           "text": "toggle - Slot to add a custom language toggle in the top-right of the header."
+        },
+        {
+          "name": "slot",
+          "text": "account - Slot to add a custom account link in the bottom-right of the header."
         }
       ],
       "usage": {},
@@ -5613,6 +5617,10 @@
       "listeners": [],
       "styles": [],
       "slots": [
+        {
+          "name": "account",
+          "docs": "Slot to add a custom account link in the bottom-right of the header."
+        },
         {
           "name": "banner",
           "docs": "Slot to add a banner across the top of the header."

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -172,7 +172,7 @@ export namespace Components {
      */
     interface GcdsCheckboxes {
         /**
-          * If true, the checkobox will be focused on component render
+          * If true, the checkbox will be focused on component render
          */
         "autofocus": boolean;
         /**
@@ -2527,7 +2527,7 @@ declare namespace LocalJSX {
      */
     interface GcdsCheckboxes {
         /**
-          * If true, the checkobox will be focused on component render
+          * If true, the checkbox will be focused on component render
          */
         "autofocus"?: boolean;
         /**

--- a/packages/web/src/components/gcds-header/gcds-header.css
+++ b/packages/web/src/components/gcds-header/gcds-header.css
@@ -14,11 +14,25 @@
   :host {
     margin: var(--gcds-header-margin) !important;
 
-    .gcds-header__container {
+    .gcds-header__container--menu {
+      width: 90%;
+      max-width: var(--gcds-header-container-max-width);
+      margin: 0 auto;
+      position: relative;
+
+      :is(slot[name='account']) {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+    }
+
+    .gcds-header__container--breadcrumbs {
       justify-content: space-between;
       width: 90%;
       max-width: var(--gcds-header-container-max-width);
       margin: 0 auto;
+      display: flex;
     }
 
     .gcds-header__skip-to-nav {
@@ -49,6 +63,23 @@
       This overrides the default top-nav width within header scope only.
     */
     --gcds-top-nav-width-full: var(--gcds-top-nav-width-constrained);
+
+    /*
+      Account button styles
+    */
+    :is(slot[name='account']) {
+      flex-shrink: 0;
+      margin-left: auto;
+      margin-top: var(--gcds-spacing-50);
+    }
+
+    & ::slotted(gcds-button[slot='account']) {
+      --gcds-button-border-radius: var(--gcds-spacing-0);
+      --gcds-button-font-desktop: var(--gcds-text-size-small-mobile);
+      --gcds-button-font-mobile: var(--gcds-text-size-small-mobile);
+      --gcds-button-mobile-margin: var(--gcds-spacing-0);
+      --gcds-button-padding: var(--gcds-spacing-100) var(--gcds-spacing-200);
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-header/gcds-header.tsx
+++ b/packages/web/src/components/gcds-header/gcds-header.tsx
@@ -21,6 +21,7 @@ import i18n from './i18n/i18n';
  * @slot skip-to-nav - Slot to add a hidden skip to content navigation at the top of the header.
  * @slot signature - Slot to replace Government of Canada signature.
  * @slot toggle - Slot to add a custom language toggle in the top-right of the header.
+ * @slot account - Slot to add a custom account link in the bottom-right of the header.
  */
 @Component({
   tag: 'gcds-header',
@@ -166,6 +167,14 @@ export class GcdsHeader {
     return !!this.el.querySelector('[slot="breadcrumb"]');
   }
 
+  private get hasAccount() {
+    return !!this.el.querySelector('[slot="account"]');
+  }
+
+  private get hasThemeTopicMenu() {
+    return !!this.el.querySelector('gcds-topic-menu[slot="menu"]');
+  }
+
   render() {
     const {
       renderSkipToNav,
@@ -175,6 +184,8 @@ export class GcdsHeader {
       hasSearch,
       hasBanner,
       hasBreadcrumb,
+      hasAccount,
+      hasThemeTopicMenu,
     } = this;
     return (
       <Host role="banner">
@@ -189,10 +200,18 @@ export class GcdsHeader {
             {renderSearch}
           </div>
         </div>
-        <slot name="menu"></slot>
-        {hasBreadcrumb ? (
-          <div class="gcds-header__container">
-            <slot name="breadcrumb"></slot>
+
+        {hasThemeTopicMenu ? (
+          <div class="gcds-header__container--menu">
+            <slot name="menu"></slot>
+            {hasAccount ? <slot name="account"></slot> : null}
+          </div>
+        ) : <slot name="menu"></slot>}
+
+        {hasBreadcrumb || (!hasBreadcrumb && !hasThemeTopicMenu && hasAccount) ? (
+          <div class="gcds-header__container--breadcrumbs">
+            {hasBreadcrumb ? <slot name="breadcrumb"></slot> : null}
+            {hasAccount && !hasThemeTopicMenu ? <slot name="account"></slot> : null}
           </div>
         ) : null}
       </Host>

--- a/packages/web/src/components/gcds-header/readme.md
+++ b/packages/web/src/components/gcds-header/readme.md
@@ -29,6 +29,7 @@ The header is the responsive Government of Canada branded header landmark.
 
 | Slot            | Description                                                               |
 | --------------- | ------------------------------------------------------------------------- |
+| `"account"`     | Slot to add a custom account link in the bottom-right of the header.      |
 | `"banner"`      | Slot to add a banner across the top of the header.                        |
 | `"breadcrumb"`  | Slot to add breadcrumbs at the bottom of the header.                      |
 | `"menu"`        | Slot to add a menu below the divider line.                                |

--- a/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
+++ b/packages/web/src/components/gcds-header/test/gcds-header.spec.tsx
@@ -61,6 +61,7 @@ describe('gcds-header', () => {
         <form slot="search"></form>
         <ul slot="menu"></ul>
         <ul slot="breadcrumbs"></ul>
+        <gcds-button slot="account" type="link" href="#">Sign In</gcds-button>
       </gcds-header>`,
     });
     expect(page.root).toEqualHtml(`
@@ -78,11 +79,17 @@ describe('gcds-header', () => {
             </div>
           </div>
           <slot name="menu"></slot>
+          <div class="gcds-header__container--breadcrumbs">
+            <slot name="account"></slot>
+          </div>
         </mock:shadow-root>
         <div slot="banner"></div>
         <form slot="search"></form>
         <ul slot="menu"></ul>
         <ul slot="breadcrumbs"></ul>
+        <gcds-button href="#" slot="account" type="link">
+          Sign In
+        </gcds-button>
       </gcds-header>
     `);
   });
@@ -99,6 +106,7 @@ describe('gcds-header', () => {
         <form slot="search"></form>
         <ul slot="menu"></ul>
         <ul slot="breadcrumbs"></ul>
+        <gcds-button slot="account" type="link" href="#">Sign In</gcds-button>
       </gcds-header>`,
     });
     expect(page.root).toEqualHtml(`
@@ -116,6 +124,9 @@ describe('gcds-header', () => {
             </div>
           </div>
           <slot name="menu"></slot>
+          <div class="gcds-header__container--breadcrumbs">
+            <slot name="account"></slot>
+          </div>
         </mock:shadow-root>
         <ul slot="skip-to-nav"></ul>
         <div slot="banner"></div>
@@ -126,6 +137,9 @@ describe('gcds-header', () => {
         <form slot="search"></form>
         <ul slot="menu"></ul>
         <ul slot="breadcrumbs"></ul>
+        <gcds-button href="#" slot="account" type="link">
+          Sign In
+        </gcds-button>
       </gcds-header>
     `);
   });

--- a/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
+++ b/packages/web/src/components/gcds-topic-menu/gcds-topic-menu.css
@@ -27,9 +27,6 @@
     }
 
     .gcds-topic-menu {
-      width: 90%;
-      max-width: var(--gcds-topic-menu-max-width);
-      margin-inline: auto;
       position: relative;
       font: var(--gcds-topic-menu-font);
 

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -50,7 +50,7 @@
 
       <!-- ------------- Top nav ------------- -->
 
-      <gcds-top-nav slot="menu" label="Top navigation" alignment="end">
+      <!-- <gcds-top-nav slot="menu" label="Top navigation" alignment="end">
         <gcds-nav-link href="#home" slot="home">Home</gcds-nav-link>
         <gcds-nav-link href="#">Nav link</gcds-nav-link>
 
@@ -65,7 +65,9 @@
         </gcds-nav-group>
 
         <gcds-nav-link href="#">Nav link</gcds-nav-link>
-      </gcds-top-nav>
+      </gcds-top-nav> -->
+
+      <gcds-topic-menu slot="menu"></gcds-topic-menu>
 
       <!-- ------------- Breadcrumbs ------------- -->
 
@@ -81,6 +83,9 @@
         <gcds-breadcrumbs-item href="#">Breadcrumb</gcds-breadcrumbs-item>
         <gcds-breadcrumbs-item href="#">Breadcrumb</gcds-breadcrumbs-item>
       </gcds-breadcrumbs> -->
+
+      <!-- ------------- Account ------------- -->
+      <gcds-button slot="account" type="link" href="#">Sign In</gcds-button>
     </gcds-header>
 
     <gcds-container layout="page" tag="main">


### PR DESCRIPTION
# Summary | Résumé

Adding option to include a Sign in link in the main header. The link has a customizable href and label.

# Test instructions | Instructions pour tester la modification

The sign in link should appear on the right, under the header border. If there is a Themes and Topics menu, the link should be to the right end of it. If no Themes and Topics menu, the link should next to the breadcrumbs.

# Notes

I was not sure how to handle the CSS changes considering you seem to use CSS variables for everything but those variables are located in another project. Let me know how I should proceed.
