### PR TITLE
fix(gcds-table): fix results to match filtered results and not total rows

### DIFF
--- a/packages/web/src/components/gcds-table/utils/render-helpers.tsx
+++ b/packages/web/src/components/gcds-table/utils/render-helpers.tsx
@@ -120,7 +120,7 @@ const renderTableStatus = (
       )
       .replace('{total}', totalRows);
 
-    // No rows avalable
+    // No rows available
   } else if (table.getRowCount() === 0) {
     return I18N[lang].showingNoRows;
     // Rows on one page

--- a/packages/web/src/components/gcds-table/utils/render-helpers.tsx
+++ b/packages/web/src/components/gcds-table/utils/render-helpers.tsx
@@ -316,7 +316,9 @@ const renderFilterSortModal = element => {
               if (sortValue === 'null') {
                 element.sorting = [];
               } else {
-                const [direction, field] = sortValue.split('-');
+                const separatorIndex = sortValue.indexOf('-');
+                const direction = separatorIndex === -1 ? sortValue : sortValue.slice(0, separatorIndex);
+                const field = separatorIndex === -1 ? '' : sortValue.slice(separatorIndex + 1);
                 element.sorting = [
                   {
                     id: field,

--- a/packages/web/src/components/gcds-table/utils/render-helpers.tsx
+++ b/packages/web/src/components/gcds-table/utils/render-helpers.tsx
@@ -94,7 +94,7 @@ const renderTableStatus = (
       .replace('{start}', currentPageIndex * paginationSize + 1)
       .replace(
         '{end}',
-        Math.min((currentPageIndex + 1) * paginationSize, totalRows),
+        Math.min((currentPageIndex + 1) * paginationSize, filteredRows),
       )
       .replace('{filtered}', filteredRows);
 


### PR DESCRIPTION
This PR was opened to apply the suggestions from the code quality tool (before we turn it off)


_This PR applies 3/4 suggestions from code quality [AI findings](https://github.com/cds-snc/gcds-components/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

AI findings:
> In the filtered pagination branch, the `{end}` replacement uses `totalRows` as the cap in `Math.min`, but it should use `filteredRows` instead. When a filter is active, the total number of rows the user can page through is `filteredRows`, not `totalRows`, so the displayed "end" value can exceed the actual number of filtered results.


Note: This fix still needs to be tested and verified