### PR TITLE
fix(gcds-link): prevent external link icon from wrapping onto a new line

### DIFF
--- a/packages/web/src/components/gcds-link/gcds-link.css
+++ b/packages/web/src/components/gcds-link/gcds-link.css
@@ -19,6 +19,10 @@
     text-decoration-thickness: var(--gcds-link-decoration-thickness);
     text-underline-offset: var(--gcds-link-underline-offset);
     transition: all 0.35s;
+
+    .text-icon-group {
+      white-space: nowrap;
+    }
   }
 }
 

--- a/packages/web/src/components/gcds-link/gcds-link.tsx
+++ b/packages/web/src/components/gcds-link/gcds-link.tsx
@@ -158,10 +158,36 @@ export class GcdsLink {
     this.updateLang();
   }
 
+  /**
+   * Returns the correct icon for the link, if applicable.
+   * If none of these conditions match, no icon is rendered.
+   */
+  private getIcon() {
+    const { href, target, external, download, lang } = this;
+    const isExternal = target === '_blank' || external;
+
+    if (isExternal) {
+      return <gcds-icon name="external" label={i18n[lang].external} />;
+    }
+
+    if (download !== undefined) {
+      return <gcds-icon name="download" label={i18n[lang].download} />;
+    }
+
+    if (href?.toLowerCase().startsWith('mailto:')) {
+      return <gcds-icon name="email" label={i18n[lang].email} />;
+    }
+
+    if (href?.toLowerCase().startsWith('tel:')) {
+      return <gcds-icon name="phone" label={i18n[lang].phone} />;
+    }
+
+    return null;
+  }
+
   render() {
     const {
       size,
-      lang,
       display,
       href,
       rel,
@@ -202,29 +228,8 @@ export class GcdsLink {
           onClick={e => emitEvent(e, this.gcdsClick, href)}
         >
           <slot></slot>
-          {target === '_blank' || external ? (
-            <gcds-icon
-              name="external"
-              label={i18n[lang].external}
-              margin-left="75"
-            />
-          ) : download !== undefined ? (
-            <gcds-icon
-              name="download"
-              label={i18n[lang].download}
-              margin-left="75"
-            />
-          ) : href && href.toLowerCase().startsWith('mailto:') ? (
-            <gcds-icon name="email" label={i18n[lang].email} margin-left="75" />
-          ) : (
-            href &&
-            href.toLowerCase().startsWith('tel:') && (
-              <gcds-icon
-                name="phone"
-                label={i18n[lang].phone}
-                margin-left="75"
-              />
-            )
+          {this.getIcon() && (
+            <span class="text-icon-group">&nbsp;{this.getIcon()}</span>
           )}
         </a>
       </Host>

--- a/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
+++ b/packages/web/src/components/gcds-link/test/gcds-link.spec.ts
@@ -34,7 +34,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" tabindex="0">
             <slot></slot>
-            <gcds-icon name="external" label="${i18n.en.external}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="external" label="${i18n.en.external}" />
+            </span>
           </a>
         </mock:shadow-root>
         External Link
@@ -52,7 +54,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="https://google.com" part="link" target="_blank" rel="noopener noreferrer" tabindex="0">
             <slot></slot>
-            <gcds-icon name="external" label="${i18n.fr.external}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="external" label="${i18n.fr.external}" />
+            </span>
           </a>
         </mock:shadow-root>
         External Link
@@ -70,7 +74,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="https://google.com" part="link" download tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="download" label="${i18n.en.download}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="download" label="${i18n.en.download}" />
+            </span>
           </a>
         </mock:shadow-root>
         Download file
@@ -88,7 +94,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="https://google.com" part="link" download tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="download" label="${i18n.fr.download}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="download" label="${i18n.fr.download}" />
+            </span>
           </a>
         </mock:shadow-root>
         Download file
@@ -106,7 +114,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="https://google.com" part="link" download="myfile.pdf" tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="download" label="${i18n.en.download}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="download" label="${i18n.en.download}" />
+            </span>
           </a>
         </mock:shadow-root>
         Download file
@@ -124,7 +134,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="https://google.com" part="link" download="myfile.pdf" tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="download" label="${i18n.fr.download}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="download" label="${i18n.fr.download}" />
+            </span>
           </a>
         </mock:shadow-root>
         Download file
@@ -142,7 +154,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="tel:1234567890" part="link" tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="phone" label="${i18n.en.phone}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="phone" label="${i18n.en.phone}" />
+            </span>
           </a>
         </mock:shadow-root>
         123-456-7890
@@ -160,7 +174,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="tel:1234567890" part="link" tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="phone" label="${i18n.fr.phone}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="phone" label="${i18n.fr.phone}" />
+            </span>
           </a>
         </mock:shadow-root>
         123-456-7890
@@ -178,7 +194,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="mailto:test@test.com" part="link" tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="email" label="${i18n.en.email}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="email" label="${i18n.en.email}" />
+            </span>
           </a>
         </mock:shadow-root>
         test@test.com
@@ -196,7 +214,9 @@ describe('gcds-link', () => {
         <mock:shadow-root>
           <a class="gcds-link link--inherit" href="mailto:test@test.com" part="link" tabindex="0" target="_self">
             <slot></slot>
-            <gcds-icon name="email" label="${i18n.fr.email}" margin-left="75" />
+            <span class="text-icon-group">
+              <gcds-icon name="email" label="${i18n.fr.email}" />
+            </span>
           </a>
         </mock:shadow-root>
         test@test.com


### PR DESCRIPTION
# 📝 Summary | Résumé

This PR fixes an issue where the external link icon in the `gcds-link` component could wrap onto a new line at the end of a line, visually detaching it from the linked text. The change ensures the icon remains visually attached to the last word of the link, improving readability and accessibility.

## 🧩 Related Issues | Cartes liées

- [Issue #1187 ](https://github.com/cds-snc/gcds-components/issues/1187)

## 🧪 Test instructions | Instructions pour tester la modification

1) Check the current behaviour
- [ ] Checkout the `main` branch
- [ ] Open the `index.html` test file
- [ ] Add the following test code inside the `<body>`:

```html
<p>Here’s an example of an external resource: <gcds-link href="https://picsum.photos/480/270" external>View a high-resolution sample image</gcds-link> for testing purposes.</p>
```
- [ ] Confirm the following behaviour:
    - [ ] Resize the browser window so the link wraps onto multiple lines
    - [ ] Confirm the external link icon detaches from the text at the line break

2) Validate the change
- [ ] Checkout this branch
- [ ] Open the `index.html` test file
- [ ] Use the exact same test code as above
- [ ] Confirm the following behaviour:
    - [ ] Confirm the external link icon stays visually attached to the last word, even when wrapping occurs

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR is a patch (use `fix:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [x] This PR does not introduce any changes to component names, properties, values, or behaviour.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] I have tested these changes on mobile viewports.
- [x] I have tested these changes across multiple supported browsers.
- [x] I have checked accessiblity and ensured all accessiblity tests pass.
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [x] I have added or updated documentation, if needed.
- [x] For visual or design-affecting changes, I have posted in dev-design slack channel.
- [x] Visual or content changes remain aligned with design tokens and component API standards.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.

## ⚠️ Impact/Risks | Risques

Low risk: This is a visual fix affecting the rendering of the `gcds-link` component. There are no API changes, breaking changes, or performance impacts.
