### PR TITLE
chore: add CODEOWNERS for our team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Users that are allowed to approve PRs
+* @cds-snc/ds-dev


### PR DESCRIPTION
# 📝 Summary | Résumé

Update the CODEOWNERS rules so that only the GCDS Dev team can approve PRs.


## 🧩 Related Issues | Cartes liées
- https://github.com/cds-snc/design-gc-conception/issues/2270

## 🧪 Test instructions | Instructions pour tester la modification
Can't test until the PR is merged
After the PR is merged, check if people who don't belong to the team listed in the CODEOWNERS file are able to approve PRs

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [x] This PR does not introduce any changes to component names, properties, values, or behaviour.

**Ready for review: (all items must be checked)**
There are no product code changes for this code, so I left this section out
