### PR TITLE
fix(gcds-file-uploader): add focus management when removing files

### DIFF
--- a/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
+++ b/packages/web/src/components/gcds-file-uploader/gcds-file-uploader.tsx
@@ -43,6 +43,7 @@ export class GcdsFileUploader {
   internals: ElementInternals;
 
   private shadowElement?: HTMLInputElement;
+  private uploadedFiles: HTMLButtonElement[] = [];
 
   private inputTitle: string = '';
 
@@ -291,6 +292,21 @@ export class GcdsFileUploader {
       this.files = dt.files;
       this.addFilesToFormData(Array.from(this.shadowElement.files));
     }
+
+    /* 
+     * Provide focus management for removing files.
+     * If there are multiple files, focus the first file.
+     * If there is only one file, focus the file input.
+     */
+    let eventElement = e.target.closest('.file-uploader__uploaded-file').querySelector('button');
+    const removeButton = this.uploadedFiles.indexOf(eventElement);
+    if (this.uploadedFiles.length > 1) {
+      this.uploadedFiles[removeButton !== 0 ? 0 : removeButton].focus();
+    } else {
+      this.shadowElement?.focus();
+    }
+    // reset uploadedFiles since render will repolulate the list of buttons
+    this.uploadedFiles = [];
 
     this.value = [...filesContainer];
     this.removedFileMessage = `${i18n[this.lang].fileRemoved} ${fileName}`;
@@ -601,7 +617,14 @@ export class GcdsFileUploader {
                 aria-label={`${i18n[lang].removeFile} ${file}.`}
               >
                 <gcds-text margin-bottom="0">{file}</gcds-text>
-                <button onClick={e => this.removeFile(e)}>
+                <button
+                  onClick={e => this.removeFile(e)}
+                  ref={element => {
+                    if (element && !this.uploadedFiles.includes(element)) {
+                      this.uploadedFiles = [...this.uploadedFiles, element];
+                    }
+                  }}
+                >
                   <span>{i18n[lang].button.remove}</span>
                   <gcds-icon name="close" size="text" margin-left="150" />
                 </button>


### PR DESCRIPTION
# 📝 Summary | Résumé

When using the `gcds-file-uploader` with a keyboard after selecting a file, removing the file would cause the element to lose focus and return to the top of the page. Added some focus management logic that will select the top remove button or the file-uploader element depending on how many files are still selected.

## 🧪 Test instructions | Instructions pour tester la modification

_TODO: Replace the instructions below as needed. Describe any steps needed to verify the change(s) work as expected._

1) Check the current behaviour
- [ ] Checkout the `main` branch
- [ ] Open the `index.html` test file
- [ ] Add the following test code inside the `<body>`:
```html
<gcds-file-uploader
          uploader-id="form-uploader"
          label="Upload file"
          hint="You can upload multiple files, but they have to be png's."
          accept="image/png"
          multiple
          required
        ></gcds-file-uploader>
```
- [ ] Confirm the following behaviour:
    - [ ] Using a keyboard focus the file-uploader
    - [ ] Press `Enter` and select two files to upload.
    - [ ] Using the keyboard focus the second 'Remove' button
    - [ ] Press `Enter`
    - [ ] Notice the focus doesn't appear on the file-uploader
    - [ ] Press `Tab`
    - [ ] Notice the focus has returned to the top of the page.
    - [ ] Navigate to the file uploader again and focus the remaining 'Remove' button
    - [ ] Press `Enter`
    - [ ] Notice the focus doesn't appear on the file-uploader
    - [ ] Press `Tab`
    - [ ] Notice the focus has returned to the top of the page.

2) Validate the change
- [ ] Checkout this branch
- [ ] Open the `index.html` test file
- [ ] Use the exact same test code as above
- [ ] Confirm the following behaviour:
    - [ ] Using a keyboard focus the file-uploader
    - [ ] Press `Enter` and select two files to upload.
    - [ ] Using the keyboard focus the second 'Remove' button
    - [ ] Press `Enter`
    - [ ] Notice the focus targets the remaining 'Remove' button
    - [ ] Press `Enter`
    - [ ] Notice the focus is now on the upload button of the file uploaded


## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one:**
- [X] This PR is a patch (use `fix:`)
- [ ] This PR introduces a minor change (use `feat:`)
- [ ] This PR introduces breaking changes to the API (use `feat!:`)
- [ ] This PR does not introduce changes that need to be published on NPM (use `chore:`, `docs:`, `ci:`)

**Breaking changes flag:**
- [X] This PR does not break existing functionality. I have completely tested the functionality of these changes. 
- [X] This PR does not introduce any changes to component names, properties, values, or behaviour.
- [ ] **_If this PR introduces API or behaviour changes_**, backwards compatibility has been implemented and documented under **Impact and Risks**.
- [ ] **_If this PR introduces a breaking change_**, release notes and versioning have been prepared.

**Ready for review: (all items must be checked)**
- [x] I have tested the English and French versions of the changes, and can verify that all content is accurate and properly displayed in both languages.
- [x] I have tested these changes on mobile viewports.
- [x] I have tested these changes across multiple supported browsers.
- [x] I have checked accessiblity and ensured all accessiblity tests pass.
- [x] I have added tests for added functionality or changed existing tests, as needed.
- [x] I have added or updated documentation, if needed.
- [x] For visual or design-affecting changes, I have posted in dev-design slack channel.
- [x] Visual or content changes remain aligned with design tokens and component API standards.
- [x] Test instructions are clear and reproducible.


## 🧐 Reviewer checklist | Liste de vérification du réviseur

**Developer checklist**

For PRs that are complex, in lieu of a simple approval or an "LGTM" ✅, paste the following info with your approval:
- [ ] I have tested the changes and functionality using the test instructions.
- [ ] I have confirmed test coverage is adequate.
- [ ] I have reviewed the code for clarity, maintainability and potential issues.
