### PR TITLE
fix(gcds-nav-group): set correct alignment prop for top-nav in nav-group

### DIFF
--- a/packages/angular/src/lib/stencil-generated/components.ts
+++ b/packages/angular/src/lib/stencil-generated/components.ts
@@ -2294,7 +2294,7 @@ export class GcdsTextarea {
    */
   set form(_: Components.GcdsTextarea['form']) {};
     /**
-   * If true, character limt counter will not be displayed under the textarea. @default false
+   * If true, character limit counter will not be displayed under the textarea. @default false
    */
   set hideLimit(_: Components.GcdsTextarea['hideLimit']) {};
     /**

--- a/packages/web/src/components.d.ts
+++ b/packages/web/src/components.d.ts
@@ -1442,7 +1442,7 @@ export namespace Components {
          */
         "hideLabel"?: boolean;
         /**
-          * If true, character limt counter will not be displayed under the textarea.
+          * If true, character limit counter will not be displayed under the textarea.
           * @default false
          */
         "hideLimit"?: boolean;
@@ -3982,7 +3982,7 @@ declare namespace LocalJSX {
          */
         "hideLabel"?: boolean;
         /**
-          * If true, character limt counter will not be displayed under the textarea.
+          * If true, character limit counter will not be displayed under the textarea.
           * @default false
          */
         "hideLimit"?: boolean;

--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.tsx
@@ -168,7 +168,7 @@ export class GcdsNavGroup {
 
       // Get the alignment value from the parent + append the corresponding class
       const alignment = (this.el.parentNode as HTMLElement).getAttribute(
-        'align',
+        'alignment',
       );
 
       if (alignment === 'end') {

--- a/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
+++ b/packages/web/src/components/gcds-nav-group/stories/gcds-nav-group.stories.tsx
@@ -109,7 +109,7 @@ const Template = args =>
 const TemplateTopNav = args =>
   `
 <!-- Web component code (Angular, Vue) -->
-<gcds-top-nav label="Top nav example" alignment="right">
+<gcds-top-nav label="Top nav example" alignment="end">
   <gcds-nav-group
     menu-label="${args.menuLabel}"
     open-trigger="${args.openTrigger}"
@@ -124,7 +124,7 @@ const TemplateTopNav = args =>
 </gcds-top-nav>
 
 <!-- React code -->
-<GcdsTopNav label="Top nav example" alignment="right">
+<GcdsTopNav label="Top nav example" alignment="end">
   <GcdsNavGroup
     menuLabel="${args.menuLabel}"
     openTrigger="${args.openTrigger}"


### PR DESCRIPTION
# Summary | Résumé

Ensure the correct `alignment` property is grabbed within the `nav-group` component to set the correct dropdown for `nav-group` in the `top-nav`.

