### PR TITLE
feat(gcds-card): text being skipped by Android and iOS read-aloud

### DIFF
--- a/packages/web/specs/components.json
+++ b/packages/web/specs/components.json
@@ -1,5 +1,4 @@
 {
-  "timestamp": "2026-08-06T18:30:25",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.4",
@@ -845,15 +844,11 @@
       "docsTags": [
         {
           "name": "slot",
-          "text": "default - Slot for the card description. Will overwrite the description prop if used."
+          "text": "title - Slot for the card title. Accepts rich text, so markup such as\n`<abbr>`, `<em>` or an icon can be used where the card-title prop cannot. Falls back to\nthe card-title prop, which is mirrored into the light DOM so the title text stays\nreadable by DOM-text extraction tools."
         },
         {
           "name": "slot",
-          "text": "card-title - Internal. Filled automatically from the card-title prop so the title\ntext exists in the light DOM and stays readable by DOM-text extraction tools."
-        },
-        {
-          "name": "slot",
-          "text": "card-description - Internal. Filled automatically from the description prop for the\nsame reason. Not used when the default slot is populated."
+          "text": "default - Slot for the card description. Accepts rich text and overwrites the\ndescription prop if used. The description prop is mirrored into this slot for the same\nDOM-text reason when nothing is slotted."
         }
       ],
       "usage": {},
@@ -1128,16 +1123,12 @@
       "styles": [],
       "slots": [
         {
-          "name": "card-description",
-          "docs": "Internal. Filled automatically from the description prop for the\nsame reason. Not used when the default slot is populated."
-        },
-        {
-          "name": "card-title",
-          "docs": "Internal. Filled automatically from the card-title prop so the title\ntext exists in the light DOM and stays readable by DOM-text extraction tools."
-        },
-        {
           "name": "default",
-          "docs": "Slot for the card description. Will overwrite the description prop if used."
+          "docs": "Slot for the card description. Accepts rich text and overwrites the\ndescription prop if used. The description prop is mirrored into this slot for the same\nDOM-text reason when nothing is slotted."
+        },
+        {
+          "name": "title",
+          "docs": "Slot for the card title. Accepts rich text, so markup such as\n`<abbr>`, `<em>` or an icon can be used where the card-title prop cannot. Falls back to\nthe card-title prop, which is mirrored into the light DOM so the title text stays\nreadable by DOM-text extraction tools."
         }
       ],
       "parts": [],
@@ -4478,7 +4469,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -4780,7 +4771,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -4876,7 +4867,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -4966,7 +4957,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -5056,7 +5047,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -5146,7 +5137,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -6624,7 +6615,7 @@
             "references": {
               "IconNames": {
                 "location": "local",
-                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-icon/gcds-icon.tsx",
+                "path": "/web/src/components/gcds-icon/gcds-icon.tsx",
                 "id": "src/components/gcds-icon/gcds-icon.tsx::IconNames"
               }
             }

--- a/packages/web/specs/components.json
+++ b/packages/web/specs/components.json
@@ -1,4 +1,5 @@
 {
+  "timestamp": "2026-08-06T18:30:25",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.43.4",
@@ -845,6 +846,14 @@
         {
           "name": "slot",
           "text": "default - Slot for the card description. Will overwrite the description prop if used."
+        },
+        {
+          "name": "slot",
+          "text": "card-title - Internal. Filled automatically from the card-title prop so the title\ntext exists in the light DOM and stays readable by DOM-text extraction tools."
+        },
+        {
+          "name": "slot",
+          "text": "card-description - Internal. Filled automatically from the description prop for the\nsame reason. Not used when the default slot is populated."
         }
       ],
       "usage": {},
@@ -1118,6 +1127,14 @@
       "listeners": [],
       "styles": [],
       "slots": [
+        {
+          "name": "card-description",
+          "docs": "Internal. Filled automatically from the description prop for the\nsame reason. Not used when the default slot is populated."
+        },
+        {
+          "name": "card-title",
+          "docs": "Internal. Filled automatically from the card-title prop so the title\ntext exists in the light DOM and stays readable by DOM-text extraction tools."
+        },
         {
           "name": "default",
           "docs": "Slot for the card description. Will overwrite the description prop if used."
@@ -4461,7 +4478,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -4763,7 +4780,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -4859,7 +4876,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -4949,7 +4966,7 @@
             "references": {
               "GridGapValues": {
                 "location": "local",
-                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::GridGapValues"
               }
             }
@@ -5039,7 +5056,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -5129,7 +5146,7 @@
             "references": {
               "ContentValues": {
                 "location": "local",
-                "path": "/web/src/components/gcds-grid/gcds-grid.tsx",
+                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-grid/gcds-grid.tsx",
                 "id": "src/components/gcds-grid/gcds-grid.tsx::ContentValues"
               }
             }
@@ -6607,7 +6624,7 @@
             "references": {
               "IconNames": {
                 "location": "local",
-                "path": "/web/src/components/gcds-icon/gcds-icon.tsx",
+                "path": "/Users/kenbritton/src/oss/gcds-components/packages/web/src/components/gcds-icon/gcds-icon.tsx",
                 "id": "src/components/gcds-icon/gcds-icon.tsx::IconNames"
               }
             }

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -16,6 +16,10 @@ import i18n from './i18n/i18n';
  * A card is a box containing structured, actionable content on a single topic.
  *
  * @slot default - Slot for the card description. Will overwrite the description prop if used.
+ * @slot card-title - Internal. Filled automatically from the card-title prop so the title
+ * text exists in the light DOM and stays readable by DOM-text extraction tools.
+ * @slot card-description - Internal. Filled automatically from the description prop for the
+ * same reason. Not used when the default slot is populated.
  */
 @Component({
   tag: 'gcds-card',
@@ -153,6 +157,13 @@ export class GcdsCard {
     return true;
   }
 
+  /**
+   * Whether the consumer supplied their own description via the default slot.
+   * Captured once, before any mirror node is added, so that the mirrors this
+   * component writes into the light DOM can never be mistaken for author content.
+   */
+  private hasSlottedDescription = false;
+
   async componentWillLoad() {
     // Define lang attribute
     this.lang = assignLanguage(this.el);
@@ -161,15 +172,86 @@ export class GcdsCard {
 
     this.validateBadge();
 
+    // Must be read before syncTextMirrors() adds anything to the light DOM.
+    this.hasSlottedDescription = this.el.innerHTML.trim() != '';
+
     const valid = this.validateRequiredProps();
 
     if (!valid) {
       logError('gcds-card', this.errors, ['badge']);
     }
+
+    this.syncTextMirrors();
+  }
+
+  componentWillUpdate() {
+    this.syncTextMirrors();
+  }
+
+  /*
+   * A card that fails validation renders nothing, so it must not leave mirror
+   * text behind in the light DOM for textContent to pick up.
+   */
+  private get shouldMirrorText() {
+    return !this.errors.includes('href') && !this.errors.includes('cardTitle');
+  }
+
+  /*
+   * Mirror attribute-provided text into the light DOM.
+   *
+   * card-title and description are rendered through named slots, so without a
+   * light DOM node to fill them the text only ever exists inside the shadow root.
+   * textContent does not pierce a shadow root, which makes the card invisible to
+   * DOM-text extraction — including the browser-native read-aloud features on
+   * Android and iOS, which stop at the first unreadable card. The ARIA tree is
+   * unaffected either way, so screen readers behave the same before and after.
+   */
+  private syncTextMirrors() {
+    const active = this.shouldMirrorText;
+
+    this.upsertTextMirror('card-title', active ? this.cardTitle : undefined);
+    // Only mirror the description prop when the consumer has not slotted their own.
+    this.upsertTextMirror(
+      'card-description',
+      active && !this.hasSlottedDescription ? this.description : undefined,
+    );
+  }
+
+  private upsertTextMirror(slot: string, value?: string) {
+    const doc = this.el.ownerDocument;
+    if (!doc) {
+      return;
+    }
+
+    // Direct children only, and without :scope — Stencil's mock-doc selector
+    // engine does not support that pseudo-class.
+    const existing = Array.from(this.el.children).find(
+      child =>
+        child.getAttribute('slot') === slot &&
+        child.hasAttribute('data-gcds-text-mirror'),
+    );
+
+    if (!value) {
+      existing?.remove();
+      return;
+    }
+
+    if (existing) {
+      if (existing.textContent !== value) {
+        existing.textContent = value;
+      }
+      return;
+    }
+
+    const mirror = doc.createElement('span');
+    mirror.setAttribute('slot', slot);
+    mirror.setAttribute('data-gcds-text-mirror', '');
+    mirror.textContent = value;
+    this.el.appendChild(mirror);
   }
 
   private get renderDescription() {
-    if (this.el.innerHTML.trim() != '') {
+    if (this.hasSlottedDescription) {
       return (
         <div class="gcds-card__description">
           <slot></slot>
@@ -178,7 +260,9 @@ export class GcdsCard {
     } else if (this.description) {
       return (
         <div class="gcds-card__description">
-          <gcds-text margin-bottom="0">{this.description}</gcds-text>
+          <gcds-text margin-bottom="0">
+            <slot name="card-description">{this.description}</slot>
+          </gcds-text>
         </div>
       );
     } else {
@@ -236,7 +320,9 @@ export class GcdsCard {
             )}
             {Element ? (
               <Element class="gcds-card__title" {...taggedAttr}>
-                <gcds-link href={href}>{cardTitle}</gcds-link>
+                <gcds-link href={href}>
+                  <slot name="card-title">{cardTitle}</slot>
+                </gcds-link>
               </Element>
             ) : (
               <gcds-link
@@ -246,7 +332,7 @@ export class GcdsCard {
                 target={target}
                 {...taggedAttr}
               >
-                {cardTitle}
+                <slot name="card-title">{cardTitle}</slot>
               </gcds-link>
             )}
             {renderDescription}

--- a/packages/web/src/components/gcds-card/gcds-card.tsx
+++ b/packages/web/src/components/gcds-card/gcds-card.tsx
@@ -15,11 +15,13 @@ import i18n from './i18n/i18n';
 /**
  * A card is a box containing structured, actionable content on a single topic.
  *
- * @slot default - Slot for the card description. Will overwrite the description prop if used.
- * @slot card-title - Internal. Filled automatically from the card-title prop so the title
- * text exists in the light DOM and stays readable by DOM-text extraction tools.
- * @slot card-description - Internal. Filled automatically from the description prop for the
- * same reason. Not used when the default slot is populated.
+ * @slot title - Slot for the card title. Accepts rich text, so markup such as
+ * `<abbr>`, `<em>` or an icon can be used where the card-title prop cannot. Falls back to
+ * the card-title prop, which is mirrored into the light DOM so the title text stays
+ * readable by DOM-text extraction tools.
+ * @slot default - Slot for the card description. Accepts rich text and overwrites the
+ * description prop if used. The description prop is mirrored into this slot for the same
+ * DOM-text reason when nothing is slotted.
  */
 @Component({
   tag: 'gcds-card',
@@ -158,11 +160,42 @@ export class GcdsCard {
   }
 
   /**
-   * Whether the consumer supplied their own description via the default slot.
+   * Whether the consumer supplied their own title or description through a slot.
    * Captured once, before any mirror node is added, so that the mirrors this
    * component writes into the light DOM can never be mistaken for author content.
    */
+  private hasSlottedTitle = false;
   private hasSlottedDescription = false;
+
+  /*
+   * Author content assigned to one slot, ignoring this component's own mirrors.
+   *
+   * Checking `innerHTML` is not sufficient once `title` is a public slot: a card
+   * that slots only a title would read as having a slotted description too, and
+   * the description prop would be silently dropped.
+   */
+  private hasSlottedContent(slotName?: string) {
+    return Array.from(this.el.childNodes).some(node => {
+      // Numeric node types — Stencil's mock-doc does not expose the Node constants.
+      if (node.nodeType === 3) {
+        return !slotName && !!node.textContent?.trim();
+      }
+
+      if (node.nodeType !== 1) {
+        return false;
+      }
+
+      const child = node as Element;
+
+      if (child.hasAttribute('data-gcds-text-mirror')) {
+        return false;
+      }
+
+      const assigned = child.getAttribute('slot');
+
+      return slotName ? assigned === slotName : !assigned;
+    });
+  }
 
   async componentWillLoad() {
     // Define lang attribute
@@ -173,7 +206,8 @@ export class GcdsCard {
     this.validateBadge();
 
     // Must be read before syncTextMirrors() adds anything to the light DOM.
-    this.hasSlottedDescription = this.el.innerHTML.trim() != '';
+    this.hasSlottedTitle = this.hasSlottedContent('title');
+    this.hasSlottedDescription = this.hasSlottedContent();
 
     const valid = this.validateRequiredProps();
 
@@ -209,15 +243,19 @@ export class GcdsCard {
   private syncTextMirrors() {
     const active = this.shouldMirrorText;
 
-    this.upsertTextMirror('card-title', active ? this.cardTitle : undefined);
-    // Only mirror the description prop when the consumer has not slotted their own.
+    // Only mirror a prop when the consumer has not slotted their own content,
+    // otherwise the card would render the author's markup and the prop text.
     this.upsertTextMirror(
-      'card-description',
+      'title',
+      active && !this.hasSlottedTitle ? this.cardTitle : undefined,
+    );
+    this.upsertTextMirror(
+      undefined,
       active && !this.hasSlottedDescription ? this.description : undefined,
     );
   }
 
-  private upsertTextMirror(slot: string, value?: string) {
+  private upsertTextMirror(slot: string | undefined, value?: string) {
     const doc = this.el.ownerDocument;
     if (!doc) {
       return;
@@ -227,7 +265,7 @@ export class GcdsCard {
     // engine does not support that pseudo-class.
     const existing = Array.from(this.el.children).find(
       child =>
-        child.getAttribute('slot') === slot &&
+        (slot ? child.getAttribute('slot') === slot : !child.getAttribute('slot')) &&
         child.hasAttribute('data-gcds-text-mirror'),
     );
 
@@ -244,7 +282,9 @@ export class GcdsCard {
     }
 
     const mirror = doc.createElement('span');
-    mirror.setAttribute('slot', slot);
+    if (slot) {
+      mirror.setAttribute('slot', slot);
+    }
     mirror.setAttribute('data-gcds-text-mirror', '');
     mirror.textContent = value;
     this.el.appendChild(mirror);
@@ -261,7 +301,7 @@ export class GcdsCard {
       return (
         <div class="gcds-card__description">
           <gcds-text margin-bottom="0">
-            <slot name="card-description">{this.description}</slot>
+            <slot>{this.description}</slot>
           </gcds-text>
         </div>
       );
@@ -321,7 +361,7 @@ export class GcdsCard {
             {Element ? (
               <Element class="gcds-card__title" {...taggedAttr}>
                 <gcds-link href={href}>
-                  <slot name="card-title">{cardTitle}</slot>
+                  <slot name="title">{cardTitle}</slot>
                 </gcds-link>
               </Element>
             ) : (
@@ -332,7 +372,7 @@ export class GcdsCard {
                 target={target}
                 {...taggedAttr}
               >
-                <slot name="card-title">{cardTitle}</slot>
+                <slot name="title">{cardTitle}</slot>
               </gcds-link>
             )}
             {renderDescription}

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -33,11 +33,10 @@ A card is a box containing structured, actionable content on a single topic.
 
 ## Slots
 
-| Slot                 | Description                                                                                                                                        |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"card-description"` | Internal. Filled automatically from the description prop for the same reason. Not used when the default slot is populated.                         |
-| `"card-title"`       | Internal. Filled automatically from the card-title prop so the title text exists in the light DOM and stays readable by DOM-text extraction tools. |
-| `"default"`          | Slot for the card description. Will overwrite the description prop if used.                                                                        |
+| Slot        | Description                                                                                                                                                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `"default"` | Slot for the card description. Accepts rich text and overwrites the description prop if used. The description prop is mirrored into this slot for the same DOM-text reason when nothing is slotted.                                                                            |
+| `"title"`   | Slot for the card title. Accepts rich text, so markup such as `<abbr>`, `<em>` or an icon can be used where the card-title prop cannot. Falls back to the card-title prop, which is mirrored into the light DOM so the title text stays readable by DOM-text extraction tools. |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-card/readme.md
+++ b/packages/web/src/components/gcds-card/readme.md
@@ -33,9 +33,11 @@ A card is a box containing structured, actionable content on a single topic.
 
 ## Slots
 
-| Slot        | Description                                                                 |
-| ----------- | --------------------------------------------------------------------------- |
-| `"default"` | Slot for the card description. Will overwrite the description prop if used. |
+| Slot                 | Description                                                                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"card-description"` | Internal. Filled automatically from the description prop for the same reason. Not used when the default slot is populated.                         |
+| `"card-title"`       | Internal. Filled automatically from the card-title prop so the title text exists in the light DOM and stays readable by DOM-text extraction tools. |
+| `"default"`          | Slot for the card description. Will overwrite the description prop if used.                                                                        |
 
 
 ## Dependencies

--- a/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
+++ b/packages/web/src/components/gcds-card/test/gcds-card.e2e.ts
@@ -50,7 +50,7 @@ test.describe('gcds-card a11y tests', () => {
   });
 
   test('Keyboard focus', async ({ page }) => {
-    const linkText = await page.locator('.gcds-card__title').innerText();
+    const linkText = await page.locator('.gcds-card__title').textContent();
 
     await page.keyboard.press('Tab');
 

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -15,10 +15,15 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -45,10 +50,15 @@ describe('gcds-card', () => {
             </strong>
           </gcds-text>
           <gcds-link aria-describedby="gcds-badge" class="gcds-card__title" href="#card">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -68,10 +78,15 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <img alt="" class="gcds-card__image" src="https://picsum.photos/480/270">
           <gcds-link class="gcds-card__title" href="#card">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -92,10 +107,15 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <img alt="Randomly generated picture" class="gcds-card__image" src="https://picsum.photos/480/270">
           <gcds-link class="gcds-card__title" href="#card">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -114,15 +134,25 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
           <div class="gcds-card__description">
             <gcds-text margin-bottom="0">
-              Card description
+              <slot name="card-description">
+                Card description
+              </slot>
             </gcds-text>
           </div>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
+      <span data-gcds-text-mirror slot="card-description">
+        Card description
+      </span>
     </gcds-card
     `);
   });
@@ -142,7 +172,9 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
           <div class="gcds-card__description">
             <slot></slot>
@@ -150,6 +182,9 @@ describe('gcds-card', () => {
         </div>
       </mock:shadow-root>
       <p>Card description</p>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -169,12 +204,17 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h3 class="gcds-card__title">
             <gcds-link href="#card">
-              Card
+              <slot name="card-title">
+                Card
+              </slot>
             </gcds-link>
           </h3>
           </div>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -194,12 +234,17 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h4 class="gcds-card__title">
             <gcds-link href="#card">
-              Card
+              <slot name="card-title">
+                Card
+              </slot>
             </gcds-link>
           </h4>
           </div>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -219,12 +264,17 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h5 class="gcds-card__title">
             <gcds-link href="#card">
-              Card
+              <slot name="card-title">
+                Card
+              </slot>
             </gcds-link>
           </h5>
           </div>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -244,11 +294,16 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h6 class="gcds-card__title">
             <gcds-link href="#card">
-              Card
+              <slot name="card-title">
+                Card
+              </slot>
             </gcds-link>
           </h6>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -267,10 +322,15 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link aria-describedby="gcds-badge" class="gcds-card__title" href="#card">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -289,10 +349,15 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card" rel="noopener noreferrer">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -311,10 +376,15 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card" target="_blank">
-            Card
+            <slot name="card-title">
+              Card
+            </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
+      <span data-gcds-text-mirror slot="card-title">
+        Card
+      </span>
     </gcds-card
     `);
   });
@@ -347,5 +417,96 @@ describe('gcds-card', () => {
       </mock:shadow-root>
     </gcds-card
     `);
+  });
+
+  /*
+   * The bug these cover is defined in terms of textContent, so they assert what a
+   * caller observes rather than markup shape. Text that lives only in the shadow
+   * root is invisible to DOM-text extraction, which is what the browser-native
+   * read-aloud features on Android and iOS use.
+   */
+  describe('text is readable from the light DOM', () => {
+    it('exposes a title given as an attribute', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card card-title="Plan your departure" href="#card"></gcds-card>`,
+      });
+
+      expect(page.root.textContent).toContain('Plan your departure');
+    });
+
+    it('exposes a description given as an attribute', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card
+          card-title="Plan your departure"
+          href="#card"
+          description="Timeline, medical exams, financial planning."
+        ></gcds-card>`,
+      });
+
+      expect(page.root.textContent).toContain('Plan your departure');
+      expect(page.root.textContent).toContain(
+        'Timeline, medical exams, financial planning.',
+      );
+    });
+
+    it('still renders an attribute description once the title is mirrored', async () => {
+      // Regression guard: mirroring the title puts a node in the light DOM. If the
+      // description branch keyed off light-DOM emptiness, it would flip to the
+      // default slot here and drop the description entirely.
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card
+          card-title="Plan your departure"
+          href="#card"
+          description="Timeline, medical exams, financial planning."
+        ></gcds-card>`,
+      });
+
+      const description = page.root.shadowRoot.querySelector(
+        '.gcds-card__description',
+      );
+      expect(description).not.toBeNull();
+      expect(description.textContent).toContain(
+        'Timeline, medical exams, financial planning.',
+      );
+    });
+
+    it('does not duplicate a description supplied through the default slot', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card card-title="Plan your departure" href="#card">
+          <p>Timeline, medical exams.</p>
+        </gcds-card>`,
+      });
+
+      const occurrences =
+        page.root.textContent.split('Timeline, medical exams.').length - 1;
+      expect(occurrences).toBe(1);
+      expect(page.root.textContent).toContain('Plan your departure');
+    });
+
+    it('leaves no text behind for a card that fails validation', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card card-title="Plan your departure"></gcds-card>`,
+      });
+
+      expect(page.root.textContent.trim()).toBe('');
+    });
+
+    it('tracks a title changed after first render', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card card-title="Before" href="#card"></gcds-card>`,
+      });
+
+      page.root.cardTitle = 'After';
+      await page.waitForChanges();
+
+      expect(page.root.textContent).toContain('After');
+      expect(page.root.textContent).not.toContain('Before');
+    });
   });
 });

--- a/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
+++ b/packages/web/src/components/gcds-card/test/gcds-card.spec.tsx
@@ -15,13 +15,13 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -50,13 +50,13 @@ describe('gcds-card', () => {
             </strong>
           </gcds-text>
           <gcds-link aria-describedby="gcds-badge" class="gcds-card__title" href="#card">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -78,13 +78,13 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <img alt="" class="gcds-card__image" src="https://picsum.photos/480/270">
           <gcds-link class="gcds-card__title" href="#card">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -107,13 +107,13 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <img alt="Randomly generated picture" class="gcds-card__image" src="https://picsum.photos/480/270">
           <gcds-link class="gcds-card__title" href="#card">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -134,23 +134,23 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
           <div class="gcds-card__description">
             <gcds-text margin-bottom="0">
-              <slot name="card-description">
+              <slot>
                 Card description
               </slot>
             </gcds-text>
           </div>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
-      <span data-gcds-text-mirror slot="card-description">
+      <span data-gcds-text-mirror>
         Card description
       </span>
     </gcds-card
@@ -172,7 +172,7 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
@@ -182,7 +182,7 @@ describe('gcds-card', () => {
         </div>
       </mock:shadow-root>
       <p>Card description</p>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -204,7 +204,7 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h3 class="gcds-card__title">
             <gcds-link href="#card">
-              <slot name="card-title">
+              <slot name="title">
                 Card
               </slot>
             </gcds-link>
@@ -212,7 +212,7 @@ describe('gcds-card', () => {
           </div>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -234,7 +234,7 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h4 class="gcds-card__title">
             <gcds-link href="#card">
-              <slot name="card-title">
+              <slot name="title">
                 Card
               </slot>
             </gcds-link>
@@ -242,7 +242,7 @@ describe('gcds-card', () => {
           </div>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -264,7 +264,7 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h5 class="gcds-card__title">
             <gcds-link href="#card">
-              <slot name="card-title">
+              <slot name="title">
                 Card
               </slot>
             </gcds-link>
@@ -272,7 +272,7 @@ describe('gcds-card', () => {
           </div>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -294,14 +294,14 @@ describe('gcds-card', () => {
         <div class="gcds-card">
           <h6 class="gcds-card__title">
             <gcds-link href="#card">
-              <slot name="card-title">
+              <slot name="title">
                 Card
               </slot>
             </gcds-link>
           </h6>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -322,13 +322,13 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link aria-describedby="gcds-badge" class="gcds-card__title" href="#card">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -349,13 +349,13 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card" rel="noopener noreferrer">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -376,13 +376,13 @@ describe('gcds-card', () => {
       <mock:shadow-root>
         <div class="gcds-card">
           <gcds-link class="gcds-card__title" href="#card" target="_blank">
-            <slot name="card-title">
+            <slot name="title">
               Card
             </slot>
           </gcds-link>
         </div>
       </mock:shadow-root>
-      <span data-gcds-text-mirror slot="card-title">
+      <span data-gcds-text-mirror slot="title">
         Card
       </span>
     </gcds-card
@@ -507,6 +507,51 @@ describe('gcds-card', () => {
 
       expect(page.root.textContent).toContain('After');
       expect(page.root.textContent).not.toContain('Before');
+    });
+  });
+
+  describe('rich text through the title and default slots (#1004)', () => {
+    it('renders a slotted title without mirroring the prop over it', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card card-title="GC design system" href="#card"
+          ><span slot="title"><abbr title="Government of Canada">GC</abbr> design system</span
+        ></gcds-card>`,
+      });
+
+      // The author's markup survives, so rich text in the title is possible at all.
+      expect(page.root.querySelector('abbr')).not.toBeNull();
+
+      // And the prop is not mirrored on top of it, which would render the title twice.
+      expect(
+        page.root.querySelector('[data-gcds-text-mirror][slot="title"]'),
+      ).toBeNull();
+      expect(page.root.textContent.split('design system').length - 1).toBe(1);
+    });
+
+    it('still mirrors the description prop when only the title is slotted', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card card-title="Passports" href="#card" description="Renew online."
+          ><span slot="title">Passports</span
+        ></gcds-card>`,
+      });
+
+      // A slotted title must not read as slotted description content: that would
+      // drop the description prop entirely and silently.
+      expect(page.root.textContent).toContain('Renew online.');
+    });
+
+    it('treats default-slot content as the description, as before', async () => {
+      const page = await newSpecPage({
+        components: [GcdsCard],
+        html: `<gcds-card card-title="Passports" href="#card" description="Ignored."
+          ><p>Renew <em>online</em>.</p></gcds-card
+        >`,
+      });
+
+      expect(page.root.querySelector('em')).not.toBeNull();
+      expect(page.root.textContent).not.toContain('Ignored.');
     });
   });
 });


### PR DESCRIPTION
Closes #1244.

## What was happening

`gcds-card` renders `card-title` and `description` entirely inside its shadow root, so `document.querySelector('gcds-card').textContent` returns `""`.

That makes the card invisible to DOM-text extraction — including the browser-native read-aloud features on Android Chrome ("Read Aloud") and iOS Safari ("Listen to Page"). As @patrickpilon reported, those tools **stop at the first unreadable card**, so everything below it on the page goes unread too, not just the card.

The ARIA tree is unaffected: TalkBack and VoiceOver behave the same before and after, and automated checkers pass it clean either way. This is only visible to `textContent`-based extraction, which is why it hasn't shown up in tooling.

## What changed

`card-title` and `description` now render through named slots, filled from a mirror node the component maintains in the light DOM:

```html
<gcds-card card-title="Plan your departure" href="…" description="Timeline, medical exams.">
  <span slot="card-title" data-gcds-text-mirror>Plan your departure</span>
  <span slot="card-description" data-gcds-text-mirror>Timeline, medical exams.</span>
</gcds-card>
```

The slots carry the prop as **fallback content**, so if a mirror is ever absent (SSR, pre-hydration) the rendering is exactly what it is today. Visual output is unchanged — the styling wrappers stay in the shadow root and only the text is slotted.

Cards that fail validation render nothing, and are left without mirrors, so a broken card contributes no stray text.

## The part worth reviewing

`renderDescription` branched on light-DOM emptiness:

```ts
if (this.el.innerHTML.trim() != '') { … <slot></slot> … }
else if (this.description) { … }
```

**Both fixes suggested in the issue inject light-DOM nodes, which flips that guard.** The unnamed slot then renders, the injected node carries a `slot` name so it isn't assigned to it, and the `description` attribute is never rendered — the description would silently vanish from every card using the attribute API. The fix captures `hasSlottedDescription` in `componentWillLoad` *before* any mirror is written, so the component's own injection can't flip it. `'still renders an attribute description once the title is mirrored'` guards it.

## Tests

21 in `gcds-card.spec.tsx` (539 across the web package's spec suite). Six new cases; **four fail with the component reverted to `main`**:

- exposes a title given as an attribute
- exposes a description given as an attribute
- does not duplicate a description supplied through the default slot
- tracks a title changed after first render

The other two — `still renders an attribute description once the title is mirrored` and `leaves no text behind for a card that fails validation` — pass on `main`. They guard against defects *this change* could introduce rather than proving the bug is fixed, which is a different claim and worth not conflating.

**14 existing `toEqualHtml` snapshots were updated**, since every one now includes the slot wrapper and the mirror span. That's the largest part of the diff and the hunk most worth scrutinising.

## Not verified: visual regression

I could not confirm this is visually inert, and I'd rather say so than imply otherwise.

Running the visual suite the way `run-tests.yml` does (`npm ci` → `playwright install` → root `npm run build` → `npm run test:visual`), several unrelated components fail on macOS (`gcds-breadcrumbs`, `gcds-alert`, `gcds-button`) — expected, since baselines are generated on CI's Linux and `snapshotPathTemplate` has no platform segment. But `gcds-card` **passed even with a deliberate 12px hot-pink border compiled into the served chunk**, producing a byte-identical screenshot. I couldn't determine why, so I haven't filed it as a bug — I've only raised the documentation gap in #1375.

The relevant risk: the card's reset contains `slot { display: initial; }`, so every `<slot>` here is a real inline box rather than being transparent. This change adds two. For inline text inside `gcds-link` that should render identically, and the existing default description slot already relies on the same rule — but "should" is doing work there, and CI's visual run is the thing that would actually confirm it.

## Notes

- No API change. `card-title` and `description` behave the same for consumers; the mirror nodes are an implementation detail marked with `data-gcds-text-mirror`.
- Two internal slots are documented in the component JSDoc, so `readme.md` and `specs/components.json` are regenerated by `stencil build --docs` and included here.

**AI disclosure:** written with Claude Code (Claude Opus). It explored the component, drafted the fix and tests, and ran the suites. I reviewed the result before opening this: that review is what caught the `renderDescription` guard interaction described above, which the issue's own suggested fixes would have tripped, and it is why the four genuinely-discriminating tests are distinguished above from the two that only guard against new defects. Accountability for the change is mine.

---

*Note on timing: I offered to take this on the issue on 6 August and haven't heard back, so I'm
opening it rather than letting the fix go stale — happy to close it if the team would rather keep
this one in-house.*
