### PR TITLE
chore(deps): update css shortcuts in test apps

### DIFF
--- a/packages/angular/tests/app/package-lock.json
+++ b/packages/angular/tests/app/package-lock.json
@@ -14,7 +14,7 @@
         "@angular/forms": "^20.1.0",
         "@angular/platform-browser": "^20.1.0",
         "@angular/router": "^20.1.0",
-        "@gcds-core/css-shortcuts": "^1.0.0",
+        "@gcds-core/css-shortcuts": "^1.1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
       },
@@ -36,7 +36,7 @@
     },
     "../../../web": {
       "name": "@gcds-core/components",
-      "version": "0.46.0",
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -53,8 +53,8 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
         "@bgotink/playwright-coverage": "^0.3.2",
-        "@cdssnc/gcds-tokens": "^2.13.1",
         "@gcds-core/fonts": "^1.0.0",
+        "@gcds-core/tokens": "^1.0.1",
         "@playwright/test": "^1.56.0",
         "@stencil/angular-outputtarget": "file:../../utils/angular-output-target",
         "@stencil/playwright": "^0.2.1",
@@ -98,7 +98,7 @@
     },
     "../../dist": {
       "name": "@cdssnc/gcds-components-angular",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -106,7 +106,7 @@
       "peerDependencies": {
         "@angular/common": "^19.0.0 || ^20.0.0",
         "@angular/core": "^19.0.0 || ^20.0.0",
-        "@cdssnc/gcds-components": "^0.46.0"
+        "@cdssnc/gcds-components": "^0.47.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -966,14 +966,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@cdssnc/gcds-components": {
-      "resolved": "../../../web",
-      "link": true
-    },
-    "node_modules/@cdssnc/gcds-components-angular": {
-      "resolved": "../../dist",
-      "link": true
-    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1426,10 +1418,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@gcds-core/components": {
+      "resolved": "../../../web",
+      "link": true
+    },
+    "node_modules/@gcds-core/components-angular": {
+      "resolved": "../../dist",
+      "link": true
+    },
     "node_modules/@gcds-core/css-shortcuts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gcds-core/css-shortcuts/-/css-shortcuts-1.0.0.tgz",
-      "integrity": "sha512-CBka74Q03OSNri4Uun24kn8rlNMlkm/6uIrGwxW8Olgs6/idkY7IQ0LjArYoG4d35iEyjGYXPjcVaXEfOJearw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gcds-core/css-shortcuts/-/css-shortcuts-1.1.0.tgz",
+      "integrity": "sha512-hG2+QYu+h0ndIGfvaOYRT0nOtYvMrb0SyYFbuVaq6gB/HkLnLcAOciLz9rixMw4nskwR0fN79EoTzd47q5X7Tw==",
       "license": "MIT"
     },
     "node_modules/@inquirer/ansi": {

--- a/packages/angular/tests/app/package.json
+++ b/packages/angular/tests/app/package.json
@@ -25,7 +25,7 @@
     "@angular/forms": "^20.1.0",
     "@angular/platform-browser": "^20.1.0",
     "@angular/router": "^20.1.0",
-    "@gcds-core/css-shortcuts": "^1.0.0",
+    "@gcds-core/css-shortcuts": "^1.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"
   },

--- a/packages/react/tests/app/package-lock.json
+++ b/packages/react/tests/app/package-lock.json
@@ -8,9 +8,9 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
-        "@cdssnc/gcds-components": "file:../../../web",
-        "@cdssnc/gcds-components-react": "file:../..",
-        "@gcds-core/css-shortcuts": "^1.0.0",
+        "@gcds-core/components": "file:../../../web",
+        "@gcds-core/components-react": "file:../..",
+        "@gcds-core/css-shortcuts": "^1.1.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.12.0"
@@ -31,11 +31,11 @@
       }
     },
     "../..": {
-      "name": "@cdssnc/gcds-components-react",
-      "version": "0.46.0",
+      "name": "@gcds-core/components-react",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cdssnc/gcds-components": "^0.46.0",
+        "@gcds-core/components": "^1.0.0",
         "@stencil/react-output-target": "^1.1.0"
       },
       "devDependencies": {
@@ -48,8 +48,8 @@
       }
     },
     "../../../web": {
-      "name": "@cdssnc/gcds-components",
-      "version": "0.46.0",
+      "name": "@gcds-core/components",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "4.35.1",
@@ -65,8 +65,8 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.21.0",
         "@bgotink/playwright-coverage": "^0.3.2",
-        "@cdssnc/gcds-tokens": "^2.13.1",
         "@gcds-core/fonts": "^1.0.0",
+        "@gcds-core/tokens": "^1.0.1",
         "@playwright/test": "^1.56.0",
         "@stencil/angular-outputtarget": "file:../../utils/angular-output-target",
         "@stencil/playwright": "^0.2.1",
@@ -389,14 +389,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@cdssnc/gcds-components": {
-      "resolved": "../../../web",
-      "link": true
-    },
-    "node_modules/@cdssnc/gcds-components-react": {
-      "resolved": "../..",
-      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.11",
@@ -997,10 +989,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@gcds-core/components": {
+      "resolved": "../../../web",
+      "link": true
+    },
+    "node_modules/@gcds-core/components-react": {
+      "resolved": "../..",
+      "link": true
+    },
     "node_modules/@gcds-core/css-shortcuts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gcds-core/css-shortcuts/-/css-shortcuts-1.0.0.tgz",
