### PR TITLE
fix(text-area): native html validation console errors

### DIFF
--- a/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
+++ b/packages/web/src/components/gcds-textarea/gcds-textarea.tsx
@@ -281,7 +281,7 @@ export class GcdsTextarea {
           `#textarea__sr-count-${this.textareaId}`,
         );
         if (srCount) {
-          srCount.textContent = `${i18n[this.lang].characters.left}${this.value == undefined ? this.maxlength : this.maxlength - this.value.length}`;
+          srCount.textContent = `${i18n[this.lang].characters.left}${this.value === undefined ? this.maxlength : this.maxlength - this.value.length}`;
         }
       }, 1500);
     }


### PR DESCRIPTION
# Summary | Résumé
- Fixes #1130 

## How to test
1. On `the-big-1` branch, go to either the react or vue `tests/app` folder
  `cd package/react/tests/app` or
  `cd package/vue/tests/app`
2. `npm install && npm run build`
4. `npm run dev`
5. Go to the Form Components page
6. Fillout the textarea, then tab or leave
7. See the error show up on the browser console
8. Checkout this branch/PR
9. Repeat steps 2-5
10. There are no more errors on the browser console