### PR TITLE
chore: Update lockFileMaintenance schedule in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>cds-snc/renovate-config"],
   "lockFileMaintenance": {
-    "schedule": ["before 6am on the first day of the month"]
+    "enabled": true,
+    "schedule": [
+      "before 6am on the 1st day of the month",
+      "before 6am on the 15th day of the month"
+    ]
   },
   "baseBranchPatterns": ["main"]
 }


### PR DESCRIPTION
# 📝 Summary | Résumé

Update `lockFileMaintenance` of the renovate config to run more often and add `enable: true` as this feature may not have been fully enabled. Hopefully this can help us with all the dependancy PRs.
