### PR TITLE
fix(gcds-file-uploader): announce file removal to screen readers

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -193,6 +193,11 @@ export class GcdsFileUploader {
   @State() inheritedAttributes: Object = {};
 
   /**
+   * Message announced to assistive technology when a file is removed.
+   */
+  @State() removedFileMessage: string = '';
+
+  /**
    * Language of rendered component
    */
   @State() lang: string;
@@ -288,6 +293,7 @@ export class GcdsFileUploader {
     }
 
     this.value = [...filesContainer];
+    this.removedFileMessage = `${i18n[this.lang].fileRemoved} ${fileName}`;
     this.gcdsRemoveFile.emit(this.value);
     this.gcdsChange.emit(this.value);
     this.el.dispatchEvent(
@@ -492,6 +498,7 @@ export class GcdsFileUploader {
       autofocus,
       form,
       inheritedAttributes,
+      removedFileMessage,
     } = this;
 
     const attrsInput = {
@@ -582,6 +589,9 @@ export class GcdsFileUploader {
                 {i18n[lang].summary.unselected}
               </gcds-sr-only>
             )}
+            <gcds-sr-only role="status" aria-live="polite">
+              {removedFileMessage}
+            </gcds-sr-only>
           </div>
 
           {value.length > 0

--- a/packages/web/src/components/gcds-file-uploader/i18n/i18n.js
+++ b/packages/web/src/components/gcds-file-uploader/i18n/i18n.js
@@ -9,6 +9,7 @@ const I18N = {
       unselected: 'No file currently selected.',
     },
     removeFile: 'Remove file',
+    fileRemoved: 'File removed:',
     droppedError:
       'One or more of the dropped files is unable to be uploaded. Accepted file types:',
   },
@@ -22,6 +23,7 @@ const I18N = {
       unselected: 'Aucun fichier actuellement sélectionné.',
     },
     removeFile: 'Supprimer le fichier',
+    fileRemoved: 'Fichier supprimé :',
     droppedError:
       'Un ou plusieurs fichiers déposés ne peuvent pas être téléversés. Types de fichiers acceptés :',
   },

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.ts
@@ -100,6 +100,13 @@ test.describe('gcds-file-uploader', () => {
         el => (el as HTMLGcdsFileUploaderElement).files.length,
       ),
     ).toBe(0);
+
+    // A screen reader should be told a file was removed (#1363)
+    const liveRegionText = await element.evaluate(el =>
+      el.shadowRoot.querySelector('gcds-sr-only[aria-live]').textContent.trim(),
+    );
+
+    expect(liveRegionText).toBe('File removed: gcds-file-uploader.e2e.html');
   });
   test('set files manually', async ({ page }) => {
     const element = page.locator('gcds-file-uploader');

--- a/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
+++ b/packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.spec.tsx
@@ -18,6 +18,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" />
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -44,6 +45,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" disabled="" aria-invalid="false" />
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -73,6 +75,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="true" aria-describedby="error-message-file-uploader file-uploader__summary" />
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -100,6 +103,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" aria-describedby="hint-file-uploader file-uploader__summary" />
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -126,6 +130,7 @@ describe('gcds-file-uploader', () => {
             </button>
             <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" />
             <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+            <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
           </div>
         </div>
         </mock:shadow-root>
@@ -152,6 +157,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" />
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -178,6 +184,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" />
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -204,6 +211,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" required="" />
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -230,6 +238,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" autofocus/>
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>
@@ -256,6 +265,7 @@ describe('gcds-file-uploader', () => {
               </button>
               <input aria-describedby="file-uploader__summary" id="file-uploader" name="file-uploader-name" type="file" value="" aria-invalid="false" form="formID"/>
               <gcds-sr-only id="file-uploader__summary">No file currently selected.</gcds-sr-only>
+              <gcds-sr-only aria-live="polite" role="status"></gcds-sr-only>
             </div>
           </div>
         </mock:shadow-root>


### PR DESCRIPTION
# 📝 Summary | Résumé

When a file is removed from the file uploader (via the Remove button), the UI updates correctly but nothing tells assistive technology that the removal happened. Focus doesn't move, and there's no live region, so a screen reader user has no way to confirm the file was actually removed — matching the exact NVDA reproduction steps in the linked issue.

This adds a `role="status" aria-live="polite"` region that announces `"File removed: <filename>"` (and the French equivalent) when `removeFile()` runs. It follows the same live-region pattern already used in `gcds-table` for status updates, so no new pattern is introduced to the codebase. The region is always present in the DOM (not conditionally rendered) so it's registered with assistive tech before the first removal — a conditionally-rendered live region can miss its first announcement in some screen reader/browser combinations.

## 🧩 Related Issues | Cartes liées

- Fixes #1363

## 🧪 Test instructions | Instructions pour tester la modification

1) Check the current behaviour
- [ ] Checkout the `main` branch, run `npm install` and `npm run build:web`, then open `packages/web/src/components/gcds-file-uploader/test/gcds-file-uploader.e2e.html` (or any page with a `gcds-file-uploader`) with a screen reader running
- [ ] Upload a file, then activate the file's "Remove" button
- [ ] Confirm: no announcement is made when the file is removed

2) Validate the change
- [ ] Checkout this branch, rebuild, reload the same page
- [ ] Upload a file, then activate "Remove"
- [ ] Confirm: the screen reader announces "File removed: `<filename>`"
- [ ] Automated coverage: `npm run test:web:unit` (updated snapshots for the new live region markup) and `npm run test:web:e2e -- --grep "upload and remove file"` (new assertion added to the existing test, checks the live region's text content after a real removeFile click in a real browser)

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR is a patch (use `fix:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality. I have completely tested the functionality of these changes.
- [x] This PR does not introduce any changes to component names, properties, values, or behaviour. (One addition: a new `fileRemoved` i18n string, additive only.)

**Ready for review:**
- [ ] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages. — *English verified via the e2e test's live-region assertion. The French string (`Fichier supprimé :`) was written to match the existing i18n file's tone/pattern but I have not visually verified it in a French-locale render — flagging for reviewer check rather than claiming this.*
- [ ] I have tested these changes on mobile viewports. — *not tested, this fix isn't viewport-dependent (it's an ARIA live-region addition with no visual/layout change) but flagging as unverified rather than assuming.*
- [ ] I have tested these changes across multiple supported browsers. — *verified via Playwright/Chromium only.*
- [x] I have checked accessibility and ensured all accessibility tests pass. (Full `gcds-file-uploader` e2e suite passes, including the existing axe-core color-contrast/label/keyboard-focus/aria-invalid checks — 13/13.)
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [ ] I have added or updated documentation, if needed. — *no user-facing docs exist for this component's internal ARIA behaviour; none identified as needing an update.*
- [x] Test instructions are clear and reproducible.

## ⚠️ Impact/Risks | Risques

No API or breaking changes. The only new surface area is the `fileRemoved` i18n string (English + French) and the always-present (but visually hidden, empty-until-triggered) live region in the render output — this does change the component's shadow DOM snapshot, which is why the existing unit test snapshots needed updating (included in this PR).