### PR TITLE
chore(postbuild): fix line endings and remove absolute paths when building on windows

### DIFF
--- a/packages/web/scripts/postbuild.js
+++ b/packages/web/scripts/postbuild.js
@@ -13,14 +13,14 @@ fs.copyFileSync('./dist/gcds/gcds.css', '../vue/gcds.css');
 // Also removes the timestamp to avoid unnecessary changes in git
 
 const COMPONENTS_FILE = '../specs/components.json';
-const WORKSPACE_ROOT = path.resolve(__dirname, '../..');
+const WORKSPACE_ROOT = path.posix.resolve(__dirname, '../..');
 
 // Paths that need sanitization
 const PATH_FIELDS = ['filePath', 'dirPath', 'readmePath', 'usagesDir'];
 
 // Sanitize a single path by removing workspace root
 function sanitizePath(filePath) {
-  return filePath?.replace(WORKSPACE_ROOT, '') || filePath;
+  return filePath?.split(WORKSPACE_ROOT).at(-1) || filePath;
 }
 
 // Sanitize all component paths
@@ -60,7 +60,11 @@ function sanitizeComponentsFile() {
     delete components.timestamp;
 
     sanitizeComponentPaths(components.components);
-    fs.writeFileSync(componentsPath, JSON.stringify(components, null, 2));
+    const sanitizedJsonStr = JSON.stringify(components, null, 2)
+      // normalize eol for Windows
+      .replaceAll('\\r', '')
+
+    fs.writeFileSync(componentsPath, sanitizedJsonStr);
 
     console.log('✅ Paths sanitized and timestamp removed in components.json');
   } catch (error) {


### PR DESCRIPTION

# 📝 Summary | Résumé

This PR updates the postbuild script so the Window's output for `specs/components.json` is the same as Linux (and MacOS presumably) by:
- removing absolute paths
- removing the `\r` character 

## 🧩 Related Issues | Cartes liées
Related: https://github.com/cds-snc/gcds-components/pull/1311#discussion_r3493273960

## 🧪 Test instructions | Instructions pour tester la modification

1) Check the current behaviour on windows
- [ ] Checkout the `main` branch
- [ ] Run `npm run build`
- [ ] notice changes to `specs/component.json` file

2) Validate the change
- [ ] Checkout this branch
- [ ] Run `npm run build`
- [ ] No changes to `specs/components.json`

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes. 

I tested this change on both Windows and Fedora Linux

**Ready for review: (all items must be checked)**
- [x] Test instructions are clear and reproducible.

## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.

**Design checklist (if needed)**

For designers, include the following info with your approval:

- [ ] I have tested the changes and functionality using the test instructions.
- [ ] The changes meet design expectations and align with the design system.
- [ ] Any design inconsistencies have been raised on slack or tracked via an issue.

**Content checklist (if needed)**

For content, include the following info with your approval:

- [ ] I understand the context and intent of the content changes.
- [ ] I have reviewed all content for clarity, readability, and tone.
- [ ] I have reviewed English and French content for accuracy and parity.

## ⚠️ Impact/Risks | Risques

_Optional: Use this section to highlight any potential implcations, risks or important notes for reviewers or maintainers, i.e. breaking changes, performance implications, dependency updates, etc._
_Highlight any deprecation notices here_
