### PR TITLE
Playwright - remove try catch and fix lint errors

### DIFF
--- a/packages/web/src/components/gcds-alert/test/gcds-alert.e2e.ts
+++ b/packages/web/src/components/gcds-alert/test/gcds-alert.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-alert', () => {
   test('renders', async ({ page }) => {
-    const alerts = await page.locator('gcds-alert');
+    const alerts = page.locator('gcds-alert');
     const count = await alerts.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/web/src/components/gcds-breadcrumbs-item/test/gcds-breadcrumbs-item.e2e.ts
+++ b/packages/web/src/components/gcds-breadcrumbs-item/test/gcds-breadcrumbs-item.e2e.ts
@@ -16,7 +16,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('gcds-breadcrumbs-item', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-breadcrumbs');
+    const element = page.locator('gcds-breadcrumbs');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -27,7 +27,7 @@ test.describe('gcds-breadcrumbs-item', () => {
     await expect(element).toHaveClass('hydrated');
 
     // Check first breadcrumb item role
-    const firstItem = await page.locator('gcds-breadcrumbs-item').first();
+    const firstItem = page.locator('gcds-breadcrumbs-item').first();
     await expect(firstItem).toHaveRole('listitem');
   });
 
@@ -35,7 +35,7 @@ test.describe('gcds-breadcrumbs-item', () => {
     const gcdsClick = await page.spyOnEvent('gcdsClick');
     const click = await page.spyOnEvent('click');
 
-    const element = await page.locator('gcds-breadcrumbs-item').last();
+    const element = page.locator('gcds-breadcrumbs-item').last();
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.e2e.ts
+++ b/packages/web/src/components/gcds-breadcrumbs/test/gcds-breadcrumbs.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-breadcrumbs', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-breadcrumbs');
+    const element = page.locator('gcds-breadcrumbs');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -16,7 +16,7 @@ test.describe('gcds-breadcrumbs', () => {
     await expect(element).toHaveClass('hydrated');
 
     // Check first breadcrumb item role
-    const firstItem = await page.locator('gcds-breadcrumbs-item').first();
+    const firstItem = page.locator('gcds-breadcrumbs-item').first();
     await expect(firstItem).toHaveRole('listitem');
   });
 });

--- a/packages/web/src/components/gcds-button/test/gcds-button.e2e.ts
+++ b/packages/web/src/components/gcds-button/test/gcds-button.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-button', () => {
   test('renders', async ({ page }) => {
-    const buttons = await page.locator('gcds-button');
+    const buttons = page.locator('gcds-button');
     const count = await buttons.count();
 
     for (let i = 0; i < count; i++) {
@@ -62,7 +62,7 @@ test.describe('gcds-button a11y tests', () => {
       .first()
       .evaluate(el => ((el as HTMLElement).innerText = 'Colour contrast'));
 
-    const buttons = await page.locator('button');
+    const buttons = page.locator('button');
 
     for (let i = 0; i < (await buttons.count()); i++) {
       buttons

--- a/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
+++ b/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-card', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-card');
+    const element = page.locator('gcds-card');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -50,9 +50,7 @@ test.describe('gcds-card a11y tests', () => {
   });
 
   test('Keyboard focus', async ({ page }) => {
-    const linkText = await (
-      await page.locator('.gcds-card__title')
-    ).innerText();
+    const linkText = await page.locator('.gcds-card__title').innerText();
 
     await page.keyboard.press('Tab');
 

--- a/packages/web/src/components/gcds-checkboxes/test/gcds-checkboxes.e2e.ts
+++ b/packages/web/src/components/gcds-checkboxes/test/gcds-checkboxes.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-checkboxes', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -19,7 +19,7 @@ test.describe('gcds-checkboxes', () => {
    * Events
    */
   test('Emit gcds custom events', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -43,7 +43,7 @@ test.describe('gcds-checkboxes', () => {
     expect(gcdsFocus).toHaveReceivedEvent();
   });
   test('Disabled - no events', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -71,7 +71,7 @@ test.describe('gcds-checkboxes', () => {
    * JS manipulation
    */
   test('Using JS - assign options', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -109,7 +109,7 @@ test.describe('gcds-checkboxes', () => {
     ).toBe('red');
   });
   test('Using JS - assign value', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -140,7 +140,7 @@ test.describe('gcds-checkboxes', () => {
    * Validation
    */
   test('Validation', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -168,7 +168,7 @@ test.describe('gcds-checkboxes', () => {
     expect(errorMessage).toEqual('');
   });
   test('Validation - custom validation', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -218,7 +218,7 @@ test.describe('gcds-checkboxes', () => {
     expect(errorMessage).toEqual('');
   });
   test('Validation - custom validation old format', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -266,7 +266,7 @@ test.describe('gcds-checkboxes', () => {
     expect(errorMessage).toEqual('');
   });
   test('HTML validity', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -316,7 +316,7 @@ test.describe('gcds-checkboxes a11y tests', () => {
     expect(results.violations).toHaveLength(0);
   });
   test('Proper labels - hidden label', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -345,7 +345,7 @@ test.describe('gcds-checkboxes a11y tests', () => {
    * Keyboard focus
    */
   test('Keyboard focus', async ({ page }) => {
-    const element = await page.locator('gcds-checkboxes');
+    const element = page.locator('gcds-checkboxes');
     await expect(element).toHaveClass('hydrated');
 
     await page.keyboard.press('Tab');

--- a/packages/web/src/components/gcds-date-input/test/gcds-date-input.e2e.ts
+++ b/packages/web/src/components/gcds-date-input/test/gcds-date-input.e2e.ts
@@ -7,7 +7,7 @@ import { dateInputErrorMessage } from '../../../validators/input-validators/inpu
 
 test.describe('gcds-date-input', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -21,7 +21,7 @@ test.describe('gcds-date-input', () => {
    * Value
    */
   test('Format: full - value', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -39,7 +39,7 @@ test.describe('gcds-date-input', () => {
     expect(value).toEqual('1234-03-11');
   });
   test('Format: compact - value', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -65,7 +65,7 @@ test.describe('gcds-date-input', () => {
    * Invalid value
    */
   test('Format: full - invalid value', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -83,7 +83,7 @@ test.describe('gcds-date-input', () => {
     expect(value).toEqual('12345-03-223');
   });
   test('Format: compact - invalid value', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -109,7 +109,7 @@ test.describe('gcds-date-input', () => {
    * Unset value
    */
   test('Format: full - unset value', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -137,7 +137,7 @@ test.describe('gcds-date-input', () => {
     expect(value).toEqual('');
   });
   test('Format: compact - unset value', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -173,7 +173,7 @@ test.describe('gcds-date-input', () => {
    * Validation
    */
   test('Validation - Missing all fields', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -189,7 +189,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.all);
   });
   test('Validation - Missing day', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -208,7 +208,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.missingday);
   });
   test('Validation - Missing year', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -227,7 +227,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.missingyear);
   });
   test('Validation - Missing month', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -246,7 +246,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.missingmonth);
   });
   test('Validation - Missing month and day', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -264,7 +264,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.missingmonthday);
   });
   test('Validation - Missing day and year', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -282,7 +282,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.missingdayyear);
   });
   test('Validation - Missing month and year', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -300,7 +300,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.missingmonthyear);
   });
   test('Validation - Year length', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -320,7 +320,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.invalidyearlength);
   });
   test('Validation - Invalid day', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -340,7 +340,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual(dateInputErrorMessage.en.invalidday);
   });
   test('Validation - Custom validation', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -391,7 +391,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual('');
   });
   test('Validation - Custom validation old format', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -445,7 +445,7 @@ test.describe('gcds-date-input', () => {
    * HTML validity
    */
   test('Format: full - valid validity', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -469,7 +469,7 @@ test.describe('gcds-date-input', () => {
     expect(validity).toEqual(true);
   });
   test('Format: compact - valid validity', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -498,7 +498,7 @@ test.describe('gcds-date-input', () => {
     expect(validity).toEqual(true);
   });
   test('Validation - min', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -522,7 +522,7 @@ test.describe('gcds-date-input', () => {
     expect(errorMessage).toEqual('Date must be on or after 2000-01-01.');
   });
   test('Validation - max', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -575,7 +575,7 @@ test.describe('gcds-date-input a11y tests', () => {
    * Keyboard focus
    */
   test('Keyboard focus', async ({ page }) => {
-    const element = await page.locator('gcds-date-input');
+    const element = page.locator('gcds-date-input');
     await expect(element).toHaveClass('hydrated');
 
     await page.keyboard.press('Tab');

--- a/packages/web/src/components/gcds-date-modified/test/gcds-date-modified.e2e.ts
+++ b/packages/web/src/components/gcds-date-modified/test/gcds-date-modified.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-date-modified', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-date-modified');
+    const element = page.locator('gcds-date-modified');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-details/test/gcds-details.e2e.ts
+++ b/packages/web/src/components/gcds-details/test/gcds-details.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-details', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-details');
+    const element = page.locator('gcds-details');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-error-message/test/gcds-error-message.e2e.ts
+++ b/packages/web/src/components/gcds-error-message/test/gcds-error-message.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-error-message', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-error-message');
+    const element = page.locator('gcds-error-message');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-error-summary/test/gcds-error-summary.e2e.ts
+++ b/packages/web/src/components/gcds-error-summary/test/gcds-error-summary.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-error-summary', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-error-summary');
+    const element = page.locator('gcds-error-summary');
 
     // Wait for element state
     await element.waitFor({ state: 'hidden' });
@@ -15,7 +15,7 @@ test.describe('gcds-error-summary', () => {
   });
 
   test('renders from listen', async ({ page }) => {
-    const form = await page.locator('form');
+    const form = page.locator('form');
     await form.waitFor({ state: 'hidden' });
 
     await form.evaluate(el => {
@@ -57,7 +57,7 @@ test.describe('gcds-error-summary', () => {
 
     await page.waitForChanges();
 
-    const submitButton = await page.locator('button[type="submit"]');
+    const submitButton = page.locator('button[type="submit"]');
     await submitButton.waitFor();
 
     await submitButton.click();
@@ -88,7 +88,7 @@ test.describe('gcds-error-summary a11y tests', () => {
    * Colour contrast test
    */
   test('colour contrast', async ({ page }) => {
-    const element = await page.locator('gcds-error-summary');
+    const element = page.locator('gcds-error-summary');
     await element.waitFor({ state: 'hidden' });
 
     element.evaluate(
@@ -108,7 +108,7 @@ test.describe('gcds-error-summary a11y tests', () => {
    * Links have discernible text
    */
   test('Link name', async ({ page }) => {
-    const form = await page.locator('form');
+    const form = page.locator('form');
     await form.waitFor({ state: 'hidden' });
 
     await form.evaluate(el => {
@@ -128,7 +128,7 @@ test.describe('gcds-error-summary a11y tests', () => {
 
     await page.waitForChanges();
 
-    const submitButton = await page.locator('button');
+    const submitButton = page.locator('button');
     await submitButton.waitFor();
 
     await submitButton.click();

--- a/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.e2e.ts
+++ b/packages/web/src/components/gcds-fieldset/test/gcds-fieldset.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-fieldset', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-fieldset');
+    const element = page.locator('gcds-fieldset');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 test.describe('gcds-file-uploader', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -17,7 +17,7 @@ test.describe('gcds-file-uploader', () => {
     await expect(element).toHaveClass('hydrated');
   });
   test('upload one file', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -28,7 +28,7 @@ test.describe('gcds-file-uploader', () => {
       './www/components/gcds-file-uploader/test/gcds-file-uploader.e2e.html',
     );
 
-    const fileInput = await page.locator('input[type="file"]');
+    const fileInput = page.locator('input[type="file"]');
 
     fileInput.setInputFiles(filePath);
 
@@ -41,14 +41,14 @@ test.describe('gcds-file-uploader', () => {
     ).toBe(1);
   });
   test('upload multiple file', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
     await element.waitFor({ state: 'visible' });
     await element.waitFor({ timeout: 10000 });
 
-    const fileInput = await page.locator('input[type="file"]');
+    const fileInput = page.locator('input[type="file"]');
 
     fileInput.setInputFiles([
       path.resolve(
@@ -68,7 +68,7 @@ test.describe('gcds-file-uploader', () => {
     ).toBe(2);
   });
   test('upload and remove file', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -79,7 +79,7 @@ test.describe('gcds-file-uploader', () => {
       './www/components/gcds-file-uploader/test/gcds-file-uploader.e2e.html',
     );
 
-    const fileInput = await page.locator('input[type="file"]');
+    const fileInput = page.locator('input[type="file"]');
 
     fileInput.setInputFiles(filePath);
 
@@ -102,7 +102,7 @@ test.describe('gcds-file-uploader', () => {
     ).toBe(0);
   });
   test('set files manually', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -131,7 +131,7 @@ test.describe('gcds-file-uploader', () => {
    * Validation
    */
   test('validation', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -152,7 +152,7 @@ test.describe('gcds-file-uploader', () => {
       './www/components/gcds-file-uploader/test/gcds-file-uploader.e2e.html',
     );
 
-    const fileInput = await page.locator('input[type="file"]');
+    const fileInput = page.locator('input[type="file"]');
 
     fileInput.setInputFiles(filePath);
 
@@ -169,7 +169,7 @@ test.describe('gcds-file-uploader', () => {
     expect(errorMessage).toEqual('');
   });
   test('validation - custom validation', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -198,7 +198,7 @@ test.describe('gcds-file-uploader', () => {
 
     await page.waitForChanges();
 
-    const fileInput = await page.locator('input[type="file"]');
+    const fileInput = page.locator('input[type="file"]');
 
     fileInput.setInputFiles(
       path.resolve(
@@ -239,7 +239,7 @@ test.describe('gcds-file-uploader', () => {
     expect(errorMessage).toEqual('');
   });
   test('validation - custom validation old format', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -267,7 +267,7 @@ test.describe('gcds-file-uploader', () => {
 
     await page.waitForChanges();
 
-    const fileInput = await page.locator('input[type="file"]');
+    const fileInput = page.locator('input[type="file"]');
 
     fileInput.setInputFiles(
       path.resolve(
@@ -309,7 +309,7 @@ test.describe('gcds-file-uploader', () => {
   });
 
   test('HTML validity', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -322,7 +322,7 @@ test.describe('gcds-file-uploader', () => {
 
     expect(validity).toBe(false);
 
-    const fileInput = await page.locator('input[type="file"]');
+    const fileInput = page.locator('input[type="file"]');
 
     fileInput.setInputFiles(
       path.resolve(
@@ -368,7 +368,7 @@ test.describe('gcds-file-uploader a11y tests', () => {
    * Keyboard focus
    */
   test('Keyboard focus', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
     await expect(element).toHaveClass('hydrated');
 
     const fileUploaderField = await page
@@ -388,7 +388,7 @@ test.describe('gcds-file-uploader a11y tests', () => {
    * Aria-invalid
    */
   test('aria-invalid', async ({ page }) => {
-    const element = await page.locator('gcds-file-uploader');
+    const element = page.locator('gcds-file-uploader');
     await expect(element).toHaveClass('hydrated');
 
     await element.evaluate(

--- a/packages/web/src/components/gcds-footer/test/gcds-footer.e2e.ts
+++ b/packages/web/src/components/gcds-footer/test/gcds-footer.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-footer', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-footer');
+    const element = page.locator('gcds-footer');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-header/test/gcds-header.e2e.ts
+++ b/packages/web/src/components/gcds-header/test/gcds-header.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-header', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-header');
+    const element = page.locator('gcds-header');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-heading/test/gcds-heading.e2e.ts
+++ b/packages/web/src/components/gcds-heading/test/gcds-heading.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-heading', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-heading');
+    const element = page.locator('gcds-heading');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-hint/test/gcds-hint.e2e.ts
+++ b/packages/web/src/components/gcds-hint/test/gcds-hint.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-hint', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-hint');
+    const element = page.locator('gcds-hint');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-icon/test/gcds-icon.e2e.ts
+++ b/packages/web/src/components/gcds-icon/test/gcds-icon.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-icon', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-icon');
+    const element = page.locator('gcds-icon');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -36,7 +36,7 @@ test.describe('gcds-icon a11y tests', () => {
    * Image alt text
    */
   test('Image alt text', async ({ page }) => {
-    const element = await page.locator('gcds-icon');
+    const element = page.locator('gcds-icon');
     await element.waitFor({ timeout: 10000 });
 
     await element.evaluate(

--- a/packages/web/src/components/gcds-input/test/gcds-input.e2e.ts
+++ b/packages/web/src/components/gcds-input/test/gcds-input.e2e.ts
@@ -7,7 +7,7 @@ import I18N from '../../../utils/i18n/i18n.js';
 
 test.describe('gcds-input', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -22,7 +22,7 @@ test.describe('gcds-input', () => {
    * Validation
    */
   test('Validation', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -49,7 +49,7 @@ test.describe('gcds-input', () => {
   });
 
   test('Validation - custom validation', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -105,7 +105,7 @@ test.describe('gcds-input', () => {
   });
 
   test('Validation - custom validation old format', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -164,7 +164,7 @@ test.describe('gcds-input', () => {
    * HTML attribute validation
    */
   test('HTML attribute validation - min/max', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -211,7 +211,7 @@ test.describe('gcds-input', () => {
   });
 
   test('HTML attribute validation - step', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -249,7 +249,7 @@ test.describe('gcds-input', () => {
   });
 
   test('HTML attribute validation - pattern', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -284,7 +284,7 @@ test.describe('gcds-input', () => {
   });
 
   test('HTML attribute validation - minlength', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -321,7 +321,7 @@ test.describe('gcds-input', () => {
   });
 
   test('HTML attribute validation - maxlength', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -364,7 +364,7 @@ test.describe('gcds-input', () => {
    * HTML validity
    */
   test('HTML validity', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -419,7 +419,7 @@ test.describe('gcds-input a11y tests', () => {
    * Aria-invalid true if error test
    */
   test('aria-invalid', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     await element.evaluate(el => {
       el.setAttribute('error-message', 'Field required');
@@ -444,7 +444,7 @@ test.describe('gcds-input a11y tests', () => {
    * Input keyboard focus
    */
   test('input keyboard focus', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
     await expect(element).toHaveClass('hydrated');
 
     const inputField = await page
@@ -465,7 +465,7 @@ test.describe('gcds-input a11y tests', () => {
    * Input label test
    */
   test('input contains label', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     await expect(element).toHaveClass('hydrated');
 
@@ -474,7 +474,7 @@ test.describe('gcds-input a11y tests', () => {
   });
 
   test('input has aria-labelledby for label', async ({ page }) => {
-    const element = await page.locator('gcds-input');
+    const element = page.locator('gcds-input');
 
     await expect(element).toHaveClass('hydrated');
 

--- a/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.e2e.ts
+++ b/packages/web/src/components/gcds-lang-toggle/test/gcds-lang-toggle.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-lang-toggle', () => {
   test('renders', async ({ page }) => {
-    const langToggles = await page.locator('gcds-lang-toggle');
+    const langToggles = page.locator('gcds-lang-toggle');
     const count = await langToggles.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/web/src/components/gcds-link/test/gcds-link.e2e.ts
+++ b/packages/web/src/components/gcds-link/test/gcds-link.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-link', () => {
   test('renders', async ({ page }) => {
-    const links = await page.locator('gcds-link');
+    const links = page.locator('gcds-link');
     const count = await links.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.e2e.ts
+++ b/packages/web/src/components/gcds-nav-group/test/gcds-nav-group.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-nav-group', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-nav-group');
+    const element = page.locator('gcds-nav-group');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -16,7 +16,7 @@ test.describe('gcds-nav-group', () => {
     await expect(element).toHaveClass('hydrated');
 
     // Check first nav link item role
-    const firstItem = await page.locator('gcds-nav-link').first();
+    const firstItem = page.locator('gcds-nav-link').first();
     await expect(firstItem).toHaveRole('listitem');
   });
 });

--- a/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.e2e.ts
+++ b/packages/web/src/components/gcds-nav-link/test/gcds-nav-link.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-nav-link', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-nav-link');
+    const element = page.locator('gcds-nav-link');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-notice/test/gcds-notice.e2e.ts
+++ b/packages/web/src/components/gcds-notice/test/gcds-notice.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-notice', () => {
   test('renders', async ({ page }) => {
-    const notices = await page.locator('gcds-notice');
+    const notices = page.locator('gcds-notice');
     const count = await notices.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/web/src/components/gcds-pagination/test/gcds-pagination.e2e.ts
+++ b/packages/web/src/components/gcds-pagination/test/gcds-pagination.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-pagination', () => {
   test('renders', async ({ page }) => {
-    const paginations = await page.locator('gcds-pagination');
+    const paginations = page.locator('gcds-pagination');
     const count = await paginations.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/web/src/components/gcds-phase-banner/test/gcds-phase-banner.e2e.ts
+++ b/packages/web/src/components/gcds-phase-banner/test/gcds-phase-banner.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-phase-banner', () => {
   test('renders', async ({ page }) => {
-    const banners = await page.locator('gcds-phase-banner');
+    const banners = page.locator('gcds-phase-banner');
     const count = await banners.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/web/src/components/gcds-radios/test/gcds-radios.e2e.ts
+++ b/packages/web/src/components/gcds-radios/test/gcds-radios.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-radios', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -19,7 +19,7 @@ test.describe('gcds-radios', () => {
    * Events
    */
   test('Emit gcds custom events', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -43,7 +43,7 @@ test.describe('gcds-radios', () => {
     expect(gcdsFocus).toHaveReceivedEvent();
   });
   test('Disabled - no events', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -71,7 +71,7 @@ test.describe('gcds-radios', () => {
    * JS manipulation
    */
   test('Using JS - assign options', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -109,7 +109,7 @@ test.describe('gcds-radios', () => {
     ).toBe('red');
   });
   test('Using JS - assign value', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -140,7 +140,7 @@ test.describe('gcds-radios', () => {
    * Validation
    */
   test('Validation', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -168,7 +168,7 @@ test.describe('gcds-radios', () => {
     expect(errorMessage).toEqual('');
   });
   test('Validation - custom validation', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -220,7 +220,7 @@ test.describe('gcds-radios', () => {
     expect(errorMessage).toEqual('');
   });
   test('Validation - custom validation old format', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -269,7 +269,7 @@ test.describe('gcds-radios', () => {
     expect(errorMessage).toEqual('');
   });
   test('HTML validity', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -322,7 +322,7 @@ test.describe('gcds-radios a11y tests', () => {
    * Keyboard focus
    */
   test('Keyboard focus', async ({ page }) => {
-    const element = await page.locator('gcds-radios');
+    const element = page.locator('gcds-radios');
     await expect(element).toHaveClass('hydrated');
 
     await page.keyboard.press('Tab');

--- a/packages/web/src/components/gcds-search/test/gcds-search.e2e.ts
+++ b/packages/web/src/components/gcds-search/test/gcds-search.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-search', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-search');
+    const element = page.locator('gcds-search');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-select/test/gcds-select.e2e.ts
+++ b/packages/web/src/components/gcds-select/test/gcds-select.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-select', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -20,7 +20,7 @@ test.describe('gcds-select', () => {
    * Validation
    */
   test('Validation', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -45,7 +45,7 @@ test.describe('gcds-select', () => {
   });
 
   test('Validation - custom validation', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
 
     // Wait for element to attach and become visible
     await element.waitFor({ state: 'attached' });
@@ -90,7 +90,7 @@ test.describe('gcds-select', () => {
   });
 
   test('Validation - custom validation (old format)', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
 
     // Wait for element to attach and become visible
     await element.waitFor({ state: 'attached' });
@@ -136,7 +136,7 @@ test.describe('gcds-select', () => {
   });
 
   test('HTML validity', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -169,7 +169,7 @@ test.describe('gcds-select a11y tests', () => {
    * Aria-invalid true if error test
    */
   test('aria-invalid', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
 
     await element.evaluate(el => {
       el.setAttribute('error-message', 'Field required');
@@ -194,7 +194,7 @@ test.describe('gcds-select a11y tests', () => {
    * Select keyboard focus
    */
   test('select keyboard focus', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
     await expect(element).toHaveClass('hydrated');
 
     const select = element.locator('select');
@@ -213,7 +213,7 @@ test.describe('gcds-select a11y tests', () => {
    * Select label test
    */
   test('select contains label', async ({ page }) => {
-    const element = await page.locator('gcds-select');
+    const element = page.locator('gcds-select');
 
     await expect(element).toHaveClass('hydrated');
 

--- a/packages/web/src/components/gcds-side-nav/test/gcds-side-nav.e2e.ts
+++ b/packages/web/src/components/gcds-side-nav/test/gcds-side-nav.e2e.ts
@@ -4,7 +4,7 @@ import { test, testMobile, testTablet } from '../../../../tests/base';
 
 test.describe('gcds-side-nav', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-side-nav');
+    const element = page.locator('gcds-side-nav');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -15,7 +15,7 @@ test.describe('gcds-side-nav', () => {
     await expect(element).toHaveClass('hydrated');
 
     // Check first nav link item role
-    const firstItem = await page.locator('gcds-nav-link').first();
+    const firstItem = page.locator('gcds-nav-link').first();
     await expect(firstItem).toHaveRole('listitem');
   });
 
@@ -56,7 +56,7 @@ test.describe('gcds-side-nav', () => {
   })
 
   test('keyboard controls', async ({ page }) => {
-    const element = await page.locator('gcds-side-nav');
+    const element = page.locator('gcds-side-nav');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-signature/test/gcds-signature.e2e.ts
+++ b/packages/web/src/components/gcds-signature/test/gcds-signature.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-signature', () => {
   test('renders', async ({ page }) => {
-    const signatures = await page.locator('gcds-signature');
+    const signatures = page.locator('gcds-signature');
     const count = await signatures.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.e2e.ts
+++ b/packages/web/src/components/gcds-sr-only/test/gcds-sr-only.e2e.ts
@@ -3,7 +3,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-sr-only', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-sr-only');
+    const element = page.locator('gcds-sr-only');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-stepper/test/gcds-stepper.e2e.ts
+++ b/packages/web/src/components/gcds-stepper/test/gcds-stepper.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-stepper', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-stepper');
+    const element = page.locator('gcds-stepper');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-text/test/gcds-text.e2e.ts
+++ b/packages/web/src/components/gcds-text/test/gcds-text.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-text', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-text');
+    const element = page.locator('gcds-text');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-textarea/test/gcds-textarea.e2e.ts
+++ b/packages/web/src/components/gcds-textarea/test/gcds-textarea.e2e.ts
@@ -7,7 +7,7 @@ import I18N from '../../../utils/i18n/i18n.js';
 
 test.describe('gcds-textarea', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -22,7 +22,7 @@ test.describe('gcds-textarea', () => {
    * Validation
    */
   test('Validation', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -49,7 +49,7 @@ test.describe('gcds-textarea', () => {
   });
 
   test('Validation - custom validation', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -104,7 +104,7 @@ test.describe('gcds-textarea', () => {
   });
 
   test('Validation - custom validation old format', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -160,7 +160,7 @@ test.describe('gcds-textarea', () => {
   });
 
   test('HTML attribute validation - minlength', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -199,7 +199,7 @@ test.describe('gcds-textarea', () => {
   test('HTML attribute validation - maxlength/character-count', async ({
     page,
   }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -249,7 +249,7 @@ test.describe('gcds-textarea a11y tests', () => {
    * Aria-invalid true if error test
    */
   test('aria-invalid', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     await element.evaluate(el => {
       el.setAttribute('error-message', 'Field required');
@@ -274,7 +274,7 @@ test.describe('gcds-textarea a11y tests', () => {
    * Textarea keyboard focus
    */
   test('textarea keyboard focus', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
     await expect(element).toHaveClass('hydrated');
 
     const textareaField = await page
@@ -295,7 +295,7 @@ test.describe('gcds-textarea a11y tests', () => {
    * Textarea label test
    */
   test('textarea contains label', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     await expect(element).toHaveClass('hydrated');
 
@@ -304,7 +304,7 @@ test.describe('gcds-textarea a11y tests', () => {
   });
 
   test('textarea has aria-labelledby for label', async ({ page }) => {
-    const element = await page.locator('gcds-textarea');
+    const element = page.locator('gcds-textarea');
 
     await expect(element).toHaveClass('hydrated');
 

--- a/packages/web/src/components/gcds-top-nav/test/gcds-top-nav.e2e.ts
+++ b/packages/web/src/components/gcds-top-nav/test/gcds-top-nav.e2e.ts
@@ -4,7 +4,7 @@ import { test, testMobile, testTablet } from '../../../../tests/base';
 
 test.describe('gcds-top-nav', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-top-nav');
+    const element = page.locator('gcds-top-nav');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });
@@ -52,7 +52,7 @@ test.describe('gcds-top-nav', () => {
   })
 
   test('keyboard controls', async ({ page }) => {
-    const element = await page.locator('gcds-top-nav');
+    const element = page.locator('gcds-top-nav');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-topic-menu/test/gcds-topic-menu.e2e.ts
+++ b/packages/web/src/components/gcds-topic-menu/test/gcds-topic-menu.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-topic-menu', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-topic-menu');
+    const element = page.locator('gcds-topic-menu');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });

--- a/packages/web/src/components/gcds-verify-banner/test/gcds-verify-banner.e2e.ts
+++ b/packages/web/src/components/gcds-verify-banner/test/gcds-verify-banner.e2e.ts
@@ -5,7 +5,7 @@ import { test } from '../../../../tests/base';
 
 test.describe('gcds-verify-banner', () => {
   test('renders', async ({ page }) => {
-    const element = await page.locator('gcds-verify-banner');
+    const element = page.locator('gcds-verify-banner');
 
     // Wait for element to attach and become visible, allowing up to 10s
     await element.waitFor({ state: 'attached' });


### PR DESCRIPTION
# Summary | Résumé

Removes try catch from playwright accessibility tests. If accessibility fails, then you'd want the test to fail too.
Makes a lot of lint fixes for #693 to be merged more smoothely (remove redundant awaits, use import instead of require)

# Test instructions | Instructions pour tester la modification

Run the playwright tests 😄 