### PR TITLE
fix(gcds-table): Add status to table description

### DIFF
--- a/packages/web/src/components/gcds-table/gcds-table.tsx
+++ b/packages/web/src/components/gcds-table/gcds-table.tsx
@@ -597,6 +597,7 @@ export class GcdsTable {
             {/* Table status */}
             <span
               class="gcds-table__page-info"
+              id="status"
               role="status"
               aria-live="polite"
             >
@@ -618,6 +619,7 @@ export class GcdsTable {
                 ? 'gcds-table__caption'
                 : undefined
             }
+            aria-describedby="status"
             ref={el => {
               if (el) this.shadowElement = el;
             }}

--- a/packages/web/src/components/gcds-table/test/gcds-table.spec.tsx
+++ b/packages/web/src/components/gcds-table/test/gcds-table.spec.tsx
@@ -78,11 +78,11 @@ describe('gcds-table', () => {
             <section class="gcds-table">
               <div class="gcds-table__active-pills"></div>
               <div class="gcds-table__row-management">
-                <span aria-live="polite" class="gcds-table__page-info" role="status">
+                <span aria-live="polite" class="gcds-table__page-info" id="status" role="status">
                   No rows to show
                 </span>
               </div>
-            <table class="gcds-table__table" tabindex="-1">
+            <table class="gcds-table__table" tabindex="-1" aria-describedby="status">
               <thead>
                 <tr></tr>
               </thead>
@@ -169,7 +169,7 @@ describe('gcds-table', () => {
     expect(errorSpy).toHaveBeenCalled();
     expect(page.root?.shadowRoot?.querySelector('tbody')).not.toBeNull();
     expect(page.root?.shadowRoot?.querySelector('table')).toEqualHtml(`
-      <table class="gcds-table__table" tabindex="-1">
+      <table class="gcds-table__table" aria-describedby="status" tabindex="-1">
         <thead>
           <tr></tr>
         </thead>


### PR DESCRIPTION
# 📝 Summary | Résumé

Add `aria-describedby` to the table element in `gcds-table` to add the table status to the table description. This will hopefully improve usability for users using assitive technology as the status is now tied to the table.

## 🧩 Related Issues | Cartes liées

- Issue https://github.com/cds-snc/design-gc-conception/issues/2551

## 🧪 Test instructions | Instructions pour tester la modification

_TODO: Replace the instructions below as needed. Describe any steps needed to verify the change(s) work as expected._

1) Check the current behaviour
- [ ] Checkout the `main` branch
- [ ] Run `npm run start`
- [ ] Scroll down to the `gcds-table` example
- [ ] Confirm the following behaviour:
    - [ ] Using your browser's accessibility dev tools view the a11y settings of the table element
    - [ ] Notice the table is only named by the caption slot and doesn't feature a description

2) Validate the change
- [ ] Checkout this branch
- [ ] Run `npm run start`
- [ ] Scroll down to the `gcds-table` example
- [ ] Confirm the following behaviour:
    - [ ] Using your browser's accessibility dev tools view the a11y settings of the table element
    - [ ] Notice the table will be named by the caption slot and feature a description of the table status

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [X] This PR is a patch (use `fix:`)
- [ ] This PR introduces a minor change (use `feat:`)
- [ ] This PR introduces breaking changes to the API (use `feat!:`)
- [ ] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [X] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [ ] This PR does not introduce any changes to component names, properties, values, or behaviour.
- [ ] **_If this PR introduces API or behaviour changes_**, backwards compatibility has been implemented and documented under **Impact and Risks**.
- [ ] **_If this PR introduces a breaking change_**, release notes and versioning have been prepared.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] I have tested these changes on mobile viewports.
- [x] I have tested these changes across multiple supported browsers.
- [x] I have checked accessiblity and ensured all accessiblity tests pass.
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [x] I have added or updated documentation, if needed.
- [x] For visual or design-affecting changes, I have posted in dev-design slack channel.
- [x] Visual or content changes remain aligned with design tokens and component API standards.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.

**Design checklist (if needed)**

For designers, include the following info with your approval:

- [ ] I have tested the changes and functionality using the test instructions.
- [ ] The changes meet design expectations and align with the design system.
- [ ] Any design inconsistencies have been raised on slack or tracked via an issue.

**Content checklist (if needed)**

For content, include the following info with your approval:

- [ ] I understand the context and intent of the content changes.
- [ ] I have reviewed all content for clarity, readability, and tone.
- [ ] I have reviewed English and French content for accuracy and parity.

## ⚠️ Impact/Risks | Risques

_Optional: Use this section to highlight any potential implcations, risks or important notes for reviewers or maintainers, i.e. breaking changes, performance implications, dependency updates, etc._
_Highlight any deprecation notices here_
