### PR TITLE
chore: fix inconsistency on version number on the changelog

### DIFF
--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -161,7 +161,7 @@ The `@cdssnc/gcds-components` package has been deprecated on npm and will no lon
 
 # Journal des modifications
 
-## [v1.3.0](https://github.com/cds-snc/gcds-components/compare/@gcds-core/components-v1.2.0...@gcds-core/components-v1.3.0) 
+## [1.3.0](https://github.com/cds-snc/gcds-components/compare/@gcds-core/components-v1.2.0...@gcds-core/components-v1.3.0) 
 
 Version publiée le&nbsp;: 2026-05-27
 


### PR DESCRIPTION
This PR was opened to apply the suggestions from the code quality tool (before we turn it off)

It updates the version number on the changelog to be more consistent

_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/cds-snc/gcds-components/security/quality/ai-findings)._