### PR TITLE
chore: update urls to new ones

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ GC Design System is committed to building a safe, welcoming, harassment-free cul
 
 Anyone can contribute to GC Design System. Whether it's submitting a bug, helping us with our “next priorities” or making requests, we welcome your ideas on how to improve GC Design System.
 
-First-time contributor? We’re here to help guide you through a successful contribution. We review all contributions before merging them into the GC Design System. Beyond pull requests, we’ve also created forms to ease with the submission of feature requests, contributions, and reporting bugs.  If you’re unsure about anything, don’t hesitate to [Contact us](https://design-system.alpha.canada.ca/en/contact/).
+First-time contributor? We’re here to help guide you through a successful contribution. We review all contributions before merging them into the GC Design System. Beyond pull requests, we’ve also created forms to ease with the submission of feature requests, contributions, and reporting bugs.  If you’re unsure about anything, don’t hesitate to [Contact us](https://design-system.canada.ca/en/contact/).
 
 #### Local installation
 
@@ -33,7 +33,7 @@ In the root directory, run `npm run build`. All five packages will be compiled.
 
 ### Submitting contributions to “next priorities”
 
-In the [Get Involved](https://design-system.alpha.canada.ca/en/get-involved/) page of our site, we'll be posting about our “next priorities”.  These will typically be the components or patterns that we’ve identified as priorities in our roadmap to work on next. Before developing them, we want to ensure that the community has an opportunity to submit contributions that can accelerate and inform design and delivery.
+In the [Get Involved](https://design-system.canada.ca/en/get-involved/) page of our site, we'll be posting about our “next priorities”.  These will typically be the components or patterns that we’ve identified as priorities in our roadmap to work on next. Before developing them, we want to ensure that the community has an opportunity to submit contributions that can accelerate and inform design and delivery.
 
 The types of contributions we'll be looking for:
 
@@ -47,7 +47,7 @@ Submit these contributions directly in [Github](https://github.com/cds-snc/gcds-
 
 ### Volunteer as a research participant for GC Design System
 
-We're always looking for new volunteers to help us continue to iterate and improve GC Design System. [Contact us](https://design-system.alpha.canada.ca/en/contact/) to sign up for usability and accessibility testing. You'll be added to our volunteer list and a GC Design System team member will reach out with opportunities to participate. 
+We're always looking for new volunteers to help us continue to iterate and improve GC Design System. [Contact us](https://design-system.canada.ca/en/contact/) to sign up for usability and accessibility testing. You'll be added to our volunteer list and a GC Design System team member will reach out with opportunities to participate. 
 
 ### Submitting bugs and issues 
 
@@ -75,7 +75,7 @@ Feel free to propose changes by creating [pull requests](https://docs.github.com
 
 If this is your first time using Github - follow these [instructions](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github) to create your account.  
 
-Github is our preferred channel for contributions. However, if you are having any difficulties or prefer to submit a contribution via a different channel, submit via our [Contact us](https://design-system.alpha.canada.ca/en/contact/) page.
+Github is our preferred channel for contributions. However, if you are having any difficulties or prefer to submit a contribution via a different channel, submit via our [Contact us](https://design-system.canada.ca/en/contact/) page.
 
 ### Security
 
@@ -133,7 +133,7 @@ Système de design GC s’engage à créer une culture sans harcèlement où rè
 
 Tout le monde peut contribuer à Système de design GC. Qu’il s’agisse de signaler un bogue, de nous aider vis-à-vis de nos « prochaines priorités » ou de faire des demandes, nous accueillons vos idées sur la façon d’améliorer Système de design GC.
 
-Vous contribuez pour la première fois? Nous sommes là pour vous guider dans la réussite de votre contribution. Nous examinons toutes les contributions avant de les fusionner dans Système de design GC. En plus de faire des demandes de tirage (pull requests), vous pouvez utiliser les formulaires que nous avons créés pour faciliter la soumission des demandes de fonctionnalités, des contributions et des rapports de bogue. Si vous doutez de la manière de vous y prendre, n’hésitez pas à [nous contacter](https://systeme-design.alpha.canada.ca/fr/contactez/).
+Vous contribuez pour la première fois? Nous sommes là pour vous guider dans la réussite de votre contribution. Nous examinons toutes les contributions avant de les fusionner dans Système de design GC. En plus de faire des demandes de tirage (pull requests), vous pouvez utiliser les formulaires que nous avons créés pour faciliter la soumission des demandes de fonctionnalités, des contributions et des rapports de bogue. Si vous doutez de la manière de vous y prendre, n’hésitez pas à [nous contacter](https://systeme-design.canada.ca/fr/contactez/).
 
 ## Installation locale
 
@@ -151,7 +151,7 @@ Dans le répertoire racine, exécutez `npm run build`. Les cinq paquets seront a
 
 ### Contribuer aux « prochaines priorités »
 
-Nous publions la nature de nos « prochaines priorités » dans la page [« S’impliquer »](https://systeme-design.alpha.canada.ca/fr/simpliquer/) de notre site Web. Il s’agit généralement des composants ou des modèles que nous avons marqués comme prioritaires dans notre feuille de route. Avant de les développer, nous voulons nous assurer que la communauté a la possibilité de soumettre des contributions qui peuvent en accélérer et en éclairer la conception et la mise en œuvre. 
+Nous publions la nature de nos « prochaines priorités » dans la page [« S’impliquer »](https://systeme-design.canada.ca/fr/simpliquer/) de notre site Web. Il s’agit généralement des composants ou des modèles que nous avons marqués comme prioritaires dans notre feuille de route. Avant de les développer, nous voulons nous assurer que la communauté a la possibilité de soumettre des contributions qui peuvent en accélérer et en éclairer la conception et la mise en œuvre. 
 
 Voici les types de contribution que nous recherchons :
 
@@ -165,7 +165,7 @@ Soumettez ces contributions directement dans [Github](https://github.com/cds-snc
 
 ### Se porter volontaire pour participer à nos études
 
-Nous sommes toujours à la recherche de nouvelles personnes pour nous aider à continuer d’itérer et d’améliorer Système de design GC. [Contactez-nous](https://systeme-design.alpha.canada.ca/fr/contactez/) pour vous inscrire aux tests d’utilisabilité et d’accessibilité. Vous faites désormais partie de notre liste de volontaires. Un membre de l’équipe de Système de design GC vous contactera lorsqu’une occasion de participer se présentera. 
+Nous sommes toujours à la recherche de nouvelles personnes pour nous aider à continuer d’itérer et d’améliorer Système de design GC. [Contactez-nous](https://systeme-design.canada.ca/fr/contactez/) pour vous inscrire aux tests d’utilisabilité et d’accessibilité. Vous faites désormais partie de notre liste de volontaires. Un membre de l’équipe de Système de design GC vous contactera lorsqu’une occasion de participer se présentera. 
 
 ### Rapporter des bogues et des problèmes 
 
@@ -193,7 +193,7 @@ N’hésitez pas à proposer des modifications en créant une [demande de tirage
 
 Si c’est la première fois que vous utilisez GitHub, suivez ces [instructions](https://docs.github.com/fr/get-started/start-your-journey/creating-an-account-on-github) pour créer votre compte. 
 
-GitHub est le canal que nous préférons pour les contributions. Cependant, si vous rencontrez des difficultés ou préférez soumettre une contribution via un autre canal, utilisez notre page [Contactez-nous](https://systeme-design.alpha.canada.ca/fr/contactez/).
+GitHub est le canal que nous préférons pour les contributions. Cependant, si vous rencontrez des difficultés ou préférez soumettre une contribution via un autre canal, utilisez notre page [Contactez-nous](https://systeme-design.canada.ca/fr/contactez/).
 
 
 ### Sécurité

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We are using [Stencil.js](https://stenciljs.com/) to build our web components.
 
 ## Documentation
 
-You can find the full documentation for GC Design System Components on [https://design-system.alpha.canada.ca/](https://design-system.alpha.canada.ca/).
+You can find the full documentation for GC Design System Components on [https://design-system.canada.ca/](https://design-system.canada.ca/).
 
 
 
@@ -49,7 +49,7 @@ Nous utilisons [Stencil.js](https://stenciljs.com/) pour créer nos composants W
 
 ## Documentation
 
-Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.alpha.canada.ca/](https://systeme-design.alpha.canada.ca/).
+Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.canada.ca/](https://systeme-design.canada.ca/).
 
 ## Paquets
 

--- a/archived/CHANGELOG.md
+++ b/archived/CHANGELOG.md
@@ -1078,7 +1078,7 @@ We’re dropping support for the `footer` slot (`slot="footer"`). We’re removi
 
 **New (required)**: The stepper will now require text or an element passed into the `slot` to display the heading element. It’s a required property and the component will not render without it.
 
-If you experience issues with the change, ‌‌[contact us](https://design-system.alpha.canada.ca/en/contact/).
+If you experience issues with the change, ‌‌[contact us](https://design-system.canada.ca/en/contact/).
 
 ##### Old implementation
 
@@ -2026,7 +2026,7 @@ Arrêt du support pour (`slot="footer"`) car nous n'avons pas observé d'utilit�
 
 **Nouveau (obligatoire)**: Le composant requiert maintenant du texte ou un élément dans le `slot` afin d'afficher l'élément d'en-tête. C'est une propriété obligatoire et le composant ne sera pas généré sans elle.
 
-Si vous avez des problèmes avec le changement, ‌‌[contactez-nous](https://design-system.alpha.canada.ca/en/contact/).
+Si vous avez des problèmes avec le changement, ‌‌[contactez-nous](https://design-system.canada.ca/en/contact/).
 
 ##### Vieille implémentation
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -10,7 +10,7 @@ The web components inherit native properties and interoperability.
 
 ## Documentation
 
-You can find the full documentation for GC Design System Components on [https://design-system.alpha.canada.ca/](https://design-system.alpha.canada.ca/).
+You can find the full documentation for GC Design System Components on [https://design-system.canada.ca/](https://design-system.canada.ca/).
 
 ## Angular installation instructions
 
@@ -53,7 +53,7 @@ Place the following code in the `styles.scss` file of your app to import GC Desi
 
 ### 3. Start building
 
-Once you've installed the design system, start building! Browse our available [components](https://design-system.alpha.canada.ca/en/components/) and [templates](https://design-system.alpha.canada.ca/en/page-templates/) to pull the code you need into your project.
+Once you've installed the design system, start building! Browse our available [components](https://design-system.canada.ca/en/components/) and [templates](https://design-system.canada.ca/en/page-templates/) to pull the code you need into your project.
 
 ## Using GC Design System components with `RouterLink`
 
@@ -103,7 +103,7 @@ Les composants Web héritent les propriétés et l'interopérabilité natives.
 
 ## Documentation
 
-Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.alpha.canada.ca/](https://systeme-design.alpha.canada.ca/).
+Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.canada.ca/](https://systeme-design.canada.ca/).
 
 ## Instructions d’installation dans Angular
 
@@ -147,7 +147,7 @@ Pour importer les styles de Système de design GC, insérez le code suivant dans
 
 ### 3. Commencez à créer
 
-Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.alpha.canada.ca/fr/composants/) et [modèles](https://systeme-design.alpha.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
+Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.canada.ca/fr/composants/) et [modèles](https://systeme-design.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
 
 ## Utilisation des composants du Système de design GC avec `RouterLink`
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Angular wrapper for gcds-components",
-  "homepage": "https://design-system.alpha.canada.ca/",
+  "homepage": "https://design-system.canada.ca/",
   "bugs": {
     "url": "https://github.com/cds-snc/gcds-components/issues"
   },

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,7 +10,7 @@ The web components inherit native properties and interoperability.
 
 ## Documentation
 
-You can find the full documentation for GC Design System Components on [https://design-system.alpha.canada.ca/](https://design-system.alpha.canada.ca/).
+You can find the full documentation for GC Design System Components on [https://design-system.canada.ca/](https://design-system.canada.ca/).
 
 ## React installation instructions
 
@@ -34,7 +34,7 @@ import '@gcds-core/components-react/gcds.css';
 
 ### 3. Start building
 
-Once you've installed the design system, start building! Browse our available [components](https://design-system.alpha.canada.ca/en/components/) and [templates](https://design-system.alpha.canada.ca/en/page-templates/) to pull the code you need into your project.
+Once you've installed the design system, start building! Browse our available [components](https://design-system.canada.ca/en/components/) and [templates](https://design-system.canada.ca/en/page-templates/) to pull the code you need into your project.
 
 ## How to contribute
 
@@ -56,7 +56,7 @@ Les composants Web héritent les propriétés et l’interopérabilité natives.
 
 ## Documentation
 
-Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.alpha.canada.ca/](https://systeme-design.alpha.canada.ca/).
+Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.canada.ca/](https://systeme-design.canada.ca/).
 
 ## Instructions d’installation dans React
 
@@ -80,7 +80,7 @@ import '@gcds-core/components-react/gcds.css';
 
 ### 3. Commencez à créer
 
-Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.alpha.canada.ca/fr/composants/) et [modèles](https://systeme-design.alpha.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
+Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.canada.ca/fr/composants/) et [modèles](https://systeme-design.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
 
 ## Apportez votre contribution
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "React wrapper for gcds-components",
-  "homepage": "https://design-system.alpha.canada.ca/",
+  "homepage": "https://design-system.canada.ca/",
   "bugs": {
     "url": "https://github.com/cds-snc/gcds-components/issues"
   },

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -10,7 +10,7 @@ The web components inherit native properties and interoperability.
 
 ## Documentation
 
-You can find the full documentation for GC Design System Components on [https://design-system.alpha.canada.ca/](https://design-system.alpha.canada.ca/).
+You can find the full documentation for GC Design System Components on [https://design-system.canada.ca/](https://design-system.canada.ca/).
 
 ## Vue installation instructions
 
@@ -58,7 +58,7 @@ b. Import the styles to your `App.vue` using the HTML style tag:
 
 ### 4. Start building
 
-Once you've installed the design system, start building! Browse our available [components](https://design-system.alpha.canada.ca/en/components/) and [templates](https://design-system.alpha.canada.ca/en/page-templates/) to pull the code you need into your project.
+Once you've installed the design system, start building! Browse our available [components](https://design-system.canada.ca/en/components/) and [templates](https://design-system.canada.ca/en/page-templates/) to pull the code you need into your project.
 
 ## Using Vite
 
@@ -99,7 +99,7 @@ Les composants Web héritent les propriétés et l’interopérabilité natives.
 
 ## Documentation
 
-Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.alpha.canada.ca/](https://systeme-design.alpha.canada.ca/).
+Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.canada.ca/](https://systeme-design.canada.ca/).
 
 ## Instructions d’installation dans Vue
 
@@ -147,7 +147,7 @@ b. Importez les styles dans fichier `App.vue` en utilisant la balise HTML `style
 
 ### 4. Commencez à créer
 
-Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.alpha.canada.ca/fr/composants/) et [modèles](https://systeme-design.alpha.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
+Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.canada.ca/fr/composants/) et [modèles](https://systeme-design.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
 
 ## Utilisation de Vite
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Vue wrapper for GC Design System components",
   "author": "Government of Canada / Gouvernement du Canada",
-  "homepage": "https://design-system.alpha.canada.ca/",
+  "homepage": "https://design-system.canada.ca/",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/vue/tests/app/index.html
+++ b/packages/vue/tests/app/index.html
@@ -14,7 +14,7 @@
     <!-- GC Design System Utility -->
     <link
       rel="stylesheet"
-      href="https://cdn.design-system.alpha.canada.ca/@gcds-core/css-shortcuts@latest/dist/gcds-css-shortcuts.min.css"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@latest/dist/gcds-css-shortcuts.min.css"
     />
   </head>
   <body>

--- a/packages/web/.storybook/manager-head.html
+++ b/packages/web/.storybook/manager-head.html
@@ -1,7 +1,7 @@
 <!-- Load GCDS tokens -->
 <link
   rel="stylesheet"
-  href="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@latest/dist/gcds/gcds.css"
+  href="https://cdn.design-system.canada.ca/@gcds-core/components@latest/dist/gcds/gcds.css"
 />
 <style>
   /* ----- SIDEBAR ----- */

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -13,11 +13,11 @@ Use this option for:
 - Svelte
 - .NET
 
-If you’re using React, Angular, or Vue frameworks, browse the [installation page](https://design-system.alpha.canada.ca/en/get-started/develop/) for framework-specific options.
+If you’re using React, Angular, or Vue frameworks, browse the [installation page](https://design-system.canada.ca/en/get-started/develop/) for framework-specific options.
 
 ## Documentation
 
-You can find the full documentation for GC Design System Components on [https://design-system.alpha.canada.ca/](https://design-system.alpha.canada.ca/).
+You can find the full documentation for GC Design System Components on [https://design-system.canada.ca/](https://design-system.canada.ca/).
 
 ## Npm installation instructions
 
@@ -47,7 +47,7 @@ Add the following `link` tags inside the `head` tag of your `HTML` files to load
 
 ### 3. Start building
 
-Once you've installed the design system, start building! Browse our available [components](https://design-system.alpha.canada.ca/en/components/) and [templates](https://design-system.alpha.canada.ca/en/page-templates/) to pull the code you need into your project.
+Once you've installed the design system, start building! Browse our available [components](https://design-system.canada.ca/en/components/) and [templates](https://design-system.canada.ca/en/page-templates/) to pull the code you need into your project.
 
 ## CDN installation instructions
 
@@ -70,11 +70,11 @@ Add the following code to the `head` tag of your `HTML` files to load GC Design 
 <!-- GC Design System -->
 <link
   rel="stylesheet"
-  href="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+  href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
 />
 <script
   type="module"
-  src="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+  src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
 ></script>
 ```
 
@@ -94,7 +94,7 @@ While it removes the need to manually update versions, it adds the risk of intro
 
 ### 2. Start building
 
-Once you've installed the design system, start building! Browse our available [components](https://design-system.alpha.canada.ca/en/components/) and [templates](https://design-system.alpha.canada.ca/en/page-templates/) to pull the code you need into your project.
+Once you've installed the design system, start building! Browse our available [components](https://design-system.canada.ca/en/components/) and [templates](https://design-system.canada.ca/en/page-templates/) to pull the code you need into your project.
 
 ## Supported frameworks
 
@@ -135,11 +135,11 @@ Utilisez cette option pour les situations suivantes :
 - Svelte
 - .NET
 
-Si vous utilisez les cadres React, Angular ou Vue, consultez la [page d’installation](https://systeme-design.alpha.canada.ca/fr/demarrer/developpement/) pour connaître les options propres à chaque cadre.
+Si vous utilisez les cadres React, Angular ou Vue, consultez la [page d’installation](https://systeme-design.canada.ca/fr/demarrer/developpement/) pour connaître les options propres à chaque cadre.
 
 ## Documentation
 
-Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.alpha.canada.ca/](https://systeme-design.alpha.canada.ca/).
+Toute la documentation sur les composants de Système de design GC est accessible à l’adresse [https://systeme-design.canada.ca/](https://systeme-design.canada.ca/).
 
 ## Instructions d’installation avec npm
 
@@ -169,7 +169,7 @@ Ajoutez les balises `link` suivantes à l’intérieur de la balise `head` de vo
 
 ### 3. Commencez à créer
 
-Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.alpha.canada.ca/fr/composants/) et [modèles](https://systeme-design.alpha.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
+Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.canada.ca/fr/composants/) et [modèles](https://systeme-design.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
 
 ## Instructions d’installation avec CDN
 
@@ -192,11 +192,11 @@ Ajoutez le code suivant à la balise `head` de vos fichiers `HTML` pour charger 
 <!-- GC Système de design -->
 <link
   rel="stylesheet"
-  href="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
+  href="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.css"
 />
 <script
   type="module"
-  src="https://cdn.design-system.alpha.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
+  src="https://cdn.design-system.canada.ca/@gcds-core/components@<version-number>/dist/gcds/gcds.esm.js"
 ></script>
 ```
 
@@ -216,7 +216,7 @@ Bien que cette approche vous évite la mise à jour manuelle des versions, elle 
 
 ### 2. Commencez à créer
 
-Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.alpha.canada.ca/fr/composants/) et [modèles](https://systeme-design.alpha.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
+Une fois le système de design installé, commencez à créer! Parcourez nos [composants](https://systeme-design.canada.ca/fr/composants/) et [modèles](https://systeme-design.canada.ca/fr/modeles-de-page/) pour y trouver le code dont vous avez besoin pour votre projet.
 
 ## Cadres d'application pris en charge
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "author": "Government of Canada / Gouvernement du Canada",
   "description": "Web components for the GCDS",
-  "homepage": "https://design-system.alpha.canada.ca/",
+  "homepage": "https://design-system.canada.ca/",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",

--- a/packages/web/src/assets/css/global.css
+++ b/packages/web/src/assets/css/global.css
@@ -8,9 +8,9 @@
 @font-face {
   font-family: 'gcds-icons';
   src:
-    url('https://cdn.design-system.alpha.canada.ca/@gcds-core/fonts@1.0.0/icons/gcds-icons.ttf')
+    url('https://cdn.design-system.canada.ca/@gcds-core/fonts@1.0.0/icons/gcds-icons.ttf')
       format('truetype'),
-    url('https://cdn.design-system.alpha.canada.ca/@gcds-core/fonts@1.0.0/icons/gcds-icons.woff')
+    url('https://cdn.design-system.canada.ca/@gcds-core/fonts@1.0.0/icons/gcds-icons.woff')
       format('woff');
   font-weight: normal;
   font-style: normal;

--- a/packages/web/src/components/gcds-card/stories/overview.mdx
+++ b/packages/web/src/components/gcds-card/stories/overview.mdx
@@ -50,7 +50,7 @@ A card is a box containing structured, actionable content on a single topic.
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/card/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/card/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-card" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-checkboxes/stories/overview.mdx
+++ b/packages/web/src/components/gcds-checkboxes/stories/overview.mdx
@@ -88,7 +88,7 @@ A checkbox is a set of options for one or multiple selections.
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/checkboxes/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/checkboxes/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-checkboxes" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-container/stories/overview.mdx
+++ b/packages/web/src/components/gcds-container/stories/overview.mdx
@@ -82,7 +82,7 @@ When set to `page`, the container uses a max width of 1140px and switches to 90%
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/container/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/container/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/develop/packages/web/src/components/gcds-container" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-date-input/stories/overview.mdx
+++ b/packages/web/src/components/gcds-date-input/stories/overview.mdx
@@ -83,7 +83,7 @@ A date input is a space to enter a known date.
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/date-input/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/date-input/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-date-input" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-file-uploader/stories/overview.mdx
+++ b/packages/web/src/components/gcds-file-uploader/stories/overview.mdx
@@ -94,7 +94,7 @@ By default all file formats are allowed.
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/file-uploader/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/file-uploader/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-file-uploader" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-grid/stories/overview.mdx
+++ b/packages/web/src/components/gcds-grid/stories/overview.mdx
@@ -108,7 +108,7 @@ Defines the grid's alignment if the grid containers size is smaller than the par
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/Grid/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/Grid/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/develop/packages/web/src/components/gcds-grid" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-heading/stories/overview.mdx
+++ b/packages/web/src/components/gcds-heading/stories/overview.mdx
@@ -60,7 +60,7 @@ A title that structures content by creating levels of hierarchy that organize pa
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/heading" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/heading" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-heading" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-input/stories/overview.mdx
+++ b/packages/web/src/components/gcds-input/stories/overview.mdx
@@ -114,7 +114,7 @@ An input is a space to enter short-form information in response to a question or
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/Input/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/Input/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-input" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
+++ b/packages/web/src/components/gcds-link/stories/gcds-link.stories.js
@@ -208,7 +208,7 @@ Default.args = {
 export const External = Template.bind({});
 External.args = {
   display: 'inline',
-  href: 'http://design-system.alpha.canada.ca',
+  href: 'http://design-system.canada.ca',
   linkRole: 'default',
   rel: '',
   target: '_blank',

--- a/packages/web/src/components/gcds-link/stories/overview.mdx
+++ b/packages/web/src/components/gcds-link/stories/overview.mdx
@@ -60,7 +60,7 @@ A navigational element that allows users to navigate to a new page, website or s
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/link/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/link/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-link" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-notice/stories/overview.mdx
+++ b/packages/web/src/components/gcds-notice/stories/overview.mdx
@@ -7,7 +7,7 @@ import * as Notice from './gcds-notice.stories';
 
 _Also called: Contextual alert_
 
-The notice is a prominent message to draw attention to important information or change. 
+The notice is a prominent message to draw attention to important information or change.
 
 <Canvas of={Notice.Default} story={{ inline: true }} />
 
@@ -56,7 +56,7 @@ The notice is a prominent message to draw attention to important information or 
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/notice/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/notice/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-notice" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-radios/stories/overview.mdx
+++ b/packages/web/src/components/gcds-radios/stories/overview.mdx
@@ -62,7 +62,7 @@ A radio is a set of options for a single selection.
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/radios/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/radios/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-radios" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-select/stories/overview.mdx
+++ b/packages/web/src/components/gcds-select/stories/overview.mdx
@@ -58,7 +58,7 @@ A list of options with a single-option choice.
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/select/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/select/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-select" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-textarea/stories/overview.mdx
+++ b/packages/web/src/components/gcds-textarea/stories/overview.mdx
@@ -58,7 +58,7 @@ A text area is a space to enter long-form information in response to a question 
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/textarea/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/textarea/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-textarea" target="_blank">Github</gcds-link>

--- a/packages/web/src/components/gcds-top-nav/stories/overview.mdx
+++ b/packages/web/src/components/gcds-top-nav/stories/overview.mdx
@@ -36,7 +36,7 @@ A top navigation is a horizontal list of page links.
 {/* prettier-ignore */}
 <ul className="resources-list">
   <li>
-    <gcds-link size="regular" href="https://design-system.alpha.canada.ca/en/components/top-navigation/" target="_blank">Guidance</gcds-link>
+    <gcds-link size="regular" href="https://design-system.canada.ca/en/components/top-navigation/" target="_blank">Guidance</gcds-link>
   </li>
   <li>
     <gcds-link size="regular" href="https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-top-nav" target="_blank">Github</gcds-link>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -11,7 +11,7 @@
     <!-- GC Design System CSS Shortcuts -->
     <link
       rel="stylesheet"
-      href="https://cdn.design-system.alpha.canada.ca/@gcds-core/css-shortcuts@latest/dist/gcds-css-shortcuts.min.css"
+      href="https://cdn.design-system.canada.ca/@gcds-core/css-shortcuts@latest/dist/gcds-css-shortcuts.min.css"
     />
 
     <!-- Local components -->


### PR DESCRIPTION
# Summary | Résumé
Updates all the alpha URLs to use the new non-alpha URLs.
Also updates the CDN URLs in the installation instructions to the non-alpha ones.