### PR TITLE
fix: Load proper language in Vue and React based on the lang attribute

### DIFF
--- a/packages/web/src/utils/utils.spec.ts
+++ b/packages/web/src/utils/utils.spec.ts
@@ -10,6 +10,7 @@ import {
   handleErrors,
   formatHTMLErrorMessage,
   validateRadioCheckboxGroup,
+  assignLanguage,
 } from './utils';
 
 import { validationErrors as I18N } from './i18n/validation-errors';
@@ -681,5 +682,51 @@ describe('validateRadioCheckboxGroup', () => {
     const validity = validateRadioCheckboxGroup(elements);
     expect(validity.valueMissing).toEqual(true);
     expect(validity.valid).toEqual(false);
+  });
+});
+
+describe('assignLanguage', () => {
+  it('assigns language based on element lang attribute - French', () => {
+    const element = document.createElement('div');
+    element.setAttribute('lang', 'fr');
+
+    expect(assignLanguage(element)).toEqual('fr');
+
+    // Generalize fr-CA to fr
+    element.setAttribute('lang', 'fr-CA');
+
+    expect(assignLanguage(element)).toEqual('fr');
+  });
+
+  it('assigns language based on element lang attribute - English', () => {
+    const element = document.createElement('div');
+    element.setAttribute('lang', 'en');
+
+    expect(assignLanguage(element)).toEqual('en');
+
+    // Generalize en-CA to en
+    element.setAttribute('lang', 'en-CA');
+
+    expect(assignLanguage(element)).toEqual('en');
+  });
+
+  it('assigns language based on closest parent lang attribute', () => {
+    const parentElement = document.createElement('div');
+    parentElement.setAttribute('lang', 'fr');
+
+    const childElement = document.createElement('div');
+    parentElement.appendChild(childElement);
+
+    expect(assignLanguage(childElement)).toEqual('fr');
+
+    parentElement.setAttribute('lang', 'en');
+
+    expect(assignLanguage(childElement)).toEqual('en');
+  });
+
+  it('defaults to English when no lang attribute is found', () => {
+    const element = document.createElement('div');
+
+    expect(assignLanguage(element)).toEqual('en');
   });
 });

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -41,24 +41,20 @@ export const inheritAttributes = (
   return attributeObject;
 };
 
-export const assignLanguage = (el: HTMLElement) => {
-  let lang = '';
-  if (!el.getAttribute('lang')) {
-    const closestLangAttribute = closestElement('[lang]', el)?.getAttribute(
-      'lang',
-    );
-    if (closestLangAttribute == 'en' || !closestLangAttribute) {
-      lang = 'en';
-    } else {
-      lang = 'fr';
-    }
-  } else if (el.getAttribute('lang') == 'en') {
-    lang = 'en';
-  } else {
-    lang = 'fr';
-  }
+/*
+ * Get language to use for component based on the following priority:
+ * 1. lang attribute on component
+ * 2. lang attribute on closest parent with a lang attribute
+ * 3. default to English
+ */
+export const assignLanguage = (el: HTMLElement): string => {
+  const rawLang =
+    el.lang ||
+    el.getAttribute('lang') ||
+    closestElement('[lang]', el)?.getAttribute('lang') ||
+    'en';
 
-  return lang;
+  return rawLang.toLowerCase().startsWith('fr') ? 'fr' : 'en';
 };
 
 // Allows use of closest() function across shadow boundaries


### PR DESCRIPTION
# 📝 Summary | Résumé

Rework the `assignLanguage` function used by the GC Design System to assign active language in components to read from `lang` property first instead of `lang` attribute as some framework outputs strip the `lang` attribute. This should fix the components ignoring passed language strings in React and Vue and only using the `lang` attribute on the `<html>` element.

Work has also been done to generalize the `en-CA` and `fr-CA` strings to just `en` and `fr` if read by the components.

## 🧩 Related Issues | Cartes liées

- Issue #1233
- Issue #1017 

## 🧪 Test instructions | Instructions pour tester la modification

1) Check the current behaviour
- [ ] Checkout the `main` branch
- [ ] Open the `/packages/vue/tests/app/src/views/FileUploader.vue` file
- [ ] Modify the File uploader to the following:
  ```html
  <gcds-file-uploader
          name="file-uploader"
          label="Upload your files"
          hint="You can upload multiple files."
          multiple
          @change="handleChange"
          required
          lang="fr"
        ></gcds-file-uploader>
  ```
- [ ] Run the Vue test app and navigate to `http://localhost:5173/file-uploader`
- [ ] Confirm the following behaviour:
    - [ ] Notice the `(required)` and `Choose file` are still appearing in English

2) Validate the change
- [ ] Checkout this branch
- [ ] Run `npm run build`
- [ ] Use the exact same test code as above
- [ ] Confirm the following behaviour:
    - [ ] Notice the component now lists `(obligatoire)` and `Choisir un fichier`


## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [X] This PR is a patch (use `fix:`)
- [ ] This PR introduces a minor change (use `feat:`)
- [ ] This PR introduces breaking changes to the API (use `feat!:`)
- [ ] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [X] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [X] This PR does not introduce any changes to component names, properties, values, or behaviour.
- [ ] **_If this PR introduces API or behaviour changes_**, backwards compatibility has been implemented and documented under **Impact and Risks**.
- [ ] **_If this PR introduces a breaking change_**, release notes and versioning have been prepared.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] I have tested these changes on mobile viewports.
- [x] I have tested these changes across multiple supported browsers.
- [x] I have checked accessiblity and ensured all accessiblity tests pass.
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [x] I have added or updated documentation, if needed.
- [x] For visual or design-affecting changes, I have posted in dev-design slack channel.
- [x] Visual or content changes remain aligned with design tokens and component API standards.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.

