### PR TITLE
style(gcds-side-nav, gcds-top-nav, gcds-nav-group, gcds-nav-link): adjusting breakpoints to improve responsive behaviour

### DIFF
--- a/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
+++ b/packages/web/src/components/gcds-nav-group/gcds-nav-group.css
@@ -121,7 +121,7 @@
 
 /* Note: viewport specific style decision */
 @layer desktop {
-  @media only screen and (width >= 64em) {
+  @media only screen and (width >= 48em) {
     :host {
       .gcds-nav-group__trigger {
         max-width: var(--gcds-nav-group-trigger-max-width);
@@ -171,7 +171,7 @@
 
 /* Note: viewport specific style decision */
 @layer mobile {
-  @media only screen and (width < 64em) {
+  @media only screen and (width < 48em) {
     :host(.gcds-mobile-nav)
       > .gcds-nav-group__container
       > .gcds-nav--expandable {
@@ -180,13 +180,6 @@
 
     :host([open]:not(.gcds-mobile-nav)) .gcds-nav-group__list {
       padding-inline-start: var(--gcds-nav-group-side-nav-dropdown-padding);
-    }
-  }
-
-  @media only screen and (48em < width < 64em) {
-    :host(.gcds-mobile-nav) .gcds-trigger--expandable {
-      width: auto;
-      align-self: flex-start;
     }
   }
 }

--- a/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
+++ b/packages/web/src/components/gcds-nav-link/gcds-nav-link.css
@@ -33,7 +33,6 @@
     }
 
     @media only screen and (width < 64em) {
-      font: var(--gcds-nav-link-font-mobile);
       min-width: 50%;
     }
 
@@ -43,7 +42,7 @@
   }
 
   /* Home styles for larger screens */
-  @media only screen and (width >= 64em) {
+  @media only screen and (width >= 48em) {
     :host([slot='home']) > .gcds-nav-link {
       font: var(--gcds-nav-link-home-font);
 
@@ -60,7 +59,7 @@
 
 @layer variants {
   /* Top-nav: styles for larger screens */
-  @media only screen and (width >= 64em) {
+  @media only screen and (width >= 48em) {
     :host > .gcds-nav-link--topnav.gcds-nav-link {
       color: var(--gcds-nav-link-top-nav-text);
       margin: var(--gcds-nav-link-top-nav-margin);
@@ -81,7 +80,7 @@
   }
 
   /* Side-nav: home styles for larger screens */
-  @media only screen and (width >= 64em) {
+  @media only screen and (width >= 48em) {
     :host([slot='home']) > .gcds-nav-link--sidenav.gcds-nav-link {
       margin-block-end: var(--gcds-side-nav-heading-margin);
       padding: var(--gcds-side-nav-heading-padding);

--- a/packages/web/src/components/gcds-side-nav/gcds-side-nav.css
+++ b/packages/web/src/components/gcds-side-nav/gcds-side-nav.css
@@ -29,7 +29,7 @@
 /* Note: viewport specific style decision */
 @layer desktop {
   :host .gcds-side-nav {
-    @media only screen and (width >= 64em) {
+    @media only screen and (width >= 48em) {
       max-width: var(--gcds-side-nav-max-width);
     }
   }
@@ -37,7 +37,7 @@
 
 /* Note: viewport specific style decision */
 @layer mobile {
-  @media only screen and (width < 64em) {
+  @media only screen and (width < 48em) {
     :host {
       .gcds-side-nav__heading {
         display: block;

--- a/packages/web/src/components/gcds-top-nav/gcds-top-nav.css
+++ b/packages/web/src/components/gcds-top-nav/gcds-top-nav.css
@@ -27,7 +27,7 @@
 
 @layer desktop {
   /* Note: viewport specific style decisions */
-  @media only screen and (width >= 64em) {
+  @media only screen and (width >= 48em) {
     :host .gcds-top-nav {
       border-block-end: var(--gcds-top-nav-border-width) solid
         var(--gcds-top-nav-border-color);


### PR DESCRIPTION
# 📝 Summary | Résumé

This PR adjusts the responsive breakpoints for `gcds-side-nav`, `gcds-top-nav`, `gcds-nav-group`, and `gcds-nav-link` to improve how navigation components render across different viewport sizes and constrained layouts.

Previously, the navigation components would transition into their mobile layout too early in embedded or constrained preview environments, resulting in a mobile presentation being shown even when the surrounding context was effectively desktop.

These changes refine the breakpoint so that desktop layouts are preserved for longer in wider contexts.

## 🧩 Related Issues | Cartes liées

N/A

## 🧪 Test instructions | Instructions pour tester la modification

1) Check the current behaviour
- [ ] Checkout the `main` branch
- [ ] Open the `index.html` test file
- [ ] Confirm the following behaviour:
    - [ ] The `top-nav` and `side-nav` components switch to mobile styling once the viewport hits `1023px` or smaller.

2) Validate the change
- [ ] Checkout this branch
- [ ] Run `npm install` (if needed)
- [ ] Open the `index.html` test file
- [ ] Use the exact same test code as above
- [ ] Confirm the following behaviour:
    - [ ] The `top-nav` and `side-nav` components switch to mobile styling once the viewport hits `767px` or smaller.

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR is a patch (use `fix:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [x] This PR does not introduce any changes to component names, properties, values, or behaviour.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] I have tested these changes on mobile viewports.
- [x] I have tested these changes across multiple supported browsers.
- [x] I have checked accessiblity and ensured all accessiblity tests pass.
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [x] I have added or updated documentation, if needed.
- [x] For visual or design-affecting changes, I have posted in dev-design slack channel.
- [x] Visual or content changes remain aligned with design tokens and component API standards.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.

## ⚠️ Impact/Risks | Risques

This change is a responsive adjustment to navigation component breakpoint behavior. It does not introduce API changes or affect component interfaces.

The main risk is unintended layout shifts at intermediate viewport widths if other consuming applications rely on the previous breakpoint thresholds.
