### PR TITLE
fix(gcds-input): stepMismatch errors with decimal numbers

### DIFF
--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -291,6 +291,13 @@ export function handleValidationResult(
  * @param el - the gcds form element that is being validated
  */
 export function formatHTMLErrorMessage(error, lang, el) {
+  console.log('step', el.step);
+  console.log('min', el.min);
+  console.log('low', (Number(el.value) / Number(el.step)) * Number(el.step));
+  console.log(
+    'high',
+    (Number(el.value) / Number(el.step)) * Number(el.step) + Number(el.step),
+  );
   switch (error) {
     case 'valueMissing':
       return validationErrors[lang][error];
@@ -313,16 +320,17 @@ export function formatHTMLErrorMessage(error, lang, el) {
     case 'rangeOverflow':
       return validationErrors[lang][error].replace('{max}', el.max);
     case 'stepMismatch':
+      const value = Number(el.value);
+      const step = el.step === 'any' ? 0 : Number(el.step || 1);
+      const base = el.min !== undefined && el.min !== null ? Number(el.min) : 0;
+      const offset = (value - base) / step;
+
+      const lower = base + Math.floor(offset) * step;
+      const upper = base + Math.ceil(offset) * step;
+
       return validationErrors[lang][error]
-        .replace(
-          '{lower}',
-          Math.floor(Number(el.value) / Number(el.step)) * Number(el.step),
-        )
-        .replace(
-          '{upper}',
-          Math.floor(Number(el.value) / Number(el.step)) * Number(el.step) +
-            Number(el.step),
-        );
+        .replace('{lower}', lower)
+        .replace('{upper}', upper);
     case 'badInput':
     case 'patternMismatch':
     default:

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -291,13 +291,6 @@ export function handleValidationResult(
  * @param el - the gcds form element that is being validated
  */
 export function formatHTMLErrorMessage(error, lang, el) {
-  console.log('step', el.step);
-  console.log('min', el.min);
-  console.log('low', (Number(el.value) / Number(el.step)) * Number(el.step));
-  console.log(
-    'high',
-    (Number(el.value) / Number(el.step)) * Number(el.step) + Number(el.step),
-  );
   switch (error) {
     case 'valueMissing':
       return validationErrors[lang][error];


### PR DESCRIPTION
# 📝 Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-components/issues/1267, when assigning a `min` with a decimal value like `1.5`, entering a number of `2` would produce a `stepMismatch` error without proper numbers (`NaN`). This was caused by the step not being defined when creating the `stepMismatch` error so the error message would produce two `NaN`s. Logic has also been added to present the appropriate number when expecting decimal numbers as valid values.

## 🧩 Related Issues | Cartes liées

- Issue https://github.com/cds-snc/gcds-components/issues/1267

## 🧪 Test instructions | Instructions pour tester la modification

_TODO: Replace the instructions below as needed. Describe any steps needed to verify the change(s) work as expected._

1) Check the current behaviour
- [ ] Checkout the `main` branch
- [ ] Open the `index.html` test file
- [ ] Add the following test code inside the `<body>`:
  ```html
       <gcds-input
        label="Number"
        type="number"
        input-id="number"
        min="1.5"
      ></gcds-input>
  ```
- [ ] Confirm the following behaviour:
    - [ ] Enter `1` into the input and remove focus.
    - [ ] Observe you get the `min` error message.
    - [ ] Enter `4` into the input and remove focus
    - [ ] Observe the `stepMismatch` error returns with `NaN` in place of the expected lower and higher values

2) Validate the change
- [ ] Checkout this branch
- [ ] Open the `index.html` test file
- [ ] Use the exact same test code as above
- [ ] Confirm the following behaviour:
    - [ ] Enter `1` into the input and remove focus.
    - [ ] Observe you get the `min` error message.
    - [ ] Enter `4` into the input and remove focus
    - [ ] Observe the `stepMismatch` error returns with `3.5` and `4.5` as the lower and higher acceptable values

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [X] This PR is a patch (use `fix:`)
- [ ] This PR introduces a minor change (use `feat:`)
- [ ] This PR introduces breaking changes to the API (use `feat!:`)
- [ ] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [X] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [X] This PR does not introduce any changes to component names, properties, values, or behaviour.
- [ ] **_If this PR introduces API or behaviour changes_**, backwards compatibility has been implemented and documented under **Impact and Risks**.
- [ ] **_If this PR introduces a breaking change_**, release notes and versioning have been prepared.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] I have tested these changes on mobile viewports.
- [x] I have tested these changes across multiple supported browsers.
- [x] I have checked accessiblity and ensured all accessiblity tests pass.
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [x] I have added or updated documentation, if needed.
- [x] For visual or design-affecting changes, I have posted in dev-design slack channel.
- [x] Visual or content changes remain aligned with design tokens and component API standards.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.