-      "integrity": "sha512-CBka74Q03OSNri4Uun24kn8rlNMlkm/6uIrGwxW8Olgs6/idkY7IQ0LjArYoG4d35iEyjGYXPjcVaXEfOJearw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gcds-core/css-shortcuts/-/css-shortcuts-1.1.0.tgz",
+      "integrity": "sha512-hG2+QYu+h0ndIGfvaOYRT0nOtYvMrb0SyYFbuVaq6gB/HkLnLcAOciLz9rixMw4nskwR0fN79EoTzd47q5X7Tw==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/packages/react/tests/app/package.json
+++ b/packages/react/tests/app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@gcds-core/components": "file:../../../web",
     "@gcds-core/components-react": "file:../..",
-    "@gcds-core/css-shortcuts": "^1.0.0",
+    "@gcds-core/css-shortcuts": "^1.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.12.0"

--- a/packages/vue/tests/app/package-lock.json
+++ b/packages/vue/tests/app/package-lock.json
@@ -8,8 +8,8 @@
       "name": "gc-design-system-components-vue-test-app",
       "version": "0.0.0",
       "dependencies": {
-        "@cdssnc/gcds-components-vue": "file:../../../vue",
-        "@cdssnc/gcds-utility": "^1.2.1",
+        "@gcds-core/components-vue": "file:../../../vue",
+        "@gcds-core/css-shortcuts": "^1.1.0",
         "vue": "^3.4.21",
         "vue-router": "^4.6.3"
       },
@@ -20,11 +20,11 @@
       }
     },
     "../..": {
-      "name": "@cdssnc/gcds-components-vue",
-      "version": "0.46.0",
+      "name": "@gcds-core/components-vue",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cdssnc/gcds-components": "^0.46.0",
+        "@gcds-core/components": "^1.0.0",
         "@stencil/vue-output-target": "^0.10.8"
       },
       "devDependencies": {
@@ -81,15 +81,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@cdssnc/gcds-components-vue": {
-      "resolved": "../..",
-      "link": true
-    },
-    "node_modules/@cdssnc/gcds-utility": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-utility/-/gcds-utility-1.2.1.tgz",
-      "integrity": "sha512-w/1zd+MS4UBSLD2OQyAj/B094KLL4Pwp9wYICMMHNlqUHLHLrpb4o+j6NfHP1jorR4/+88fPNV1Z+x3LV5IXdg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -458,6 +449,16 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@gcds-core/components-vue": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@gcds-core/css-shortcuts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gcds-core/css-shortcuts/-/css-shortcuts-1.1.0.tgz",
+      "integrity": "sha512-hG2+QYu+h0ndIGfvaOYRT0nOtYvMrb0SyYFbuVaq6gB/HkLnLcAOciLz9rixMw4nskwR0fN79EoTzd47q5X7Tw==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
@@ -1291,24 +1292,6 @@
         "@babel/helper-validator-identifier": "^7.27.1"
       }
     },
-    "@cdssnc/gcds-components-vue": {
-      "version": "file:../..",
-      "requires": {
-        "@cdssnc/gcds-components": "^0.46.0",
-        "@playwright/test": "^1.56.0",
-        "@stencil/vue-output-target": "^0.10.8",
-        "@types/node": "^20.14.2",
-        "@vitejs/plugin-vue": "^5.0.4",
-        "@vue/compiler-dom": "^3.4.26",
-        "@vue/server-renderer": "^3.4.27",
-        "vue": "^3.4.26"
-      }
-    },
-    "@cdssnc/gcds-utility": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-utility/-/gcds-utility-1.2.1.tgz",
-      "integrity": "sha512-w/1zd+MS4UBSLD2OQyAj/B094KLL4Pwp9wYICMMHNlqUHLHLrpb4o+j6NfHP1jorR4/+88fPNV1Z+x3LV5IXdg=="
-    },
     "@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -1469,6 +1452,24 @@
       "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "dev": true,
       "optional": true
+    },
+    "@gcds-core/components-vue": {
+      "version": "file:../..",
+      "requires": {
+        "@gcds-core/components": "^1.0.0",
+        "@playwright/test": "^1.56.0",
+        "@stencil/vue-output-target": "^0.10.8",
+        "@types/node": "^20.14.2",
+        "@vitejs/plugin-vue": "^5.0.4",
+        "@vue/compiler-dom": "^3.4.26",
+        "@vue/server-renderer": "^3.4.27",
+        "vue": "^3.4.26"
+      }
+    },
+    "@gcds-core/css-shortcuts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gcds-core/css-shortcuts/-/css-shortcuts-1.1.0.tgz",
+      "integrity": "sha512-hG2+QYu+h0ndIGfvaOYRT0nOtYvMrb0SyYFbuVaq6gB/HkLnLcAOciLz9rixMw4nskwR0fN79EoTzd47q5X7Tw=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.5",

--- a/packages/vue/tests/app/package.json
+++ b/packages/vue/tests/app/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@gcds-core/components-vue": "file:../../../vue",
-    "@gcds-core/css-shortcuts": "^1.0.1",
+    "@gcds-core/css-shortcuts": "^1.1.0",
     "vue": "^3.4.21",
     "vue-router": "^4.6.3"
   },


### PR DESCRIPTION
# Summary | Résumé

Update CSS Shortcuts to its latest version for the React, Vue & Angular test apps.