### PR TITLE
fix(gcds-table): Pressing Enter correctly opens filter dialog

### DIFF
--- a/packages/web/src/components/gcds-table/test/gcds-table.e2e.ts
+++ b/packages/web/src/components/gcds-table/test/gcds-table.e2e.ts
@@ -157,7 +157,8 @@ test.describe('gcds-table', () => {
     }
 
     async applyFilterEnter(text: string) {
-      await this.clickAndWait(this.filterButton);
+      await this.filterButton.focus();
+      await this.filterButton.press('Enter');
       await expect(this.filterInput).toBeVisible();
       await this.filterInput.fill(text);
 
@@ -551,7 +552,9 @@ test.describe('gcds-table', () => {
     await expect.poll(() => getVisiblePokedexValues(element)).toEqual([7]);
 
     // Verify modal is closed and focus returns to table after submission.
-    await expect(element.locator('dialog.gcds-table__modal')).not.toHaveAttribute('open', '');
+    await expect(
+      element.locator('dialog.gcds-table__modal'),
+    ).not.toHaveAttribute('open', '');
     await expect(element.locator('table')).toBeFocused();
   });
 

--- a/packages/web/src/components/gcds-table/utils/render-helpers.tsx
+++ b/packages/web/src/components/gcds-table/utils/render-helpers.tsx
@@ -214,12 +214,16 @@ const getSortValue = (sort: SortingState) => {
 
 const renderFilterSortModal = element => {
   const { filter, filterValue, lang } = element;
+  let justOpened = false;
   return (
     <div class="gcds-table__filters">
       <gcds-button
         size="small"
         button-role="primary"
-        onClick={() => element.filterSortModal.showModal()}
+        onClick={() => {
+          justOpened = true;
+          element.filterSortModal.showModal();
+        }}
       >
         <div>
           {element.filter && element.sortEnabled() ? (
@@ -285,6 +289,11 @@ const renderFilterSortModal = element => {
           class="gcds-table__modal-body"
           onKeyUp={ev => {
             if (ev.key === 'Enter') {
+              if (justOpened) {
+                justOpened = false;
+                return;
+              }
+
               if (document.activeElement?.shadowRoot?.activeElement === element.filterInput ||
                 document.activeElement?.shadowRoot?.activeElement === element.sortRadios
               ) {


### PR DESCRIPTION
# 📝 Summary | Résumé

Add additional check to the open dialog logic in `gcds-table` to prevent filter dialog from closing immediately after opening when using `Enter` to open the dialog. 

## 🧩 Related Issues | Cartes liées

- Issue https://github.com/cds-snc/design-gc-conception/issues/2548

## 🧪 Test instructions | Instructions pour tester la modification

1) Check the current behaviour
- [ ] Checkout the `main` branch
- [ ] Run `npm run start`
- [ ] Scroll down to the `gcds-table` example
- [ ] Confirm the following behaviour:
    - [ ] Focus the `Filter and sort` button
    - [ ] Press `Enter` open the filter dialog
    - [ ] Notice the filter will open and then close immediately and focus the table

2) Validate the change
- [ ] Checkout this branch
- [ ] Run `npm run start`
- [ ] Scroll down to the `gcds-table` example
- [ ] Confirm the following behaviour:
    - [ ] Focus the `Filter and sort` button
    - [ ] Press `Enter` open the filter dialog
    - [ ] Notice filter dialog will open and have the filter input focused

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR is a patch (use `fix:`)
- [ ] This PR introduces a minor change (use `feat:`)
- [ ] This PR introduces breaking changes to the API (use `feat!:`)
- [ ] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [x] This PR does not introduce any changes to component names, properties, values, or behaviour.
- [ ] **_If this PR introduces API or behaviour changes_**, backwards compatibility has been implemented and documented under **Impact and Risks**.
- [ ] **_If this PR introduces a breaking change_**, release notes and versioning have been prepared.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] I have tested these changes on mobile viewports.
- [x] I have tested these changes across multiple supported browsers.
- [x] I have checked accessiblity and ensured all accessiblity tests pass.
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [x] I have added or updated documentation, if needed.
- [x] For visual or design-affecting changes, I have posted in dev-design slack channel.
- [x] Visual or content changes remain aligned with design tokens and component API standards.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.

**Design checklist (if needed)**

For designers, include the following info with your approval:

- [ ] I have tested the changes and functionality using the test instructions.
- [ ] The changes meet design expectations and align with the design system.
- [ ] Any design inconsistencies have been raised on slack or tracked via an issue.

**Content checklist (if needed)**

For content, include the following info with your approval:

- [ ] I understand the context and intent of the content changes.
- [ ] I have reviewed all content for clarity, readability, and tone.
- [ ] I have reviewed English and French content for accuracy and parity.

## ⚠️ Impact/Risks | Risques

_Optional: Use this section to highlight any potential implcations, risks or important notes for reviewers or maintainers, i.e. breaking changes, performance implications, dependency updates, etc._
_Highlight any deprecation notices here_
