### PR TITLE
fix: show native spinner buttons for gcds-input number type

### DIFF
--- a/packages/web/src/components/gcds-input/gcds-input.css
+++ b/packages/web/src/components/gcds-input/gcds-input.css
@@ -47,16 +47,6 @@
         border-color ease-in-out 0.15s,
         box-shadow ease-in-out 0.15s,
         outline ease-in-out 0.15s;
-
-      /* Hide number arrows */
-      &[type='number'] {
-        -moz-appearance: textfield;
-
-        &::-webkit-outer-spin-button,
-        &::-webkit-inner-spin-button {
-          -webkit-appearance: none;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
# 📝 Summary | Résumé

`<gcds-input type="number">` hides the browser-native increment/decrement (spinner) buttons through CSS in `packages/web/src/components/gcds-input/gcds-input.css`:

- `-moz-appearance: textfield` (Firefox)
- `-webkit-appearance: none` on `::-webkit-outer-spin-button` / `::-webkit-inner-spin-button` (Chromium / WebKit)

This removed the visible, clickable step controls for pointer and touch users — the concern raised in #1011. Keyboard arrow-key stepping still worked, but there was no equivalent affordance for mouse/touch. This PR removes that CSS block so the native spinner controls render again.

**Accessibility note:** native user-agent spin buttons are exempt from WCAG 2.2 SC 2.5.8 (Target Size, Minimum), so restoring them does not introduce a target-size failure. If the team would prefer consistently-styled, token-based −/+ controls over the browser defaults, that could be a follow-up — happy to open a separate issue.

## 🧩 Related Issues | Cartes liées

- Closes #1011

## 🧪 Test instructions | Instructions pour tester la modification

Test markup:

    <gcds-input label="Quantity" input-id="qty" name="qty" type="number" value="5"></gcds-input>

**1) Current behaviour (`main`)**
- [ ] Check out `main` and render the markup above
- [ ] Focus or hover the field — no increment/decrement arrows appear in Chromium/WebKit, and none appear in Firefox

**2) Validate the change (this branch)**
- [ ] Check out this branch and render the same markup
- [ ] Chromium / WebKit: focus or hover the field → native ▲▼ spinner buttons appear on the trailing edge and step the value
- [ ] Firefox: the ▲▼ spinner buttons are visible and step the value
- [ ] Keyboard ↑ / ↓ still steps the value as before

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [x] This PR is a patch (use `fix:`)

**Breaking changes flag:**
- [x] This PR does not break existing functionality.
- [x] This PR does not introduce any changes to component names, properties, values, or behaviour. (CSS-only; restores the default browser rendering.)

**Ready for review:**
- [x] I have tested these changes across multiple supported browsers (Chromium and Firefox rendering of the native controls).

_Note: This is a CSS-only change with no DOM or API changes, so the existing Stencil spec snapshots (which assert shadow-DOM structure, not styles) are unaffected. It does change the number-input visual-regression baseline; per CONTRIBUTING, local baselines are not committed — a maintainer can regenerate them via the "Update visual snapshots" workflow._

## ⚠️ Impact/Risks | Risques

- CSS-only change; no changes to the component's DOM, props, or public API.
- Native spinner rendering differs between Firefox and Chromium/WebKit (inherent to user-agent controls).
- Changes the number-input visual-regression baseline (spinners now render).