### PR TITLE
chore: update french changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ Version publiée le&nbsp;: 2026-05-27
 
 ### :bug: :wrench: Corrections de bogues
 
-* **gcds-input:** erreurs `stepMismatch` avec des nombres décimaux ([#1271](https://github.com/cds-snc/gcds-components/issues/1271)) ([5b14383](https://github.com/cds-snc/gcds-components/commit/5b14383daa0f9584b03b8d16f969111894c76605))
+* **gcds-input&nbsp;:** erreurs `stepMismatch` avec les nombres décimaux ([#1271](https://github.com/cds-snc/gcds-components/issues/1271)) ([5b14383](https://github.com/cds-snc/gcds-components/commit/5b14383daa0f9584b03b8d16f969111894c76605))
 
 ### 🎨 Styles
 

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -169,21 +169,21 @@ Version publiée le&nbsp;: 2026-05-27
   
   ```html
   <gcds-table
-    columns=“”
-    data=“”
-  
-    sort=“false”
-  
-    pagination=“false”
-    pagination-current-page=“1”
-    pagination-size=“10”
+    columns=""
+    data=""
+
+    sort="false"
+
+    pagination="false"
+    pagination-current-page="1"
+    pagination-size="10"
     pagination-size-options=[10, 25, 50, 0]
-  
-    filter=“false”
-    filter-value=“”
+
+    filter="false"
+    filter-value=""
   >
-    <slot name=“caption”></slot>
-    <slot name=“cell:<field>”></slot>
+    <slot name="caption"></slot>
+    <slot name="cell:<field>"></slot>
   </gcds-table>
   ```
 
@@ -193,7 +193,7 @@ Version publiée le&nbsp;: 2026-05-27
 
 ### :bug: :wrench: Corrections de bogues
 
-* **gcds-input:** erreurs `stepMismatch` avec des nombres décimaux ([#1271](https://github.com/cds-snc/gcds-components/issues/1271)) ([5b14383](https://github.com/cds-snc/gcds-components/commit/5b14383daa0f9584b03b8d16f969111894c76605))
+* **gcds-input&nbsp;:** erreurs `stepMismatch` avec les nombres décimaux ([#1271](https://github.com/cds-snc/gcds-components/issues/1271)) ([5b14383](https://github.com/cds-snc/gcds-components/commit/5b14383daa0f9584b03b8d16f969111894c76605))
 
 ### 🎨 Styles
 


### PR DESCRIPTION
# 📝 Summary | Résumé

Small grammar fix on the french changelog -- we received the actual translation from the translation team to replace the temporary translation we put in

## 🧩 Related Issues | Cartes liées

No ticket

## 🧪 Test instructions | Instructions pour tester la modification

1.  Check the `CHANGELOG.md` file. 
  - Should say "**gcds-input** : erreurs `stepMismatch` avec les nombres décimaux" 
  - _instead of_ "**gcds-input: erreurs** `stepMismatch` avec des nombres décimaux"

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [x] This PR does not introduce any changes to component names, properties, values, or behaviour.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur
This will be a simple review, just needs to check the test instructions above

## ⚠️ Impact/Risks | Risques
None